### PR TITLE
feat: add support for negative test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # ouroboros-mock
 Go library and CLI framework for mocking Ouroboros connections
+
+## Features
+
+- Mock Ouroboros protocol conversations for testing
+- Support for positive and negative test cases
+- Easy-to-use conversation entry API
+
+## Usage
+
+### Basic Conversation
+
+```go
+mockConn := ouroboros_mock.NewConnection(
+    ouroboros_mock.ProtocolRoleClient,
+    []ouroboros_mock.ConversationEntry{
+        ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+        ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+    },
+)
+```
+
+### Negative Test Cases
+
+To test scenarios where errors are expected, set the `ExpectedError` field on conversation entries:
+
+```go
+mockConn := ouroboros_mock.NewConnection(
+    ouroboros_mock.ProtocolRoleClient,
+    []ouroboros_mock.ConversationEntry{
+        ouroboros_mock.ConversationEntryInput{
+            ProtocolId:    999, // Invalid protocol ID
+            ExpectedError: "input message protocol ID did not match expected value: expected 999, got 0",
+        },
+    },
+)
+```
+
+If the entry produces an error matching the `ExpectedError`, the conversation continues without failure. If the error does not match or no error occurs when expected, the mock will report an error.

--- a/entry.go
+++ b/entry.go
@@ -44,13 +44,17 @@ type ConversationEntryInput struct {
 	Message         protocol.Message
 	MessageType     uint
 	MsgFromCborFunc protocol.MessageFromCborFunc
+	ExpectedError   string
+	IsRegex         bool
 }
 
 type ConversationEntryOutput struct {
 	conversationEntryBase
-	ProtocolId uint16
-	IsResponse bool
-	Messages   []protocol.Message
+	ProtocolId    uint16
+	IsResponse    bool
+	Messages      []protocol.Message
+	ExpectedError string
+	IsRegex       bool
 }
 
 type ConversationEntryClose struct {


### PR DESCRIPTION
Closes #36 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds negative test case support to the Ouroboros mock. You can now mark conversation entries with expected errors (exact or regex) so tests pass when errors are intentional.

- **New Features**
  - Added ExpectedError and IsRegex to ConversationEntryInput/Output.
  - Runtime error matching: continue on match; fail on mismatch or missing error.
  - Updated README with example usage for negative cases.
  - Adjusted tests to assert no error when an expected error is met.

<sup>Written for commit cd01ada8b80c5042736a1b3c03051cbd83a62979. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation entries can declare an expected error (exact or regex); matching errors let the conversation continue, mismatches cause failure.

* **Documentation**
  * Added features overview, usage examples, and code samples clarifying error validation and test configuration.

* **Tests**
  * Improved test error handling with timeout-aware checks to ensure clean async termination and more robust verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->