### PR TITLE
feat: add client handshake entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,35 @@ Go library and CLI framework for mocking Ouroboros connections
 
 ```go
 mockConn := ouroboros_mock.NewConnection(
-    ouroboros_mock.ProtocolRoleClient,
+    ouroboros_mock.ProtocolRoleServer, // Mock acts as server
     []ouroboros_mock.ConversationEntry{
         ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
         ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+    },
+)
+```
+### Client Handshake Conversation
+
+When mocking a client that initiates the handshake:
+
+```go
+mockConn := ouroboros_mock.NewConnection(
+    ouroboros_mock.ProtocolRoleClient, // Mock acts as client
+    []ouroboros_mock.ConversationEntry{
+        ouroboros_mock.ConversationEntryHandshakeRequestOutput,    // Mock sends ProposeVersions
+        ouroboros_mock.ConversationEntryHandshakeNtCResponseInput, // Mock expects AcceptVersion for NtC
+    },
+)
+```
+
+For NtN protocol:
+
+```go
+mockConn := ouroboros_mock.NewConnection(
+    ouroboros_mock.ProtocolRoleClient, // Mock acts as client
+    []ouroboros_mock.ConversationEntry{
+        ouroboros_mock.ConversationEntryHandshakeRequestOutput,    // Mock sends ProposeVersions
+        ouroboros_mock.ConversationEntryHandshakeNtNResponseInput, // Mock expects AcceptVersion for NtN
     },
 )
 ```

--- a/entry.go
+++ b/entry.go
@@ -104,6 +104,56 @@ var ConversationEntryHandshakeNtNResponse = ConversationEntryOutput{
 	},
 }
 
+// ConversationEntryHandshakeRequestOutput is a pre-defined conversation entry for a client handshake request
+var ConversationEntryHandshakeRequestOutput = ConversationEntryOutput{
+	ProtocolId: handshake.ProtocolId,
+	IsResponse: false,
+	Messages: []protocol.Message{
+		handshake.NewMsgProposeVersions(protocol.ProtocolVersionMap{
+			MockProtocolVersionNtC: protocol.VersionDataNtC9to14(
+				MockNetworkMagic,
+			),
+			MockProtocolVersionNtN: protocol.VersionDataNtN13andUp{
+				VersionDataNtN11to12: protocol.VersionDataNtN11to12{
+					CborNetworkMagic:                       MockNetworkMagic,
+					CborInitiatorAndResponderDiffusionMode: protocol.DiffusionModeInitiatorOnly,
+					CborPeerSharing:                        protocol.PeerSharingModeNoPeerSharing,
+					CborQuery:                              protocol.QueryModeDisabled,
+				},
+			},
+		}),
+	},
+}
+
+// ConversationEntryHandshakeNtCResponseInput is a pre-defined conversation entry for a client expecting a server NtC handshake response
+var ConversationEntryHandshakeNtCResponseInput = ConversationEntryInput{
+	ProtocolId: handshake.ProtocolId,
+	IsResponse: true,
+	Message: handshake.NewMsgAcceptVersion(
+		MockProtocolVersionNtC,
+		protocol.VersionDataNtC9to14(MockNetworkMagic),
+	),
+	MsgFromCborFunc: handshake.NewMsgFromCbor,
+}
+
+// ConversationEntryHandshakeNtNResponseInput is a pre-defined conversation entry for a client expecting a server NtN handshake response
+var ConversationEntryHandshakeNtNResponseInput = ConversationEntryInput{
+	ProtocolId: handshake.ProtocolId,
+	IsResponse: true,
+	Message: handshake.NewMsgAcceptVersion(
+		MockProtocolVersionNtN,
+		protocol.VersionDataNtN13andUp{
+			VersionDataNtN11to12: protocol.VersionDataNtN11to12{
+				CborNetworkMagic:                       MockNetworkMagic,
+				CborInitiatorAndResponderDiffusionMode: protocol.DiffusionModeInitiatorOnly,
+				CborPeerSharing:                        protocol.PeerSharingModeNoPeerSharing,
+				CborQuery:                              protocol.QueryModeDisabled,
+			},
+		},
+	),
+	MsgFromCborFunc: handshake.NewMsgFromCbor,
+}
+
 // ConversationEntryKeepAliveRequest is a pre-defined conversation entry for a keep-alive request
 var ConversationEntryKeepAliveRequest = ConversationEntryInput{
 	ProtocolId:      keepalive.ProtocolId,


### PR DESCRIPTION
Closes #105 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added pre-defined client handshake conversation entries for NtC and NtN, and updated README with usage examples. This lets you mock client-initiated handshakes more easily in tests.

- **New Features**
  - ConversationEntryHandshakeRequestOutput: sends ProposeVersions with mock network magic and defaults.
  - ConversationEntryHandshakeNtCResponseInput: expects AcceptVersion for NtC.
  - ConversationEntryHandshakeNtNResponseInput: expects AcceptVersion for NtN.
  - README: examples for client handshake flows (NtC and NtN).

<sup>Written for commit 39ce6752e0abc739a595671a1762243b0032ce04. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for client-side handshake request and response handling for NtC and NtN protocols in conversation mocking.

* **Documentation**
  * Enhanced examples with annotated references in basic conversation scenarios.
  * Added dedicated sections illustrating server-role mock configurations for different protocol handshakes.
  * Improved negative test case guidance with practical error-handling code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->