### PR TITLE
ci(golangci-lint): use go 1.25

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0 https://github.com/actions/setup-go/releases/tag/v6.1.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the golangci-lint GitHub Actions workflow to use Go 1.25.x. This keeps linting aligned with the current toolchain and prevents version drift.

<sup>Written for commit 5c8b0d9991a861e1c4f2ffbd365abcd44392c73f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

