### PR TITLE
feat: enhanced mock support

### DIFF
--- a/blockfetch/entries.go
+++ b/blockfetch/entries.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntryRequestRange expects a RequestRange message from the client
+type ConversationEntryRequestRange struct {
+	Start pcommon.Point // Optional: expected start point for validation (empty hash means accept any)
+	End   pcommon.Point // Optional: expected end point for validation (empty hash means accept any)
+}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryInput
+func (e ConversationEntryRequestRange) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      blockfetch.ProtocolId,
+		IsResponse:      false,
+		MessageType:     blockfetch.MessageTypeRequestRange,
+		MsgFromCborFunc: blockfetch.NewMsgFromCbor,
+	}
+	// If Start and End are provided, set the expected message for validation
+	// Check hash instead of slot since slot 0 is valid (genesis block)
+	if len(e.Start.Hash) > 0 || len(e.End.Hash) > 0 {
+		entry.Message = blockfetch.NewMsgRequestRange(e.Start, e.End)
+	}
+	return entry
+}
+
+// ConversationEntryStartBatch sends a StartBatch message to the client
+type ConversationEntryStartBatch struct{}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryOutput
+func (e ConversationEntryStartBatch) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: blockfetch.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			blockfetch.NewMsgStartBatch(),
+		},
+	}
+}
+
+// ConversationEntryBlock sends a Block message to the client
+type ConversationEntryBlock struct {
+	BlockType uint   // Block type (era) - for documentation/metadata only, not used in wire protocol
+	BlockCbor []byte // Raw block CBOR data (wrapped block format)
+}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryOutput
+func (e ConversationEntryBlock) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: blockfetch.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			blockfetch.NewMsgBlock(e.BlockCbor),
+		},
+	}
+}
+
+// ConversationEntryBatchDone sends a BatchDone message to the client
+type ConversationEntryBatchDone struct{}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryOutput
+func (e ConversationEntryBatchDone) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: blockfetch.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			blockfetch.NewMsgBatchDone(),
+		},
+	}
+}
+
+// ConversationEntryNoBlocks sends a NoBlocks message when blocks are unavailable
+type ConversationEntryNoBlocks struct{}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryOutput
+func (e ConversationEntryNoBlocks) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: blockfetch.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			blockfetch.NewMsgNoBlocks(),
+		},
+	}
+}
+
+// ConversationEntryClientDone expects a ClientDone message from the client
+type ConversationEntryClientDone struct{}
+
+// ToEntry converts this BlockFetch entry to a generic ConversationEntryInput
+func (e ConversationEntryClientDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      blockfetch.ProtocolId,
+		IsResponse:      false,
+		MessageType:     blockfetch.MessageTypeClientDone,
+		MsgFromCborFunc: blockfetch.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewRequestRangeEntry creates a ConversationEntryInput for expecting a RequestRange message
+func NewRequestRangeEntry(
+	start, end pcommon.Point,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryRequestRange{
+		Start: start,
+		End:   end,
+	}.ToEntry()
+}
+
+// NewRequestRangeEntryAny creates a ConversationEntryInput for expecting any RequestRange message
+func NewRequestRangeEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryRequestRange{}.ToEntry()
+}
+
+// NewStartBatchEntry creates a ConversationEntryOutput for sending a StartBatch message
+func NewStartBatchEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryStartBatch{}.ToEntry()
+}
+
+// NewBlockEntry creates a ConversationEntryOutput for sending a Block message
+func NewBlockEntry(
+	blockType uint,
+	blockCbor []byte,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryBlock{
+		BlockType: blockType,
+		BlockCbor: blockCbor,
+	}.ToEntry()
+}
+
+// NewBatchDoneEntry creates a ConversationEntryOutput for sending a BatchDone message
+func NewBatchDoneEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryBatchDone{}.ToEntry()
+}
+
+// NewNoBlocksEntry creates a ConversationEntryOutput for sending a NoBlocks message
+func NewNoBlocksEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryNoBlocks{}.ToEntry()
+}
+
+// NewClientDoneEntry creates a ConversationEntryInput for expecting a ClientDone message
+func NewClientDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryClientDone{}.ToEntry()
+}

--- a/blockfetch/entries_test.go
+++ b/blockfetch/entries_test.go
@@ -1,0 +1,553 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	bf "github.com/blinklabs-io/ouroboros-mock/blockfetch"
+)
+
+// TestConversationEntryRequestRange_ToEntry tests that ConversationEntryRequestRange
+// produces correct ConversationEntryInput values
+func TestConversationEntryRequestRange_ToEntry(t *testing.T) {
+	t.Run("with specific points", func(t *testing.T) {
+		start := pcommon.NewPoint(100, bf.MockBlockHash1)
+		end := pcommon.NewPoint(200, bf.MockBlockHash2)
+
+		entry := bf.ConversationEntryRequestRange{
+			Start: start,
+			End:   end,
+		}
+
+		result := entry.ToEntry()
+
+		if result.ProtocolId != blockfetch.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				blockfetch.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != false {
+			t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+		}
+		if result.MessageType != blockfetch.MessageTypeRequestRange {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				blockfetch.MessageTypeRequestRange,
+				result.MessageType,
+			)
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+		if result.Message == nil {
+			t.Error(
+				"expected Message to be set when Start/End points are provided",
+			)
+		}
+	})
+
+	t.Run("without specific points", func(t *testing.T) {
+		entry := bf.ConversationEntryRequestRange{}
+
+		result := entry.ToEntry()
+
+		if result.ProtocolId != blockfetch.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				blockfetch.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != false {
+			t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+		}
+		if result.MessageType != blockfetch.MessageTypeRequestRange {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				blockfetch.MessageTypeRequestRange,
+				result.MessageType,
+			)
+		}
+		if result.Message != nil {
+			t.Error(
+				"expected Message to be nil when no Start/End points are provided",
+			)
+		}
+	})
+}
+
+// TestConversationEntryClientDone_ToEntry tests that ConversationEntryClientDone
+// produces correct ConversationEntryInput values
+func TestConversationEntryClientDone_ToEntry(t *testing.T) {
+	entry := bf.ConversationEntryClientDone{}
+
+	result := entry.ToEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+	}
+	if result.MessageType != blockfetch.MessageTypeClientDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			blockfetch.MessageTypeClientDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryStartBatch_ToEntry tests that ConversationEntryStartBatch
+// produces correct ConversationEntryOutput values
+func TestConversationEntryStartBatch_ToEntry(t *testing.T) {
+	entry := bf.ConversationEntryStartBatch{}
+
+	result := entry.ToEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0] == nil {
+		t.Error("expected Messages[0] to be set")
+	}
+}
+
+// TestConversationEntryNoBlocks_ToEntry tests that ConversationEntryNoBlocks
+// produces correct ConversationEntryOutput values
+func TestConversationEntryNoBlocks_ToEntry(t *testing.T) {
+	entry := bf.ConversationEntryNoBlocks{}
+
+	result := entry.ToEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0] == nil {
+		t.Error("expected Messages[0] to be set")
+	}
+}
+
+// TestConversationEntryBlock_ToEntry tests that ConversationEntryBlock
+// produces correct ConversationEntryOutput values
+func TestConversationEntryBlock_ToEntry(t *testing.T) {
+	testBlockCbor := []byte{
+		0x82,
+		0x06,
+		0x82,
+		0xa0,
+		0x84,
+		0x80,
+		0x80,
+		0x80,
+		0xa0,
+	}
+
+	entry := bf.ConversationEntryBlock{
+		BlockType: bf.MockBlockTypeConway,
+		BlockCbor: testBlockCbor,
+	}
+
+	result := entry.ToEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0] == nil {
+		t.Error("expected Messages[0] to be set")
+	}
+}
+
+// TestConversationEntryBatchDone_ToEntry tests that ConversationEntryBatchDone
+// produces correct ConversationEntryOutput values
+func TestConversationEntryBatchDone_ToEntry(t *testing.T) {
+	entry := bf.ConversationEntryBatchDone{}
+
+	result := entry.ToEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0] == nil {
+		t.Error("expected Messages[0] to be set")
+	}
+}
+
+// TestNewRequestRangeEntry tests the helper function for creating RequestRange entries
+func TestNewRequestRangeEntry(t *testing.T) {
+	start := pcommon.NewPoint(100, bf.MockBlockHash1)
+	end := pcommon.NewPoint(200, bf.MockBlockHash2)
+
+	result := bf.NewRequestRangeEntry(start, end)
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+	}
+	if result.MessageType != blockfetch.MessageTypeRequestRange {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			blockfetch.MessageTypeRequestRange,
+			result.MessageType,
+		)
+	}
+	if result.Message == nil {
+		t.Error("expected Message to be set")
+	}
+}
+
+// TestNewRequestRangeEntryAny tests the helper function for creating any RequestRange entries
+func TestNewRequestRangeEntryAny(t *testing.T) {
+	result := bf.NewRequestRangeEntryAny()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+	}
+	if result.MessageType != blockfetch.MessageTypeRequestRange {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			blockfetch.MessageTypeRequestRange,
+			result.MessageType,
+		)
+	}
+	if result.Message != nil {
+		t.Error("expected Message to be nil for 'any' entry")
+	}
+}
+
+// TestNewClientDoneEntry tests the helper function for creating ClientDone entries
+func TestNewClientDoneEntry(t *testing.T) {
+	result := bf.NewClientDoneEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse false, got %v", result.IsResponse)
+	}
+	if result.MessageType != blockfetch.MessageTypeClientDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			blockfetch.MessageTypeClientDone,
+			result.MessageType,
+		)
+	}
+}
+
+// TestNewStartBatchEntry tests the helper function for creating StartBatch entries
+func TestNewStartBatchEntry(t *testing.T) {
+	result := bf.NewStartBatchEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewNoBlocksEntry tests the helper function for creating NoBlocks entries
+func TestNewNoBlocksEntry(t *testing.T) {
+	result := bf.NewNoBlocksEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewBlockEntry tests the helper function for creating Block entries
+func TestNewBlockEntry(t *testing.T) {
+	testBlockCbor := []byte{
+		0x82,
+		0x06,
+		0x82,
+		0xa0,
+		0x84,
+		0x80,
+		0x80,
+		0x80,
+		0xa0,
+	}
+
+	result := bf.NewBlockEntry(bf.MockBlockTypeConway, testBlockCbor)
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewBatchDoneEntry tests the helper function for creating BatchDone entries
+func TestNewBatchDoneEntry(t *testing.T) {
+	result := bf.NewBatchDoneEntry()
+
+	if result.ProtocolId != blockfetch.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			blockfetch.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse true, got %v", result.IsResponse)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationBlockFetchRange tests that the fixture is a valid slice
+func TestConversationBlockFetchRange(t *testing.T) {
+	fixture := bf.ConversationBlockFetchRange
+
+	if fixture == nil {
+		t.Fatal("ConversationBlockFetchRange should not be nil")
+	}
+
+	// Expected: handshake request, handshake response, request range,
+	// start batch, 2 blocks, batch done = 7 entries
+	expectedLen := 7
+	if len(fixture) != expectedLen {
+		t.Errorf("expected %d entries, got %d", expectedLen, len(fixture))
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range fixture {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationBlockFetchNoBlocks tests that the fixture is a valid slice
+func TestConversationBlockFetchNoBlocks(t *testing.T) {
+	fixture := bf.ConversationBlockFetchNoBlocks
+
+	if fixture == nil {
+		t.Fatal("ConversationBlockFetchNoBlocks should not be nil")
+	}
+
+	// Expected: handshake request, handshake response, request range,
+	// no blocks = 4 entries
+	expectedLen := 4
+	if len(fixture) != expectedLen {
+		t.Errorf("expected %d entries, got %d", expectedLen, len(fixture))
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range fixture {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationBlockFetchMultipleBatches tests that the fixture is a valid slice
+func TestConversationBlockFetchMultipleBatches(t *testing.T) {
+	fixture := bf.ConversationBlockFetchMultipleBatches
+
+	if fixture == nil {
+		t.Fatal("ConversationBlockFetchMultipleBatches should not be nil")
+	}
+
+	// Expected: handshake request, handshake response,
+	// first batch: request range, start batch, block, batch done (4)
+	// second batch: request range, start batch, block, block, batch done (5)
+	// client done = 2 + 4 + 5 + 1 = 12 entries
+	expectedLen := 12
+	if len(fixture) != expectedLen {
+		t.Errorf("expected %d entries, got %d", expectedLen, len(fixture))
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range fixture {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestMockConstants verifies the mock constants are set correctly
+func TestMockConstants(t *testing.T) {
+	t.Run("MockBlockTypeConway", func(t *testing.T) {
+		if bf.MockBlockTypeConway != 6 {
+			t.Errorf(
+				"expected MockBlockTypeConway to be 6, got %d",
+				bf.MockBlockTypeConway,
+			)
+		}
+	})
+
+	t.Run("MockBlockHashes", func(t *testing.T) {
+		hashes := [][]byte{
+			bf.MockBlockHash1,
+			bf.MockBlockHash2,
+			bf.MockBlockHash3,
+			bf.MockBlockHash4,
+		}
+		for i, hash := range hashes {
+			if len(hash) != 32 {
+				t.Errorf(
+					"MockBlockHash%d should be 32 bytes, got %d",
+					i+1,
+					len(hash),
+				)
+			}
+		}
+
+		// Verify hashes are distinct
+		for i := range hashes {
+			for j := i + 1; j < len(hashes); j++ {
+				if bytes.Equal(hashes[i], hashes[j]) {
+					t.Errorf(
+						"MockBlockHash%d and MockBlockHash%d should be distinct",
+						i+1,
+						j+1,
+					)
+				}
+			}
+		}
+	})
+
+	t.Run("MockPoints", func(t *testing.T) {
+		points := []pcommon.Point{
+			bf.MockPoint1,
+			bf.MockPoint2,
+			bf.MockPoint3,
+			bf.MockPoint4,
+		}
+		expectedSlots := []uint64{100, 200, 300, 400}
+
+		for i, point := range points {
+			if point.Slot != expectedSlots[i] {
+				t.Errorf(
+					"MockPoint%d.Slot should be %d, got %d",
+					i+1,
+					expectedSlots[i],
+					point.Slot,
+				)
+			}
+		}
+	})
+
+	t.Run("MockBlockCbor", func(t *testing.T) {
+		cborData := [][]byte{
+			bf.MockBlockCbor1,
+			bf.MockBlockCbor2,
+			bf.MockBlockCbor3,
+		}
+		for i, cbor := range cborData {
+			if len(cbor) == 0 {
+				t.Errorf("MockBlockCbor%d should not be empty", i+1)
+			}
+		}
+	})
+}

--- a/blockfetch/fixtures.go
+++ b/blockfetch/fixtures.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import (
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for BlockFetch testing
+
+// MockBlockTypeConway is the block type for Conway era blocks
+const MockBlockTypeConway uint = 6
+
+// MockBlockHash1 is a sample block hash for testing
+var MockBlockHash1 = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// MockBlockHash2 is a second sample block hash for testing
+var MockBlockHash2 = []byte{
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+	0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+	0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+	0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
+}
+
+// MockBlockHash3 is a third sample block hash for testing
+var MockBlockHash3 = []byte{
+	0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+	0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+	0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+	0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
+}
+
+// MockBlockHash4 is a fourth sample block hash for testing
+var MockBlockHash4 = []byte{
+	0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+	0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70,
+	0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+	0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80,
+}
+
+// MockPoint1 represents a point on the chain for testing (slot 100)
+var MockPoint1 = pcommon.NewPoint(100, MockBlockHash1)
+
+// MockPoint2 represents a second point on the chain for testing (slot 200)
+var MockPoint2 = pcommon.NewPoint(200, MockBlockHash2)
+
+// MockPoint3 represents a third point on the chain for testing (slot 300)
+var MockPoint3 = pcommon.NewPoint(300, MockBlockHash3)
+
+// MockPoint4 represents a fourth point on the chain for testing (slot 400)
+var MockPoint4 = pcommon.NewPoint(400, MockBlockHash4)
+
+// MockBlockCbor1 is sample block CBOR data for testing
+var MockBlockCbor1 = []byte{
+	0x82, 0x06, 0x82, // Conway era block wrapper
+	0xa0,       // Empty header map
+	0x84,       // Array of 4
+	0x80, 0x80, // Empty arrays for body parts
+	0x80, 0xa0, // Empty arrays/maps
+}
+
+// MockBlockCbor2 is a second sample block CBOR data for testing
+var MockBlockCbor2 = []byte{
+	0x82, 0x06, 0x82, // Conway era block wrapper
+	0xa1, 0x00, 0x01, // Header with slot
+	0x84,       // Array of 4
+	0x80, 0x80, // Empty arrays for body parts
+	0x80, 0xa0, // Empty arrays/maps
+}
+
+// MockBlockCbor3 is a third sample block CBOR data for testing
+var MockBlockCbor3 = []byte{
+	0x82, 0x06, 0x82, // Conway era block wrapper
+	0xa1, 0x00, 0x02, // Header with slot
+	0x84,       // Array of 4
+	0x80, 0x80, // Empty arrays for body parts
+	0x80, 0xa0, // Empty arrays/maps
+}
+
+// Pre-defined conversations for common BlockFetch scenarios
+
+// ConversationBlockFetchRange is a pre-defined conversation for fetching a range of blocks:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - RequestRange (from MockPoint1 to MockPoint2)
+// - StartBatch
+// - Block (MockBlockCbor1)
+// - Block (MockBlockCbor2)
+// - BatchDone
+var ConversationBlockFetchRange = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// RequestRange
+	NewRequestRangeEntryAny(),
+	// StartBatch
+	NewStartBatchEntry(),
+	// Blocks
+	NewBlockEntry(MockBlockTypeConway, MockBlockCbor1),
+	NewBlockEntry(MockBlockTypeConway, MockBlockCbor2),
+	// BatchDone
+	NewBatchDoneEntry(),
+}
+
+// ConversationBlockFetchNoBlocks is a pre-defined conversation for when requested blocks
+// are not available:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - RequestRange
+// - NoBlocks
+var ConversationBlockFetchNoBlocks = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// RequestRange
+	NewRequestRangeEntryAny(),
+	// NoBlocks response
+	NewNoBlocksEntry(),
+}
+
+// ConversationBlockFetchMultipleBatches is a pre-defined conversation for multiple
+// range requests:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - First batch: RequestRange -> StartBatch -> Block -> BatchDone
+// - Second batch: RequestRange -> StartBatch -> Block -> Block -> BatchDone
+// - ClientDone
+var ConversationBlockFetchMultipleBatches = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// First batch
+	NewRequestRangeEntryAny(),
+	NewStartBatchEntry(),
+	NewBlockEntry(MockBlockTypeConway, MockBlockCbor1),
+	NewBatchDoneEntry(),
+	// Second batch
+	NewRequestRangeEntryAny(),
+	NewStartBatchEntry(),
+	NewBlockEntry(MockBlockTypeConway, MockBlockCbor2),
+	NewBlockEntry(MockBlockTypeConway, MockBlockCbor3),
+	NewBatchDoneEntry(),
+	// Client done
+	NewClientDoneEntry(),
+}

--- a/blocks/allegra.go
+++ b/blocks/allegra.go
@@ -1,0 +1,352 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// AllegraBlockBuilder implements BlockBuilder for Allegra era blocks
+type AllegraBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewAllegraBlockBuilder creates a new AllegraBlockBuilder
+func NewAllegraBlockBuilder() *AllegraBlockBuilder {
+	return &AllegraBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *AllegraBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *AllegraBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *AllegraBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *AllegraBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *AllegraBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Allegra block that satisfies the ledger.Block interface
+func (b *AllegraBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockAllegraBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *AllegraBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockAllegraBlock is a mock implementation of an Allegra block that satisfies ledger.Block
+type MockAllegraBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Allegra
+func (b *MockAllegraBlock) Type() int {
+	return allegra.BlockTypeAllegra
+}
+
+// Hash returns the block hash
+func (b *MockAllegraBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockAllegraBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockAllegraBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockAllegraBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockAllegraBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockAllegraBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Allegra era
+func (b *MockAllegraBlock) Era() lcommon.Era {
+	return allegra.EraAllegra
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockAllegraBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockAllegraBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockAllegraBlock) Header() ledger.BlockHeader {
+	return &MockAllegraBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockAllegraBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockAllegraBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockAllegraBlockHeader is a mock implementation of an Allegra block header
+type MockAllegraBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockAllegraBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockAllegraBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockAllegraBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockAllegraBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockAllegraBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockAllegraBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Allegra era
+func (h *MockAllegraBlockHeader) Era() lcommon.Era {
+	return allegra.EraAllegra
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockAllegraBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockAllegraBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// AllegraHeaderBuilder implements HeaderBuilder for Allegra era block headers
+type AllegraHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewAllegraHeaderBuilder creates a new AllegraHeaderBuilder
+func NewAllegraHeaderBuilder() *AllegraHeaderBuilder {
+	return &AllegraHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *AllegraHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *AllegraHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *AllegraHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *AllegraHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Allegra block header that satisfies the ledger.BlockHeader interface
+func (b *AllegraHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockAllegraBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *AllegraHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/alonzo.go
+++ b/blocks/alonzo.go
@@ -1,0 +1,354 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// AlonzoBlockBuilder implements BlockBuilder for Alonzo era blocks.
+// Alonzo introduced Plutus scripts, enabling smart contracts on Cardano.
+type AlonzoBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewAlonzoBlockBuilder creates a new AlonzoBlockBuilder
+func NewAlonzoBlockBuilder() *AlonzoBlockBuilder {
+	return &AlonzoBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *AlonzoBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *AlonzoBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *AlonzoBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *AlonzoBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *AlonzoBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Alonzo block that satisfies the ledger.Block interface
+func (b *AlonzoBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockAlonzoBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *AlonzoBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockAlonzoBlock is a mock implementation of an Alonzo block that satisfies ledger.Block.
+// Alonzo was the era that introduced Plutus scripts to Cardano.
+type MockAlonzoBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Alonzo
+func (b *MockAlonzoBlock) Type() int {
+	return alonzo.BlockTypeAlonzo
+}
+
+// Hash returns the block hash
+func (b *MockAlonzoBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockAlonzoBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockAlonzoBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockAlonzoBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockAlonzoBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockAlonzoBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Alonzo era
+func (b *MockAlonzoBlock) Era() lcommon.Era {
+	return alonzo.EraAlonzo
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockAlonzoBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockAlonzoBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockAlonzoBlock) Header() ledger.BlockHeader {
+	return &MockAlonzoBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockAlonzoBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockAlonzoBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockAlonzoBlockHeader is a mock implementation of an Alonzo block header
+type MockAlonzoBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockAlonzoBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockAlonzoBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockAlonzoBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockAlonzoBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockAlonzoBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockAlonzoBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Alonzo era
+func (h *MockAlonzoBlockHeader) Era() lcommon.Era {
+	return alonzo.EraAlonzo
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockAlonzoBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockAlonzoBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// AlonzoHeaderBuilder implements HeaderBuilder for Alonzo era block headers
+type AlonzoHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewAlonzoHeaderBuilder creates a new AlonzoHeaderBuilder
+func NewAlonzoHeaderBuilder() *AlonzoHeaderBuilder {
+	return &AlonzoHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *AlonzoHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *AlonzoHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *AlonzoHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *AlonzoHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Alonzo block header that satisfies the ledger.BlockHeader interface
+func (b *AlonzoHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockAlonzoBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *AlonzoHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/babbage.go
+++ b/blocks/babbage.go
@@ -1,0 +1,354 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// BabbageBlockBuilder implements BlockBuilder for Babbage era blocks.
+// Babbage introduced reference inputs and inline datums, enhancing smart contract capabilities.
+type BabbageBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewBabbageBlockBuilder creates a new BabbageBlockBuilder
+func NewBabbageBlockBuilder() *BabbageBlockBuilder {
+	return &BabbageBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *BabbageBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *BabbageBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *BabbageBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *BabbageBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *BabbageBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Babbage block that satisfies the ledger.Block interface
+func (b *BabbageBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockBabbageBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *BabbageBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockBabbageBlock is a mock implementation of a Babbage block that satisfies ledger.Block.
+// Babbage was the era that introduced reference inputs and inline datums to Cardano.
+type MockBabbageBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Babbage
+func (b *MockBabbageBlock) Type() int {
+	return babbage.BlockTypeBabbage
+}
+
+// Hash returns the block hash
+func (b *MockBabbageBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockBabbageBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockBabbageBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockBabbageBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockBabbageBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockBabbageBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Babbage era
+func (b *MockBabbageBlock) Era() lcommon.Era {
+	return babbage.EraBabbage
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockBabbageBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockBabbageBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockBabbageBlock) Header() ledger.BlockHeader {
+	return &MockBabbageBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockBabbageBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockBabbageBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockBabbageBlockHeader is a mock implementation of a Babbage block header
+type MockBabbageBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockBabbageBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockBabbageBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockBabbageBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockBabbageBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockBabbageBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockBabbageBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Babbage era
+func (h *MockBabbageBlockHeader) Era() lcommon.Era {
+	return babbage.EraBabbage
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockBabbageBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockBabbageBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// BabbageHeaderBuilder implements HeaderBuilder for Babbage era block headers
+type BabbageHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewBabbageHeaderBuilder creates a new BabbageHeaderBuilder
+func NewBabbageHeaderBuilder() *BabbageHeaderBuilder {
+	return &BabbageHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *BabbageHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *BabbageHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *BabbageHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *BabbageHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Babbage block header that satisfies the ledger.BlockHeader interface
+func (b *BabbageHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockBabbageBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *BabbageHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/blocks_test.go
+++ b/blocks/blocks_test.go
@@ -1,0 +1,1558 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/ouroboros-mock/blocks"
+)
+
+// TestNewConwayChainBuilder tests that NewConwayChainBuilder creates a builder with defaults
+func TestNewConwayChainBuilder(t *testing.T) {
+	builder := blocks.NewConwayChainBuilder()
+	if builder == nil {
+		t.Fatal("NewConwayChainBuilder returned nil")
+	}
+
+	// Build with no blocks should return empty slice
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %d blocks", len(result))
+	}
+}
+
+// TestConwayChainBuilderWithStartSlot tests WithStartSlot sets correct start slot
+func TestConwayChainBuilderWithStartSlot(t *testing.T) {
+	startSlot := uint64(100)
+	builder := blocks.NewConwayChainBuilder().
+		WithStartSlot(startSlot).
+		AddBlocks(3)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(result))
+	}
+
+	// First block should have the start slot
+	if result[0].SlotNumber() != startSlot {
+		t.Errorf(
+			"expected first block slot %d, got %d",
+			startSlot,
+			result[0].SlotNumber(),
+		)
+	}
+}
+
+// TestConwayChainBuilderWithStartBlockNumber tests WithStartBlockNumber sets correct start block number
+func TestConwayChainBuilderWithStartBlockNumber(t *testing.T) {
+	startBlockNum := uint64(50)
+	builder := blocks.NewConwayChainBuilder().
+		WithStartBlockNumber(startBlockNum).
+		AddBlocks(3)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(result))
+	}
+
+	// First block should have the start block number
+	if result[0].BlockNumber() != startBlockNum {
+		t.Errorf(
+			"expected first block number %d, got %d",
+			startBlockNum,
+			result[0].BlockNumber(),
+		)
+	}
+}
+
+// TestConwayChainBuilderWithSlotInterval tests WithSlotInterval sets correct slot intervals
+func TestConwayChainBuilderWithSlotInterval(t *testing.T) {
+	startSlot := uint64(0)
+	slotInterval := uint64(5)
+	builder := blocks.NewConwayChainBuilder().
+		WithStartSlot(startSlot).
+		WithSlotInterval(slotInterval).
+		AddBlocks(4)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	expectedSlots := []uint64{0, 5, 10, 15}
+	for i, block := range result {
+		if block.SlotNumber() != expectedSlots[i] {
+			t.Errorf(
+				"block %d: expected slot %d, got %d",
+				i,
+				expectedSlots[i],
+				block.SlotNumber(),
+			)
+		}
+	}
+}
+
+// TestConwayChainBuilderAddBlocks tests AddBlocks adds correct number of blocks
+func TestConwayChainBuilderAddBlocks(t *testing.T) {
+	builder := blocks.NewConwayChainBuilder().AddBlocks(5)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != 5 {
+		t.Errorf("expected 5 blocks, got %d", len(result))
+	}
+}
+
+// TestConwayChainBuilderBuildValidProgression tests Build returns valid blocks with proper slot/block number progression
+func TestConwayChainBuilderBuildValidProgression(t *testing.T) {
+	startSlot := uint64(100)
+	startBlockNum := uint64(10)
+	slotInterval := uint64(2)
+	count := 5
+
+	builder := blocks.NewConwayChainBuilder().
+		WithStartBlockNumber(startBlockNum).
+		WithStartSlot(startSlot).
+		WithSlotInterval(slotInterval).
+		AddBlocks(count)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != count {
+		t.Fatalf("expected %d blocks, got %d", count, len(result))
+	}
+
+	for i, block := range result {
+		expectedSlot := startSlot + uint64(i)*slotInterval
+		expectedBlockNum := startBlockNum + uint64(i)
+
+		if block.SlotNumber() != expectedSlot {
+			t.Errorf(
+				"block %d: expected slot %d, got %d",
+				i,
+				expectedSlot,
+				block.SlotNumber(),
+			)
+		}
+		if block.BlockNumber() != expectedBlockNum {
+			t.Errorf(
+				"block %d: expected block number %d, got %d",
+				i,
+				expectedBlockNum,
+				block.BlockNumber(),
+			)
+		}
+	}
+}
+
+// TestConwayChainBuilderBlockLinking tests that blocks are properly linked via prevHash
+func TestConwayChainBuilderBlockLinking(t *testing.T) {
+	genesisHash := make([]byte, 32)
+	for i := range genesisHash {
+		genesisHash[i] = byte(i)
+	}
+
+	builder := blocks.NewConwayChainBuilder().
+		WithGenesisHash(genesisHash).
+		AddBlocks(3)
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// First block's prevHash should be the genesis hash
+	if !bytes.Equal(result[0].PrevHash().Bytes(), genesisHash) {
+		t.Errorf("first block prevHash doesn't match genesis hash")
+	}
+
+	// Each subsequent block's prevHash should match the previous block's hash
+	for i := 1; i < len(result); i++ {
+		prevBlockHash := result[i-1].Hash().Bytes()
+		currentPrevHash := result[i].PrevHash().Bytes()
+		if !bytes.Equal(currentPrevHash, prevBlockHash) {
+			t.Errorf(
+				"block %d: prevHash doesn't match previous block's hash",
+				i,
+			)
+		}
+	}
+}
+
+// TestConwayChainBuilderWithCustomHash tests WithCustomHash option
+func TestConwayChainBuilderWithCustomHash(t *testing.T) {
+	customHash := make([]byte, 32)
+	for i := range customHash {
+		customHash[i] = 0xAB
+	}
+
+	builder := blocks.NewConwayChainBuilder().
+		AddBlock(blocks.WithCustomHash(customHash))
+
+	result, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+
+	if !bytes.Equal(result[0].Hash().Bytes(), customHash) {
+		t.Errorf("block hash doesn't match custom hash")
+	}
+}
+
+// TestConwayBlockBuilder tests NewConwayBlockBuilder
+func TestConwayBlockBuilder(t *testing.T) {
+	builder := blocks.NewConwayBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewConwayBlockBuilder returned nil")
+	}
+}
+
+// TestConwayBlockBuilderWithSlot tests WithSlot
+func TestConwayBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(12345)
+	block, err := blocks.NewConwayBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestConwayBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestConwayBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(999)
+	block, err := blocks.NewConwayBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestConwayBlockBuilderWithHash tests WithHash
+func TestConwayBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i)
+	}
+
+	block, err := blocks.NewConwayBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestConwayBlockBuilderWithPrevHash tests WithPrevHash
+func TestConwayBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(255 - i)
+	}
+
+	block, err := blocks.NewConwayBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestConwayBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestConwayBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewConwayBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	// Currently returns nil as a placeholder
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestConwayBlockEra tests that Conway block returns correct era
+func TestConwayBlockEra(t *testing.T) {
+	block, err := blocks.NewConwayBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != conway.EraIdConway {
+		t.Errorf(
+			"expected Conway era ID %d, got %d",
+			conway.EraIdConway,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestConwayBlockType tests that Conway block returns correct type
+func TestConwayBlockType(t *testing.T) {
+	block, err := blocks.NewConwayBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != conway.BlockTypeConway {
+		t.Errorf(
+			"expected Conway block type %d, got %d",
+			conway.BlockTypeConway,
+			block.Type(),
+		)
+	}
+}
+
+// TestBabbageBlockBuilder tests NewBabbageBlockBuilder
+func TestBabbageBlockBuilder(t *testing.T) {
+	builder := blocks.NewBabbageBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewBabbageBlockBuilder returned nil")
+	}
+}
+
+// TestBabbageBlockBuilderWithSlot tests WithSlot
+func TestBabbageBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(54321)
+	block, err := blocks.NewBabbageBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestBabbageBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestBabbageBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(888)
+	block, err := blocks.NewBabbageBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestBabbageBlockBuilderWithHash tests WithHash
+func TestBabbageBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i * 2)
+	}
+
+	block, err := blocks.NewBabbageBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestBabbageBlockBuilderWithPrevHash tests WithPrevHash
+func TestBabbageBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i * 3)
+	}
+
+	block, err := blocks.NewBabbageBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestBabbageBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestBabbageBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewBabbageBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestBabbageBlockEra tests that Babbage block returns correct era
+func TestBabbageBlockEra(t *testing.T) {
+	block, err := blocks.NewBabbageBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != babbage.EraIdBabbage {
+		t.Errorf(
+			"expected Babbage era ID %d, got %d",
+			babbage.EraIdBabbage,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestBabbageBlockType tests that Babbage block returns correct type
+func TestBabbageBlockType(t *testing.T) {
+	block, err := blocks.NewBabbageBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != babbage.BlockTypeBabbage {
+		t.Errorf(
+			"expected Babbage block type %d, got %d",
+			babbage.BlockTypeBabbage,
+			block.Type(),
+		)
+	}
+}
+
+// TestAlonzoBlockBuilder tests NewAlonzoBlockBuilder
+func TestAlonzoBlockBuilder(t *testing.T) {
+	builder := blocks.NewAlonzoBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewAlonzoBlockBuilder returned nil")
+	}
+}
+
+// TestAlonzoBlockBuilderWithSlot tests WithSlot
+func TestAlonzoBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(11111)
+	block, err := blocks.NewAlonzoBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestAlonzoBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestAlonzoBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(777)
+	block, err := blocks.NewAlonzoBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestAlonzoBlockBuilderWithHash tests WithHash
+func TestAlonzoBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i + 10)
+	}
+
+	block, err := blocks.NewAlonzoBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestAlonzoBlockBuilderWithPrevHash tests WithPrevHash
+func TestAlonzoBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i + 20)
+	}
+
+	block, err := blocks.NewAlonzoBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestAlonzoBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestAlonzoBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewAlonzoBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestAlonzoBlockEra tests that Alonzo block returns correct era
+func TestAlonzoBlockEra(t *testing.T) {
+	block, err := blocks.NewAlonzoBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != alonzo.EraIdAlonzo {
+		t.Errorf(
+			"expected Alonzo era ID %d, got %d",
+			alonzo.EraIdAlonzo,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestAlonzoBlockType tests that Alonzo block returns correct type
+func TestAlonzoBlockType(t *testing.T) {
+	block, err := blocks.NewAlonzoBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != alonzo.BlockTypeAlonzo {
+		t.Errorf(
+			"expected Alonzo block type %d, got %d",
+			alonzo.BlockTypeAlonzo,
+			block.Type(),
+		)
+	}
+}
+
+// TestMaryBlockBuilder tests NewMaryBlockBuilder
+func TestMaryBlockBuilder(t *testing.T) {
+	builder := blocks.NewMaryBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewMaryBlockBuilder returned nil")
+	}
+}
+
+// TestMaryBlockBuilderWithSlot tests WithSlot
+func TestMaryBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(22222)
+	block, err := blocks.NewMaryBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestMaryBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestMaryBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(666)
+	block, err := blocks.NewMaryBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestMaryBlockBuilderWithHash tests WithHash
+func TestMaryBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i + 30)
+	}
+
+	block, err := blocks.NewMaryBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestMaryBlockBuilderWithPrevHash tests WithPrevHash
+func TestMaryBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i + 40)
+	}
+
+	block, err := blocks.NewMaryBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestMaryBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestMaryBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewMaryBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestMaryBlockEra tests that Mary block returns correct era
+func TestMaryBlockEra(t *testing.T) {
+	block, err := blocks.NewMaryBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != mary.EraIdMary {
+		t.Errorf(
+			"expected Mary era ID %d, got %d",
+			mary.EraIdMary,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestMaryBlockType tests that Mary block returns correct type
+func TestMaryBlockType(t *testing.T) {
+	block, err := blocks.NewMaryBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != mary.BlockTypeMary {
+		t.Errorf(
+			"expected Mary block type %d, got %d",
+			mary.BlockTypeMary,
+			block.Type(),
+		)
+	}
+}
+
+// TestAllegraBlockBuilder tests NewAllegraBlockBuilder
+func TestAllegraBlockBuilder(t *testing.T) {
+	builder := blocks.NewAllegraBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewAllegraBlockBuilder returned nil")
+	}
+}
+
+// TestAllegraBlockBuilderWithSlot tests WithSlot
+func TestAllegraBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(33333)
+	block, err := blocks.NewAllegraBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestAllegraBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestAllegraBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(555)
+	block, err := blocks.NewAllegraBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestAllegraBlockBuilderWithHash tests WithHash
+func TestAllegraBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i + 50)
+	}
+
+	block, err := blocks.NewAllegraBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestAllegraBlockBuilderWithPrevHash tests WithPrevHash
+func TestAllegraBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i + 60)
+	}
+
+	block, err := blocks.NewAllegraBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestAllegraBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestAllegraBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewAllegraBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestAllegraBlockEra tests that Allegra block returns correct era
+func TestAllegraBlockEra(t *testing.T) {
+	block, err := blocks.NewAllegraBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != allegra.EraIdAllegra {
+		t.Errorf(
+			"expected Allegra era ID %d, got %d",
+			allegra.EraIdAllegra,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestAllegraBlockType tests that Allegra block returns correct type
+func TestAllegraBlockType(t *testing.T) {
+	block, err := blocks.NewAllegraBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != allegra.BlockTypeAllegra {
+		t.Errorf(
+			"expected Allegra block type %d, got %d",
+			allegra.BlockTypeAllegra,
+			block.Type(),
+		)
+	}
+}
+
+// TestShelleyBlockBuilder tests NewShelleyBlockBuilder
+func TestShelleyBlockBuilder(t *testing.T) {
+	builder := blocks.NewShelleyBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewShelleyBlockBuilder returned nil")
+	}
+}
+
+// TestShelleyBlockBuilderWithSlot tests WithSlot
+func TestShelleyBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(44444)
+	block, err := blocks.NewShelleyBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestShelleyBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestShelleyBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(444)
+	block, err := blocks.NewShelleyBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestShelleyBlockBuilderWithHash tests WithHash
+func TestShelleyBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i + 70)
+	}
+
+	block, err := blocks.NewShelleyBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestShelleyBlockBuilderWithPrevHash tests WithPrevHash
+func TestShelleyBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i + 80)
+	}
+
+	block, err := blocks.NewShelleyBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestShelleyBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestShelleyBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewShelleyBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestShelleyBlockEra tests that Shelley block returns correct era
+func TestShelleyBlockEra(t *testing.T) {
+	block, err := blocks.NewShelleyBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != shelley.EraIdShelley {
+		t.Errorf(
+			"expected Shelley era ID %d, got %d",
+			shelley.EraIdShelley,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestShelleyBlockType tests that Shelley block returns correct type
+func TestShelleyBlockType(t *testing.T) {
+	block, err := blocks.NewShelleyBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != shelley.BlockTypeShelley {
+		t.Errorf(
+			"expected Shelley block type %d, got %d",
+			shelley.BlockTypeShelley,
+			block.Type(),
+		)
+	}
+}
+
+// TestByronBlockBuilder tests NewByronBlockBuilder
+func TestByronBlockBuilder(t *testing.T) {
+	builder := blocks.NewByronBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewByronBlockBuilder returned nil")
+	}
+}
+
+// TestByronEBBBlockBuilder tests NewByronEBBBlockBuilder
+func TestByronEBBBlockBuilder(t *testing.T) {
+	builder := blocks.NewByronEBBBlockBuilder()
+	if builder == nil {
+		t.Fatal("NewByronEBBBlockBuilder returned nil")
+	}
+}
+
+// TestByronBlockBuilderWithSlot tests WithSlot
+func TestByronBlockBuilderWithSlot(t *testing.T) {
+	slot := uint64(55555)
+	block, err := blocks.NewByronBlockBuilder().
+		WithSlot(slot).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, block.SlotNumber())
+	}
+}
+
+// TestByronBlockBuilderWithBlockNumber tests WithBlockNumber
+func TestByronBlockBuilderWithBlockNumber(t *testing.T) {
+	blockNum := uint64(333)
+	block, err := blocks.NewByronBlockBuilder().
+		WithBlockNumber(blockNum).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			block.BlockNumber(),
+		)
+	}
+}
+
+// TestByronBlockBuilderWithHash tests WithHash
+func TestByronBlockBuilderWithHash(t *testing.T) {
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i + 90)
+	}
+
+	block, err := blocks.NewByronBlockBuilder().
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match expected value")
+	}
+}
+
+// TestByronBlockBuilderWithPrevHash tests WithPrevHash
+func TestByronBlockBuilderWithPrevHash(t *testing.T) {
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(i + 100)
+	}
+
+	block, err := blocks.NewByronBlockBuilder().
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !bytes.Equal(block.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match expected value")
+	}
+}
+
+// TestByronBlockBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestByronBlockBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewByronBlockBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestByronBlockEra tests that Byron block returns correct era
+func TestByronBlockEra(t *testing.T) {
+	block, err := blocks.NewByronBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Era().Id != byron.EraIdByron {
+		t.Errorf(
+			"expected Byron era ID %d, got %d",
+			byron.EraIdByron,
+			block.Era().Id,
+		)
+	}
+}
+
+// TestByronBlockType tests that Byron main block returns correct type
+func TestByronBlockType(t *testing.T) {
+	block, err := blocks.NewByronBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != byron.BlockTypeByronMain {
+		t.Errorf(
+			"expected Byron main block type %d, got %d",
+			byron.BlockTypeByronMain,
+			block.Type(),
+		)
+	}
+}
+
+// TestByronEBBBlockType tests that Byron EBB block returns correct type
+func TestByronEBBBlockType(t *testing.T) {
+	block, err := blocks.NewByronEBBBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != byron.BlockTypeByronEbb {
+		t.Errorf(
+			"expected Byron EBB block type %d, got %d",
+			byron.BlockTypeByronEbb,
+			block.Type(),
+		)
+	}
+}
+
+// TestByronBlockBuilderWithEBB tests WithEBB method
+func TestByronBlockBuilderWithEBB(t *testing.T) {
+	// Create a regular block and convert to EBB
+	block, err := blocks.NewByronBlockBuilder().
+		WithEBB(true).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.Type() != byron.BlockTypeByronEbb {
+		t.Errorf(
+			"expected Byron EBB block type %d, got %d",
+			byron.BlockTypeByronEbb,
+			block.Type(),
+		)
+	}
+}
+
+// TestBlockHeader tests that block headers are correctly returned
+func TestBlockHeader(t *testing.T) {
+	slot := uint64(1000)
+	blockNum := uint64(100)
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = byte(i)
+	}
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = byte(255 - i)
+	}
+
+	block, err := blocks.NewConwayBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	header := block.Header()
+	if header == nil {
+		t.Fatal("Header returned nil")
+	}
+
+	if header.SlotNumber() != slot {
+		t.Errorf("header slot: expected %d, got %d", slot, header.SlotNumber())
+	}
+	if header.BlockNumber() != blockNum {
+		t.Errorf(
+			"header block number: expected %d, got %d",
+			blockNum,
+			header.BlockNumber(),
+		)
+	}
+	if !bytes.Equal(header.Hash().Bytes(), hash) {
+		t.Errorf("header hash doesn't match")
+	}
+	if !bytes.Equal(header.PrevHash().Bytes(), prevHash) {
+		t.Errorf("header prevHash doesn't match")
+	}
+}
+
+// TestConwayHeaderBuilder tests NewConwayHeaderBuilder
+func TestConwayHeaderBuilder(t *testing.T) {
+	builder := blocks.NewConwayHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewConwayHeaderBuilder returned nil")
+	}
+}
+
+// TestConwayHeaderBuilderBuild tests building a Conway header
+func TestConwayHeaderBuilderBuild(t *testing.T) {
+	slot := uint64(5000)
+	blockNum := uint64(500)
+	hash := make([]byte, 32)
+	for i := range hash {
+		hash[i] = 0xAA
+	}
+	prevHash := make([]byte, 32)
+	for i := range prevHash {
+		prevHash[i] = 0xBB
+	}
+
+	header, err := blocks.NewConwayHeaderBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != slot {
+		t.Errorf("expected slot %d, got %d", slot, header.SlotNumber())
+	}
+	if header.BlockNumber() != blockNum {
+		t.Errorf(
+			"expected block number %d, got %d",
+			blockNum,
+			header.BlockNumber(),
+		)
+	}
+	if !bytes.Equal(header.Hash().Bytes(), hash) {
+		t.Errorf("hash doesn't match")
+	}
+	if !bytes.Equal(header.PrevHash().Bytes(), prevHash) {
+		t.Errorf("prevHash doesn't match")
+	}
+}
+
+// TestConwayHeaderBuilderBuildCbor tests BuildCbor returns nil (placeholder)
+func TestConwayHeaderBuilderBuildCbor(t *testing.T) {
+	cbor, err := blocks.NewConwayHeaderBuilder().BuildCbor()
+
+	if err != nil {
+		t.Fatalf("BuildCbor failed: %v", err)
+	}
+
+	if cbor != nil {
+		t.Errorf("expected nil CBOR, got %v", cbor)
+	}
+}
+
+// TestBabbageHeaderBuilder tests NewBabbageHeaderBuilder
+func TestBabbageHeaderBuilder(t *testing.T) {
+	builder := blocks.NewBabbageHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewBabbageHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(1000).
+		WithBlockNumber(100).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 1000 {
+		t.Errorf("expected slot 1000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 100 {
+		t.Errorf("expected block number 100, got %d", header.BlockNumber())
+	}
+}
+
+// TestAlonzoHeaderBuilder tests NewAlonzoHeaderBuilder
+func TestAlonzoHeaderBuilder(t *testing.T) {
+	builder := blocks.NewAlonzoHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewAlonzoHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(2000).
+		WithBlockNumber(200).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 2000 {
+		t.Errorf("expected slot 2000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 200 {
+		t.Errorf("expected block number 200, got %d", header.BlockNumber())
+	}
+}
+
+// TestMaryHeaderBuilder tests NewMaryHeaderBuilder
+func TestMaryHeaderBuilder(t *testing.T) {
+	builder := blocks.NewMaryHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewMaryHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(3000).
+		WithBlockNumber(300).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 3000 {
+		t.Errorf("expected slot 3000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 300 {
+		t.Errorf("expected block number 300, got %d", header.BlockNumber())
+	}
+}
+
+// TestAllegraHeaderBuilder tests NewAllegraHeaderBuilder
+func TestAllegraHeaderBuilder(t *testing.T) {
+	builder := blocks.NewAllegraHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewAllegraHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(4000).
+		WithBlockNumber(400).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 4000 {
+		t.Errorf("expected slot 4000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 400 {
+		t.Errorf("expected block number 400, got %d", header.BlockNumber())
+	}
+}
+
+// TestShelleyHeaderBuilder tests NewShelleyHeaderBuilder
+func TestShelleyHeaderBuilder(t *testing.T) {
+	builder := blocks.NewShelleyHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewShelleyHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(5000).
+		WithBlockNumber(500).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 5000 {
+		t.Errorf("expected slot 5000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 500 {
+		t.Errorf("expected block number 500, got %d", header.BlockNumber())
+	}
+}
+
+// TestByronHeaderBuilder tests NewByronHeaderBuilder
+func TestByronHeaderBuilder(t *testing.T) {
+	builder := blocks.NewByronHeaderBuilder()
+	if builder == nil {
+		t.Fatal("NewByronHeaderBuilder returned nil")
+	}
+
+	header, err := builder.
+		WithSlot(6000).
+		WithBlockNumber(600).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if header.SlotNumber() != 6000 {
+		t.Errorf("expected slot 6000, got %d", header.SlotNumber())
+	}
+	if header.BlockNumber() != 600 {
+		t.Errorf("expected block number 600, got %d", header.BlockNumber())
+	}
+}
+
+// TestByronHeaderBuilderWithEBB tests WithEBB on header builder
+func TestByronHeaderBuilderWithEBB(t *testing.T) {
+	builder := blocks.NewByronHeaderBuilder().WithEBB(true)
+	if builder == nil {
+		t.Fatal("NewByronHeaderBuilder returned nil")
+	}
+
+	header, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Header should be created successfully
+	if header == nil {
+		t.Fatal("Header is nil")
+	}
+}
+
+// TestBlockTransactionsEmpty tests that blocks with no transactions return nil or empty slice
+func TestBlockTransactionsEmpty(t *testing.T) {
+	block, err := blocks.NewConwayBlockBuilder().Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	txs := block.Transactions()
+	if len(txs) != 0 {
+		t.Errorf("expected 0 transactions, got %d", len(txs))
+	}
+}
+
+// TestChainBuilderInterface tests that ConwayChainBuilder implements ChainBuilder interface
+func TestChainBuilderInterface(t *testing.T) {
+	var _ blocks.ChainBuilder = blocks.NewConwayChainBuilder()
+}
+
+// TestBlockBuilderInterface tests that era-specific builders implement BlockBuilder interface
+func TestBlockBuilderInterface(t *testing.T) {
+	var _ blocks.BlockBuilder = blocks.NewConwayBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewBabbageBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewAlonzoBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewMaryBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewAllegraBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewShelleyBlockBuilder()
+	var _ blocks.BlockBuilder = blocks.NewByronBlockBuilder()
+}
+
+// TestHeaderBuilderInterface tests that era-specific header builders implement HeaderBuilder interface
+func TestHeaderBuilderInterface(t *testing.T) {
+	var _ blocks.HeaderBuilder = blocks.NewConwayHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewBabbageHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewAlonzoHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewMaryHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewAllegraHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewShelleyHeaderBuilder()
+	var _ blocks.HeaderBuilder = blocks.NewByronHeaderBuilder()
+}
+
+// TestChainBuilderMethodChaining tests that method chaining works correctly
+func TestChainBuilderMethodChaining(t *testing.T) {
+	result, err := blocks.NewConwayChainBuilder().
+		WithStartSlot(100).
+		WithSlotInterval(5).
+		WithEra(6).
+		AddBlocks(2).
+		AddBlock().
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 blocks, got %d", len(result))
+	}
+
+	// Check slot progression
+	expectedSlots := []uint64{100, 105, 110}
+	for i, block := range result {
+		if block.SlotNumber() != expectedSlots[i] {
+			t.Errorf(
+				"block %d: expected slot %d, got %d",
+				i,
+				expectedSlots[i],
+				block.SlotNumber(),
+			)
+		}
+	}
+}
+
+// TestBlockBuilderMethodChaining tests that block builder method chaining works correctly
+func TestBlockBuilderMethodChaining(t *testing.T) {
+	hash := make([]byte, 32)
+	prevHash := make([]byte, 32)
+
+	block, err := blocks.NewConwayBlockBuilder().
+		WithSlot(1000).
+		WithBlockNumber(100).
+		WithHash(hash).
+		WithPrevHash(prevHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if block.SlotNumber() != 1000 {
+		t.Errorf("expected slot 1000, got %d", block.SlotNumber())
+	}
+	if block.BlockNumber() != 100 {
+		t.Errorf("expected block number 100, got %d", block.BlockNumber())
+	}
+}

--- a/blocks/builder.go
+++ b/blocks/builder.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// BlockBuilder defines an interface for building mock blocks
+type BlockBuilder interface {
+	WithSlot(slot uint64) BlockBuilder
+	WithBlockNumber(number uint64) BlockBuilder
+	WithHash(hash []byte) BlockBuilder
+	WithPrevHash(prevHash []byte) BlockBuilder
+	WithTransactions(txs ...TxBuilder) BlockBuilder
+	Build() (ledger.Block, error)
+	BuildCbor() ([]byte, error)
+}
+
+// HeaderBuilder defines an interface for building mock block headers
+type HeaderBuilder interface {
+	WithSlot(slot uint64) HeaderBuilder
+	WithBlockNumber(number uint64) HeaderBuilder
+	WithHash(hash []byte) HeaderBuilder
+	WithPrevHash(prevHash []byte) HeaderBuilder
+	Build() (ledger.BlockHeader, error)
+	BuildCbor() ([]byte, error)
+}
+
+// TxBuilder defines an interface for building mock transactions
+type TxBuilder interface {
+	// Build constructs a transaction from the builder state
+	Build() (lcommon.Transaction, error)
+}

--- a/blocks/byron.go
+++ b/blocks/byron.go
@@ -1,0 +1,391 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// ByronBlockBuilder implements BlockBuilder for Byron era blocks
+type ByronBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	isEBB        bool
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewByronBlockBuilder creates a new ByronBlockBuilder for regular Byron main blocks
+func NewByronBlockBuilder() *ByronBlockBuilder {
+	return &ByronBlockBuilder{
+		isEBB: false,
+	}
+}
+
+// NewByronEBBBlockBuilder creates a new ByronBlockBuilder for epoch boundary blocks
+func NewByronEBBBlockBuilder() *ByronBlockBuilder {
+	return &ByronBlockBuilder{
+		isEBB: true,
+	}
+}
+
+// WithSlot sets the slot number for the block
+func (b *ByronBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ByronBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ByronBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ByronBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *ByronBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// WithEBB sets whether this is an epoch boundary block
+func (b *ByronBlockBuilder) WithEBB(isEBB bool) *ByronBlockBuilder {
+	b.isEBB = isEBB
+	return b
+}
+
+// Build constructs a mock Byron block that satisfies the ledger.Block interface
+func (b *ByronBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockByronBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+		isEBB:       b.isEBB,
+	}
+
+	// Build transactions if any (EBB blocks don't have transactions)
+	if !b.isEBB {
+		for _, txBuilder := range b.transactions {
+			tx, err := txBuilder.Build()
+			if err != nil {
+				return nil, err
+			}
+			mockBlock.transactions = append(mockBlock.transactions, tx)
+		}
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *ByronBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockByronBlock is a mock implementation of a Byron block that satisfies ledger.Block
+type MockByronBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+	isEBB        bool
+}
+
+// Type returns the block type identifier for Byron
+func (b *MockByronBlock) Type() int {
+	if b.isEBB {
+		return byron.BlockTypeByronEbb
+	}
+	return byron.BlockTypeByronMain
+}
+
+// Hash returns the block hash
+func (b *MockByronBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockByronBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockByronBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockByronBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockByronBlock) IssuerVkey() lcommon.IssuerVkey {
+	// Byron blocks don't have an issuer
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockByronBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Byron era
+func (b *MockByronBlock) Era() lcommon.Era {
+	return byron.EraByron
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockByronBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockByronBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockByronBlock) Header() ledger.BlockHeader {
+	return &MockByronBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+		isEBB:       b.isEBB,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockByronBlock) Transactions() []lcommon.Transaction {
+	// EBB blocks don't have transactions
+	if b.isEBB {
+		return nil
+	}
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockByronBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockByronBlockHeader is a mock implementation of a Byron block header
+type MockByronBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	isEBB       bool
+}
+
+// Hash returns the block header hash
+func (h *MockByronBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockByronBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockByronBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockByronBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockByronBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	// Byron blocks don't have an issuer
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockByronBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Byron era
+func (h *MockByronBlockHeader) Era() lcommon.Era {
+	return byron.EraByron
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockByronBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockByronBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// ByronHeaderBuilder implements HeaderBuilder for Byron era block headers
+type ByronHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	isEBB       bool
+	hashErr     error
+	prevHashErr error
+}
+
+// NewByronHeaderBuilder creates a new ByronHeaderBuilder
+func NewByronHeaderBuilder() *ByronHeaderBuilder {
+	return &ByronHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *ByronHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ByronHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ByronHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ByronHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithEBB sets whether this is an epoch boundary block header
+func (b *ByronHeaderBuilder) WithEBB(isEBB bool) *ByronHeaderBuilder {
+	b.isEBB = isEBB
+	return b
+}
+
+// Build constructs a mock Byron block header that satisfies the ledger.BlockHeader interface
+func (b *ByronHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockByronBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+		isEBB:       b.isEBB,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *ByronHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/chain.go
+++ b/blocks/chain.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// ChainBuilder defines an interface for building linked block sequences
+type ChainBuilder interface {
+	WithStartSlot(slot uint64) ChainBuilder
+	WithSlotInterval(interval uint64) ChainBuilder
+	WithEra(era uint) ChainBuilder
+	AddBlock(opts ...BlockOption) ChainBuilder
+	AddBlocks(count int) ChainBuilder
+	Build() ([]ledger.Block, error)
+}
+
+// BlockOption is a function that modifies a block configuration
+type BlockOption func(*blockConfig)
+
+// blockConfig holds configuration for a single block in the chain
+type blockConfig struct {
+	transactions []TxBuilder
+	customHash   []byte
+}
+
+// WithTxBuilders adds transaction builders to the block
+func WithTxBuilders(txs ...TxBuilder) BlockOption {
+	return func(cfg *blockConfig) {
+		cfg.transactions = append(cfg.transactions, txs...)
+	}
+}
+
+// WithCustomHash sets a custom hash for the block
+func WithCustomHash(hash []byte) BlockOption {
+	return func(cfg *blockConfig) {
+		cfg.customHash = hash
+	}
+}
+
+// ConwayChainBuilder implements ChainBuilder for Conway era blocks.
+// Note: This builder always creates Conway era blocks. The WithEra method
+// is a no-op, preserved for interface compatibility. For other eras,
+// create era-specific chain builders.
+type ConwayChainBuilder struct {
+	startSlot     uint64
+	slotInterval  uint64
+	blockConfigs  []*blockConfig
+	genesisHash   []byte
+	startBlockNum uint64
+}
+
+// NewConwayChainBuilder creates a new ConwayChainBuilder with default settings
+func NewConwayChainBuilder() *ConwayChainBuilder {
+	return &ConwayChainBuilder{
+		startSlot:     0,
+		slotInterval:  1,
+		blockConfigs:  make([]*blockConfig, 0),
+		genesisHash:   make([]byte, 32), // Zero hash as genesis
+		startBlockNum: 0,
+	}
+}
+
+// WithStartSlot sets the starting slot number for the chain
+func (b *ConwayChainBuilder) WithStartSlot(slot uint64) ChainBuilder {
+	b.startSlot = slot
+	return b
+}
+
+// WithSlotInterval sets the interval between consecutive slots.
+// If interval is 0, it defaults to 1 to prevent same-slot blocks.
+func (b *ConwayChainBuilder) WithSlotInterval(interval uint64) ChainBuilder {
+	if interval == 0 {
+		interval = 1
+	}
+	b.slotInterval = interval
+	return b
+}
+
+// WithEra is a no-op for ConwayChainBuilder (always produces Conway blocks).
+// This method exists for ChainBuilder interface compatibility.
+// For other eras, use era-specific chain builders.
+func (b *ConwayChainBuilder) WithEra(_ uint) ChainBuilder {
+	return b
+}
+
+// WithGenesisHash sets the genesis hash (prevHash of the first block)
+func (b *ConwayChainBuilder) WithGenesisHash(hash []byte) *ConwayChainBuilder {
+	b.genesisHash = hash
+	return b
+}
+
+// WithStartBlockNumber sets the starting block number
+func (b *ConwayChainBuilder) WithStartBlockNumber(
+	blockNum uint64,
+) *ConwayChainBuilder {
+	b.startBlockNum = blockNum
+	return b
+}
+
+// AddBlock adds a block with optional configuration to the chain
+func (b *ConwayChainBuilder) AddBlock(opts ...BlockOption) ChainBuilder {
+	cfg := &blockConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	b.blockConfigs = append(b.blockConfigs, cfg)
+	return b
+}
+
+// AddBlocks adds multiple empty blocks to the chain
+func (b *ConwayChainBuilder) AddBlocks(count int) ChainBuilder {
+	for range count {
+		b.blockConfigs = append(b.blockConfigs, &blockConfig{})
+	}
+	return b
+}
+
+// Build constructs the chain of linked blocks
+func (b *ConwayChainBuilder) Build() ([]ledger.Block, error) {
+	if len(b.blockConfigs) == 0 {
+		return []ledger.Block{}, nil
+	}
+
+	blocks := make([]ledger.Block, 0, len(b.blockConfigs))
+	prevHash := b.genesisHash
+
+	for i, cfg := range b.blockConfigs {
+		// #nosec G115 - i is bounded by slice length which fits in int
+		slot := b.startSlot + uint64(i)*b.slotInterval
+		// #nosec G115 - i is bounded by slice length which fits in int
+		blockNum := b.startBlockNum + uint64(i)
+
+		// Generate block hash (either custom or deterministic)
+		var blockHash []byte
+		if cfg.customHash != nil {
+			blockHash = cfg.customHash
+		} else {
+			blockHash = generateBlockHash(slot, blockNum, prevHash)
+		}
+
+		// Build the block using ConwayBlockBuilder
+		builder := NewConwayBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(blockHash).
+			WithPrevHash(prevHash)
+
+		// Add transactions if any
+		if len(cfg.transactions) > 0 {
+			builder.WithTransactions(cfg.transactions...)
+		}
+
+		block, err := builder.Build()
+		if err != nil {
+			return nil, err
+		}
+
+		blocks = append(blocks, block)
+		prevHash = blockHash
+	}
+
+	return blocks, nil
+}
+
+// generateBlockHash creates a deterministic hash based on block parameters
+func generateBlockHash(slot, blockNum uint64, prevHash []byte) []byte {
+	// Create a deterministic hash from slot, block number, and previous hash
+	data := make([]byte, 16, 16+len(prevHash))
+	binary.BigEndian.PutUint64(data[0:8], slot)
+	binary.BigEndian.PutUint64(data[8:16], blockNum)
+	data = append(data, prevHash...)
+
+	hash := sha256.Sum256(data)
+	return hash[:]
+}

--- a/blocks/conway.go
+++ b/blocks/conway.go
@@ -1,0 +1,352 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// ConwayBlockBuilder implements BlockBuilder for Conway era blocks
+type ConwayBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewConwayBlockBuilder creates a new ConwayBlockBuilder
+func NewConwayBlockBuilder() *ConwayBlockBuilder {
+	return &ConwayBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *ConwayBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ConwayBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ConwayBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ConwayBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *ConwayBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Conway block that satisfies the ledger.Block interface
+func (b *ConwayBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockConwayBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *ConwayBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockConwayBlock is a mock implementation of a Conway block that satisfies ledger.Block
+type MockConwayBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Conway
+func (b *MockConwayBlock) Type() int {
+	return conway.BlockTypeConway
+}
+
+// Hash returns the block hash
+func (b *MockConwayBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockConwayBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockConwayBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockConwayBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockConwayBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockConwayBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Conway era
+func (b *MockConwayBlock) Era() lcommon.Era {
+	return conway.EraConway
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockConwayBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockConwayBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockConwayBlock) Header() ledger.BlockHeader {
+	return &MockConwayBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockConwayBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockConwayBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockConwayBlockHeader is a mock implementation of a Conway block header
+type MockConwayBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockConwayBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockConwayBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockConwayBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockConwayBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockConwayBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockConwayBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Conway era
+func (h *MockConwayBlockHeader) Era() lcommon.Era {
+	return conway.EraConway
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockConwayBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockConwayBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// ConwayHeaderBuilder implements HeaderBuilder for Conway era block headers
+type ConwayHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewConwayHeaderBuilder creates a new ConwayHeaderBuilder
+func NewConwayHeaderBuilder() *ConwayHeaderBuilder {
+	return &ConwayHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *ConwayHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ConwayHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ConwayHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ConwayHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Conway block header that satisfies the ledger.BlockHeader interface
+func (b *ConwayHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockConwayBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *ConwayHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/mary.go
+++ b/blocks/mary.go
@@ -1,0 +1,352 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// MaryBlockBuilder implements BlockBuilder for Mary era blocks
+type MaryBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewMaryBlockBuilder creates a new MaryBlockBuilder
+func NewMaryBlockBuilder() *MaryBlockBuilder {
+	return &MaryBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *MaryBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *MaryBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *MaryBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *MaryBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *MaryBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Mary block that satisfies the ledger.Block interface
+func (b *MaryBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockMaryBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *MaryBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockMaryBlock is a mock implementation of a Mary block that satisfies ledger.Block
+type MockMaryBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Mary
+func (b *MockMaryBlock) Type() int {
+	return mary.BlockTypeMary
+}
+
+// Hash returns the block hash
+func (b *MockMaryBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockMaryBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockMaryBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockMaryBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockMaryBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockMaryBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Mary era
+func (b *MockMaryBlock) Era() lcommon.Era {
+	return mary.EraMary
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockMaryBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockMaryBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockMaryBlock) Header() ledger.BlockHeader {
+	return &MockMaryBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockMaryBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockMaryBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockMaryBlockHeader is a mock implementation of a Mary block header
+type MockMaryBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockMaryBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockMaryBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockMaryBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockMaryBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockMaryBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockMaryBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Mary era
+func (h *MockMaryBlockHeader) Era() lcommon.Era {
+	return mary.EraMary
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockMaryBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockMaryBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// MaryHeaderBuilder implements HeaderBuilder for Mary era block headers
+type MaryHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewMaryHeaderBuilder creates a new MaryHeaderBuilder
+func NewMaryHeaderBuilder() *MaryHeaderBuilder {
+	return &MaryHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *MaryHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *MaryHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *MaryHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *MaryHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Mary block header that satisfies the ledger.BlockHeader interface
+func (b *MaryHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockMaryBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *MaryHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/blocks/shelley.go
+++ b/blocks/shelley.go
@@ -1,0 +1,352 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// ShelleyBlockBuilder implements BlockBuilder for Shelley era blocks
+type ShelleyBlockBuilder struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []TxBuilder
+	hashErr      error
+	prevHashErr  error
+}
+
+// NewShelleyBlockBuilder creates a new ShelleyBlockBuilder
+func NewShelleyBlockBuilder() *ShelleyBlockBuilder {
+	return &ShelleyBlockBuilder{}
+}
+
+// WithSlot sets the slot number for the block
+func (b *ShelleyBlockBuilder) WithSlot(slot uint64) BlockBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ShelleyBlockBuilder) WithBlockNumber(number uint64) BlockBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ShelleyBlockBuilder) WithHash(hash []byte) BlockBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ShelleyBlockBuilder) WithPrevHash(prevHash []byte) BlockBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// WithTransactions sets the transactions for the block
+func (b *ShelleyBlockBuilder) WithTransactions(
+	txs ...TxBuilder,
+) BlockBuilder {
+	b.transactions = txs
+	return b
+}
+
+// Build constructs a mock Shelley block that satisfies the ledger.Block interface
+func (b *ShelleyBlockBuilder) Build() (ledger.Block, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	mockBlock := &MockShelleyBlock{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+
+	// Build transactions if any
+	for _, txBuilder := range b.transactions {
+		tx, err := txBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		mockBlock.transactions = append(mockBlock.transactions, tx)
+	}
+
+	return mockBlock, nil
+}
+
+// BuildCbor returns the CBOR encoding of the block
+// Currently returns nil as a placeholder
+func (b *ShelleyBlockBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}
+
+// MockShelleyBlock is a mock implementation of a Shelley block that satisfies ledger.Block
+type MockShelleyBlock struct {
+	slot         uint64
+	blockNumber  uint64
+	hash         lcommon.Blake2b256
+	prevHash     lcommon.Blake2b256
+	transactions []lcommon.Transaction
+}
+
+// Type returns the block type identifier for Shelley
+func (b *MockShelleyBlock) Type() int {
+	return shelley.BlockTypeShelley
+}
+
+// Hash returns the block hash
+func (b *MockShelleyBlock) Hash() lcommon.Blake2b256 {
+	return b.hash
+}
+
+// PrevHash returns the previous block hash
+func (b *MockShelleyBlock) PrevHash() lcommon.Blake2b256 {
+	return b.prevHash
+}
+
+// BlockNumber returns the block number
+func (b *MockShelleyBlock) BlockNumber() uint64 {
+	return b.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (b *MockShelleyBlock) SlotNumber() uint64 {
+	return b.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (b *MockShelleyBlock) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (b *MockShelleyBlock) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Shelley era
+func (b *MockShelleyBlock) Era() lcommon.Era {
+	return shelley.EraShelley
+}
+
+// Cbor returns the CBOR encoding of the block
+func (b *MockShelleyBlock) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (b *MockShelleyBlock) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// Header returns the block header
+func (b *MockShelleyBlock) Header() ledger.BlockHeader {
+	return &MockShelleyBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}
+}
+
+// Transactions returns the list of transactions in the block
+func (b *MockShelleyBlock) Transactions() []lcommon.Transaction {
+	return b.transactions
+}
+
+// Utxorpc returns the block in UTxO RPC format
+func (b *MockShelleyBlock) Utxorpc() (*utxorpc.Block, error) {
+	txs := make([]*utxorpc.Tx, 0, len(b.transactions))
+	for _, t := range b.transactions {
+		tx, err := t.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	body := &utxorpc.BlockBody{
+		Tx: txs,
+	}
+	header := &utxorpc.BlockHeader{
+		Hash:   b.hash[:],
+		Height: b.blockNumber,
+		Slot:   b.slot,
+	}
+	block := &utxorpc.Block{
+		Body:   body,
+		Header: header,
+	}
+	return block, nil
+}
+
+// MockShelleyBlockHeader is a mock implementation of a Shelley block header
+type MockShelleyBlockHeader struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+}
+
+// Hash returns the block header hash
+func (h *MockShelleyBlockHeader) Hash() lcommon.Blake2b256 {
+	return h.hash
+}
+
+// PrevHash returns the previous block hash
+func (h *MockShelleyBlockHeader) PrevHash() lcommon.Blake2b256 {
+	return h.prevHash
+}
+
+// BlockNumber returns the block number
+func (h *MockShelleyBlockHeader) BlockNumber() uint64 {
+	return h.blockNumber
+}
+
+// SlotNumber returns the slot number
+func (h *MockShelleyBlockHeader) SlotNumber() uint64 {
+	return h.slot
+}
+
+// IssuerVkey returns the issuer verification key
+func (h *MockShelleyBlockHeader) IssuerVkey() lcommon.IssuerVkey {
+	return lcommon.IssuerVkey{}
+}
+
+// BlockBodySize returns the block body size
+func (h *MockShelleyBlockHeader) BlockBodySize() uint64 {
+	return 0
+}
+
+// Era returns the Shelley era
+func (h *MockShelleyBlockHeader) Era() lcommon.Era {
+	return shelley.EraShelley
+}
+
+// Cbor returns the CBOR encoding of the header
+func (h *MockShelleyBlockHeader) Cbor() []byte {
+	return nil
+}
+
+// BlockBodyHash returns the block body hash
+func (h *MockShelleyBlockHeader) BlockBodyHash() lcommon.Blake2b256 {
+	return lcommon.Blake2b256{}
+}
+
+// ShelleyHeaderBuilder implements HeaderBuilder for Shelley era block headers
+type ShelleyHeaderBuilder struct {
+	slot        uint64
+	blockNumber uint64
+	hash        lcommon.Blake2b256
+	prevHash    lcommon.Blake2b256
+	hashErr     error
+	prevHashErr error
+}
+
+// NewShelleyHeaderBuilder creates a new ShelleyHeaderBuilder
+func NewShelleyHeaderBuilder() *ShelleyHeaderBuilder {
+	return &ShelleyHeaderBuilder{}
+}
+
+// WithSlot sets the slot number for the header
+func (b *ShelleyHeaderBuilder) WithSlot(slot uint64) HeaderBuilder {
+	b.slot = slot
+	return b
+}
+
+// WithBlockNumber sets the block number
+func (b *ShelleyHeaderBuilder) WithBlockNumber(number uint64) HeaderBuilder {
+	b.blockNumber = number
+	return b
+}
+
+// WithHash sets the block hash
+func (b *ShelleyHeaderBuilder) WithHash(hash []byte) HeaderBuilder {
+	if len(hash) != len(b.hash) {
+		b.hashErr = fmt.Errorf(
+			"hash must be exactly %d bytes, got %d",
+			len(b.hash),
+			len(hash),
+		)
+		return b
+	}
+	copy(b.hash[:], hash)
+	return b
+}
+
+// WithPrevHash sets the previous block hash
+func (b *ShelleyHeaderBuilder) WithPrevHash(prevHash []byte) HeaderBuilder {
+	if len(prevHash) != len(b.prevHash) {
+		b.prevHashErr = fmt.Errorf(
+			"prevHash must be exactly %d bytes, got %d",
+			len(b.prevHash),
+			len(prevHash),
+		)
+		return b
+	}
+	copy(b.prevHash[:], prevHash)
+	return b
+}
+
+// Build constructs a mock Shelley block header that satisfies the ledger.BlockHeader interface
+func (b *ShelleyHeaderBuilder) Build() (ledger.BlockHeader, error) {
+	if b.hashErr != nil {
+		return nil, b.hashErr
+	}
+	if b.prevHashErr != nil {
+		return nil, b.prevHashErr
+	}
+	return &MockShelleyBlockHeader{
+		slot:        b.slot,
+		blockNumber: b.blockNumber,
+		hash:        b.hash,
+		prevHash:    b.prevHash,
+	}, nil
+}
+
+// BuildCbor returns the CBOR encoding of the header
+// Currently returns nil as a placeholder
+func (b *ShelleyHeaderBuilder) BuildCbor() ([]byte, error) {
+	// TODO: Implement CBOR encoding when needed
+	return nil, nil
+}

--- a/chainsync/entries.go
+++ b/chainsync/entries.go
@@ -1,0 +1,334 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// getProtocolId returns the appropriate ChainSync protocol ID based on mode
+func getProtocolId(isNtC bool) uint16 {
+	if isNtC {
+		return chainsync.ProtocolIdNtC
+	}
+	return chainsync.ProtocolIdNtN
+}
+
+// ConversationEntryFindIntersect expects a FindIntersect message from the client
+type ConversationEntryFindIntersect struct {
+	Points []pcommon.Point // Optional: expected points for validation (nil means accept any)
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryInput
+func (e ConversationEntryFindIntersect) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      getProtocolId(isNtC),
+		IsResponse:      false,
+		MessageType:     chainsync.MessageTypeFindIntersect,
+		MsgFromCborFunc: NewMsgFromCborFunc(isNtC),
+	}
+	if e.Points != nil {
+		entry.Message = chainsync.NewMsgFindIntersect(e.Points)
+	}
+	return entry
+}
+
+// ConversationEntryIntersectFound sends an IntersectFound response to the client
+type ConversationEntryIntersectFound struct {
+	Point pcommon.Point // The intersection point found
+	Tip   pcommon.Tip   // Current chain tip
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput
+func (e ConversationEntryIntersectFound) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: getProtocolId(isNtC),
+		IsResponse: true,
+		Messages: []protocol.Message{
+			chainsync.NewMsgIntersectFound(e.Point, e.Tip),
+		},
+	}
+}
+
+// ConversationEntryIntersectNotFound sends an IntersectNotFound response to the client
+type ConversationEntryIntersectNotFound struct {
+	Tip pcommon.Tip // Current chain tip
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput
+func (e ConversationEntryIntersectNotFound) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: getProtocolId(isNtC),
+		IsResponse: true,
+		Messages: []protocol.Message{
+			chainsync.NewMsgIntersectNotFound(e.Tip),
+		},
+	}
+}
+
+// ConversationEntryRequestNext expects a RequestNext message from the client
+type ConversationEntryRequestNext struct{}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryInput
+func (e ConversationEntryRequestNext) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      getProtocolId(isNtC),
+		IsResponse:      false,
+		MessageType:     chainsync.MessageTypeRequestNext,
+		MsgFromCborFunc: NewMsgFromCborFunc(isNtC),
+	}
+}
+
+// ConversationEntryAwaitReply sends an AwaitReply message to the client (at chain tip)
+type ConversationEntryAwaitReply struct{}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput
+func (e ConversationEntryAwaitReply) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: getProtocolId(isNtC),
+		IsResponse: true,
+		Messages: []protocol.Message{
+			chainsync.NewMsgAwaitReply(),
+		},
+	}
+}
+
+// ConversationEntryRollForward sends a RollForward message with block/header data to the client
+type ConversationEntryRollForward struct {
+	BlockType uint        // Block type (era)
+	BlockCbor []byte      // Raw block/header CBOR data
+	Tip       pcommon.Tip // Current chain tip
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput.
+// Returns an error if the RollForward message cannot be created.
+func (e ConversationEntryRollForward) ToEntry(
+	isNtC bool,
+) (ouroboros_mock.ConversationEntryOutput, error) {
+	var msg protocol.Message
+	if isNtC {
+		rollForwardMsg, err := chainsync.NewMsgRollForwardNtC(
+			e.BlockType,
+			e.BlockCbor,
+			e.Tip,
+		)
+		if err != nil {
+			return ouroboros_mock.ConversationEntryOutput{}, fmt.Errorf(
+				"failed to create RollForward NtC message: %w "+
+					"(BlockType=%d, BlockCbor len=%d, Tip=%+v)",
+				err, e.BlockType, len(e.BlockCbor), e.Tip,
+			)
+		}
+		msg = rollForwardMsg
+	} else {
+		// For NtN, BlockType represents the era, and we pass 0 for byronType
+		// The byronType is only relevant for Byron era blocks
+		rollForwardMsg, err := chainsync.NewMsgRollForwardNtN(
+			e.BlockType, // era
+			0,           // byronType (0 for non-Byron, set appropriately for Byron)
+			e.BlockCbor,
+			e.Tip,
+		)
+		if err != nil {
+			return ouroboros_mock.ConversationEntryOutput{}, fmt.Errorf(
+				"failed to create RollForward NtN message: %w "+
+					"(Era=%d, BlockCbor len=%d, Tip=%+v)",
+				err, e.BlockType, len(e.BlockCbor), e.Tip,
+			)
+		}
+		msg = rollForwardMsg
+	}
+
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: getProtocolId(isNtC),
+		IsResponse: true,
+		Messages:   []protocol.Message{msg},
+	}, nil
+}
+
+// ConversationEntryRollForwardNtN is a specialized RollForward for NtN with explicit Byron type
+type ConversationEntryRollForwardNtN struct {
+	Era       uint        // Era (0=Byron, 1=Shelley, etc.)
+	ByronType uint        // Byron block type (EBB=0, Main=1), only used for Byron era
+	BlockCbor []byte      // Raw header CBOR data
+	Tip       pcommon.Tip // Current chain tip
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput.
+// Returns an error if the RollForward message cannot be created.
+func (e ConversationEntryRollForwardNtN) ToEntry() (ouroboros_mock.ConversationEntryOutput, error) {
+	rollForwardMsg, err := chainsync.NewMsgRollForwardNtN(
+		e.Era,
+		e.ByronType,
+		e.BlockCbor,
+		e.Tip,
+	)
+	if err != nil {
+		return ouroboros_mock.ConversationEntryOutput{}, fmt.Errorf(
+			"failed to create RollForward NtN message: %w "+
+				"(Era=%d, ByronType=%d, BlockCbor len=%d, Tip=%+v)",
+			err, e.Era, e.ByronType, len(e.BlockCbor), e.Tip,
+		)
+	}
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: chainsync.ProtocolIdNtN,
+		IsResponse: true,
+		Messages:   []protocol.Message{rollForwardMsg},
+	}, nil
+}
+
+// ConversationEntryRollBackward sends a RollBackward message to the client
+type ConversationEntryRollBackward struct {
+	Point pcommon.Point // The point to roll back to
+	Tip   pcommon.Tip   // Current chain tip
+}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryOutput
+func (e ConversationEntryRollBackward) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: getProtocolId(isNtC),
+		IsResponse: true,
+		Messages: []protocol.Message{
+			chainsync.NewMsgRollBackward(e.Point, e.Tip),
+		},
+	}
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate the protocol
+type ConversationEntryDone struct{}
+
+// ToEntry converts this ChainSync entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry(
+	isNtC bool,
+) ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      getProtocolId(isNtC),
+		IsResponse:      false,
+		MessageType:     chainsync.MessageTypeDone,
+		MsgFromCborFunc: NewMsgFromCborFunc(isNtC),
+	}
+}
+
+// NewMsgFromCborFunc returns the appropriate message parser function based on protocol mode
+func NewMsgFromCborFunc(isNtC bool) protocol.MessageFromCborFunc {
+	if isNtC {
+		return chainsync.NewMsgFromCborNtC
+	}
+	return chainsync.NewMsgFromCborNtN
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewFindIntersectEntry creates a ConversationEntryInput for expecting a FindIntersect message
+func NewFindIntersectEntry(
+	isNtC bool,
+	points []pcommon.Point,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryFindIntersect{Points: points}.ToEntry(isNtC)
+}
+
+// NewIntersectFoundEntry creates a ConversationEntryOutput for sending an IntersectFound response
+func NewIntersectFoundEntry(
+	isNtC bool,
+	point pcommon.Point,
+	tip pcommon.Tip,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryIntersectFound{
+		Point: point,
+		Tip:   tip,
+	}.ToEntry(
+		isNtC,
+	)
+}
+
+// NewIntersectNotFoundEntry creates a ConversationEntryOutput for sending an IntersectNotFound response
+func NewIntersectNotFoundEntry(
+	isNtC bool,
+	tip pcommon.Tip,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryIntersectNotFound{Tip: tip}.ToEntry(isNtC)
+}
+
+// NewRequestNextEntry creates a ConversationEntryInput for expecting a RequestNext message
+func NewRequestNextEntry(isNtC bool) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryRequestNext{}.ToEntry(isNtC)
+}
+
+// NewAwaitReplyEntry creates a ConversationEntryOutput for sending an AwaitReply message
+func NewAwaitReplyEntry(isNtC bool) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryAwaitReply{}.ToEntry(isNtC)
+}
+
+// NewRollForwardEntry creates a ConversationEntryOutput for sending a RollForward message.
+// Returns an error if the RollForward message cannot be created.
+func NewRollForwardEntry(
+	isNtC bool,
+	blockType uint,
+	blockCbor []byte,
+	tip pcommon.Tip,
+) (ouroboros_mock.ConversationEntryOutput, error) {
+	return ConversationEntryRollForward{
+		BlockType: blockType,
+		BlockCbor: blockCbor,
+		Tip:       tip,
+	}.ToEntry(isNtC)
+}
+
+// NewRollBackwardEntry creates a ConversationEntryOutput for sending a RollBackward message
+func NewRollBackwardEntry(
+	isNtC bool,
+	point pcommon.Point,
+	tip pcommon.Tip,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryRollBackward{Point: point, Tip: tip}.ToEntry(isNtC)
+}
+
+// MustRollForwardEntry creates a ConversationEntryOutput for sending a RollForward message.
+// Panics if the RollForward message cannot be created. Use this for fixtures and test setup
+// where errors indicate programmer mistakes. For production code, use NewRollForwardEntry.
+func MustRollForwardEntry(
+	isNtC bool,
+	blockType uint,
+	blockCbor []byte,
+	tip pcommon.Tip,
+) ouroboros_mock.ConversationEntryOutput {
+	entry, err := NewRollForwardEntry(isNtC, blockType, blockCbor, tip)
+	if err != nil {
+		panic(err)
+	}
+	return entry
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry(isNtC bool) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry(isNtC)
+}

--- a/chainsync/entries_test.go
+++ b/chainsync/entries_test.go
@@ -1,0 +1,1206 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	cs "github.com/blinklabs-io/ouroboros-mock/chainsync"
+)
+
+// Test data for tests
+var (
+	testBlockHash = []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	testPoint = pcommon.NewPoint(100, testBlockHash)
+	testTip   = pcommon.Tip{
+		Point:       pcommon.NewPoint(1000, testBlockHash),
+		BlockNumber: 100,
+	}
+	testBlockCbor = []byte{0x82, 0x00, 0xa0}
+)
+
+// TestConversationEntryFindIntersect tests the FindIntersect entry type
+func TestConversationEntryFindIntersect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		points   []pcommon.Point
+		wantNil  bool
+		expected uint16
+	}{
+		{
+			name:     "NtC with nil points",
+			isNtC:    true,
+			points:   nil,
+			wantNil:  true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN with nil points",
+			isNtC:    false,
+			points:   nil,
+			wantNil:  true,
+			expected: chainsync.ProtocolIdNtN,
+		},
+		{
+			name:     "NtC with points",
+			isNtC:    true,
+			points:   []pcommon.Point{testPoint},
+			wantNil:  false,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN with points",
+			isNtC:    false,
+			points:   []pcommon.Point{testPoint},
+			wantNil:  false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryFindIntersect{Points: tc.points}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != false {
+				t.Errorf("expected IsResponse to be false, got true")
+			}
+
+			if result.MessageType != chainsync.MessageTypeFindIntersect {
+				t.Errorf(
+					"expected message type %d, got %d",
+					chainsync.MessageTypeFindIntersect,
+					result.MessageType,
+				)
+			}
+
+			if result.MsgFromCborFunc == nil {
+				t.Error("expected MsgFromCborFunc to be non-nil")
+			}
+
+			if tc.wantNil && result.Message != nil {
+				t.Error("expected Message to be nil when Points is nil")
+			}
+
+			if !tc.wantNil && result.Message == nil {
+				t.Error(
+					"expected Message to be non-nil when Points is provided",
+				)
+			}
+		})
+	}
+}
+
+// TestConversationEntryIntersectFound tests the IntersectFound entry type
+func TestConversationEntryIntersectFound(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryIntersectFound{
+				Point: testPoint,
+				Tip:   testTip,
+			}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Errorf("expected IsResponse to be true, got false")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryIntersectNotFound tests the IntersectNotFound entry type
+func TestConversationEntryIntersectNotFound(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryIntersectNotFound{Tip: testTip}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Errorf("expected IsResponse to be true, got false")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryRequestNext tests the RequestNext entry type
+func TestConversationEntryRequestNext(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryRequestNext{}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != false {
+				t.Errorf("expected IsResponse to be false, got true")
+			}
+
+			if result.MessageType != chainsync.MessageTypeRequestNext {
+				t.Errorf(
+					"expected message type %d, got %d",
+					chainsync.MessageTypeRequestNext,
+					result.MessageType,
+				)
+			}
+
+			if result.MsgFromCborFunc == nil {
+				t.Error("expected MsgFromCborFunc to be non-nil")
+			}
+		})
+	}
+}
+
+// TestConversationEntryAwaitReply tests the AwaitReply entry type
+func TestConversationEntryAwaitReply(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryAwaitReply{}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Errorf("expected IsResponse to be true, got false")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryRollForward tests the RollForward entry type
+func TestConversationEntryRollForward(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryRollForward{
+				BlockType: 0,
+				BlockCbor: testBlockCbor,
+				Tip:       testTip,
+			}
+			result, err := entry.ToEntry(tc.isNtC)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Errorf("expected IsResponse to be true, got false")
+			}
+
+			// Note: RollForward may return empty messages on error,
+			// but with valid CBOR it should return 1 message
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryRollForwardNtN tests the RollForwardNtN entry type
+func TestConversationEntryRollForwardNtN(t *testing.T) {
+	entry := cs.ConversationEntryRollForwardNtN{
+		Era:       1, // Shelley
+		ByronType: 0,
+		BlockCbor: testBlockCbor,
+		Tip:       testTip,
+	}
+	result, err := entry.ToEntry()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ProtocolId != chainsync.ProtocolIdNtN {
+		t.Errorf(
+			"expected protocol ID %d, got %d",
+			chainsync.ProtocolIdNtN,
+			result.ProtocolId,
+		)
+	}
+
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryRollBackward tests the RollBackward entry type
+func TestConversationEntryRollBackward(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryRollBackward{
+				Point: testPoint,
+				Tip:   testTip,
+			}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Errorf("expected IsResponse to be true, got false")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryDone tests the Done entry type
+func TestConversationEntryDone(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := cs.ConversationEntryDone{}
+			result := entry.ToEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			// Done is sent by client, not as a response
+			if result.IsResponse != false {
+				t.Errorf("expected IsResponse to be false, got true")
+			}
+
+			if result.MessageType != chainsync.MessageTypeDone {
+				t.Errorf(
+					"expected MessageType %d, got %d",
+					chainsync.MessageTypeDone,
+					result.MessageType,
+				)
+			}
+
+			if result.MsgFromCborFunc == nil {
+				t.Error("expected MsgFromCborFunc to be set")
+			}
+		})
+	}
+}
+
+// TestNewMsgFromCborFunc tests the NewMsgFromCborFunc helper
+func TestNewMsgFromCborFunc(t *testing.T) {
+	t.Run("NtC", func(t *testing.T) {
+		fn := cs.NewMsgFromCborFunc(true)
+		if fn == nil {
+			t.Error("expected non-nil function for NtC")
+		}
+	})
+
+	t.Run("NtN", func(t *testing.T) {
+		fn := cs.NewMsgFromCborFunc(false)
+		if fn == nil {
+			t.Error("expected non-nil function for NtN")
+		}
+	})
+}
+
+// TestNewFindIntersectEntry tests the NewFindIntersectEntry helper function
+func TestNewFindIntersectEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		points   []pcommon.Point
+		expected uint16
+	}{
+		{
+			name:     "NtC with nil points",
+			isNtC:    true,
+			points:   nil,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN with nil points",
+			isNtC:    false,
+			points:   nil,
+			expected: chainsync.ProtocolIdNtN,
+		},
+		{
+			name:     "NtC with points",
+			isNtC:    true,
+			points:   []pcommon.Point{testPoint},
+			expected: chainsync.ProtocolIdNtC,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewFindIntersectEntry(tc.isNtC, tc.points)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != false {
+				t.Error("expected IsResponse to be false")
+			}
+
+			if result.MessageType != chainsync.MessageTypeFindIntersect {
+				t.Errorf(
+					"expected message type %d, got %d",
+					chainsync.MessageTypeFindIntersect,
+					result.MessageType,
+				)
+			}
+		})
+	}
+}
+
+// TestNewIntersectFoundEntry tests the NewIntersectFoundEntry helper function
+func TestNewIntersectFoundEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewIntersectFoundEntry(tc.isNtC, testPoint, testTip)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Error("expected IsResponse to be true")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestNewIntersectNotFoundEntry tests the NewIntersectNotFoundEntry helper function
+func TestNewIntersectNotFoundEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewIntersectNotFoundEntry(tc.isNtC, testTip)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Error("expected IsResponse to be true")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestNewRequestNextEntry tests the NewRequestNextEntry helper function
+func TestNewRequestNextEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewRequestNextEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != false {
+				t.Error("expected IsResponse to be false")
+			}
+
+			if result.MessageType != chainsync.MessageTypeRequestNext {
+				t.Errorf(
+					"expected message type %d, got %d",
+					chainsync.MessageTypeRequestNext,
+					result.MessageType,
+				)
+			}
+		})
+	}
+}
+
+// TestNewAwaitReplyEntry tests the NewAwaitReplyEntry helper function
+func TestNewAwaitReplyEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewAwaitReplyEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Error("expected IsResponse to be true")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestNewRollForwardEntry tests the NewRollForwardEntry helper function
+func TestNewRollForwardEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := cs.NewRollForwardEntry(
+				tc.isNtC,
+				0,
+				testBlockCbor,
+				testTip,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Error("expected IsResponse to be true")
+			}
+		})
+	}
+}
+
+// TestNewRollBackwardEntry tests the NewRollBackwardEntry helper function
+func TestNewRollBackwardEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewRollBackwardEntry(tc.isNtC, testPoint, testTip)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != true {
+				t.Error("expected IsResponse to be true")
+			}
+
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestNewDoneEntry tests the NewDoneEntry helper function
+func TestNewDoneEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isNtC    bool
+		expected uint16
+	}{
+		{
+			name:     "NtC",
+			isNtC:    true,
+			expected: chainsync.ProtocolIdNtC,
+		},
+		{
+			name:     "NtN",
+			isNtC:    false,
+			expected: chainsync.ProtocolIdNtN,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := cs.NewDoneEntry(tc.isNtC)
+
+			if result.ProtocolId != tc.expected {
+				t.Errorf(
+					"expected protocol ID %d, got %d",
+					tc.expected,
+					result.ProtocolId,
+				)
+			}
+
+			if result.IsResponse != false {
+				t.Error("expected IsResponse to be false")
+			}
+
+			if result.MessageType != chainsync.MessageTypeDone {
+				t.Errorf(
+					"expected MessageType %d, got %d",
+					chainsync.MessageTypeDone,
+					result.MessageType,
+				)
+			}
+
+			if result.MsgFromCborFunc == nil {
+				t.Error("expected MsgFromCborFunc to be set")
+			}
+		})
+	}
+}
+
+// TestFixtures tests that the pre-defined conversation fixtures are valid slices
+func TestFixtures(t *testing.T) {
+	t.Run("MockOriginPoint", func(t *testing.T) {
+		if cs.MockOriginPoint.Slot != 0 {
+			t.Errorf(
+				"expected origin point slot 0, got %d",
+				cs.MockOriginPoint.Slot,
+			)
+		}
+	})
+
+	t.Run("MockBlockHash", func(t *testing.T) {
+		if len(cs.MockBlockHash) != 32 {
+			t.Errorf(
+				"expected block hash length 32, got %d",
+				len(cs.MockBlockHash),
+			)
+		}
+	})
+
+	t.Run("MockBlockHash2", func(t *testing.T) {
+		if len(cs.MockBlockHash2) != 32 {
+			t.Errorf(
+				"expected block hash length 32, got %d",
+				len(cs.MockBlockHash2),
+			)
+		}
+	})
+
+	t.Run("MockBlockHash3", func(t *testing.T) {
+		if len(cs.MockBlockHash3) != 32 {
+			t.Errorf(
+				"expected block hash length 32, got %d",
+				len(cs.MockBlockHash3),
+			)
+		}
+	})
+
+	t.Run("MockTip", func(t *testing.T) {
+		if cs.MockTip.BlockNumber != 100 {
+			t.Errorf(
+				"expected block number 100, got %d",
+				cs.MockTip.BlockNumber,
+			)
+		}
+		if cs.MockTip.Point.Slot != 1000 {
+			t.Errorf("expected slot 1000, got %d", cs.MockTip.Point.Slot)
+		}
+	})
+
+	t.Run("MockTip2", func(t *testing.T) {
+		if cs.MockTip2.BlockNumber != 50 {
+			t.Errorf(
+				"expected block number 50, got %d",
+				cs.MockTip2.BlockNumber,
+			)
+		}
+		if cs.MockTip2.Point.Slot != 500 {
+			t.Errorf("expected slot 500, got %d", cs.MockTip2.Point.Slot)
+		}
+	})
+
+	t.Run("MockPoint1", func(t *testing.T) {
+		if cs.MockPoint1.Slot != 100 {
+			t.Errorf("expected slot 100, got %d", cs.MockPoint1.Slot)
+		}
+	})
+
+	t.Run("MockPoint2", func(t *testing.T) {
+		if cs.MockPoint2.Slot != 200 {
+			t.Errorf("expected slot 200, got %d", cs.MockPoint2.Slot)
+		}
+	})
+
+	t.Run("MockPoint3", func(t *testing.T) {
+		if cs.MockPoint3.Slot != 300 {
+			t.Errorf("expected slot 300, got %d", cs.MockPoint3.Slot)
+		}
+	})
+
+	t.Run("MockBlockCbor", func(t *testing.T) {
+		if len(cs.MockBlockCbor) == 0 {
+			t.Error("expected non-empty block CBOR")
+		}
+	})
+}
+
+// TestConversationChainSyncFromOrigin tests that the fixture is a valid slice
+func TestConversationChainSyncFromOrigin(t *testing.T) {
+	if cs.ConversationChainSyncFromOrigin == nil {
+		t.Fatal("ConversationChainSyncFromOrigin should not be nil")
+	}
+
+	if len(cs.ConversationChainSyncFromOrigin) == 0 {
+		t.Error("ConversationChainSyncFromOrigin should not be empty")
+	}
+
+	// Expected structure:
+	// - Handshake request
+	// - Handshake response
+	// - FindIntersect
+	// - IntersectFound
+	// - RequestNext
+	// - RollForward
+	// - RequestNext
+	// - AwaitReply
+	expectedLen := 8
+	if len(cs.ConversationChainSyncFromOrigin) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(cs.ConversationChainSyncFromOrigin),
+		)
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range cs.ConversationChainSyncFromOrigin {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationChainSyncRollback tests that the rollback fixture is valid
+func TestConversationChainSyncRollback(t *testing.T) {
+	if cs.ConversationChainSyncRollback == nil {
+		t.Fatal("ConversationChainSyncRollback should not be nil")
+	}
+
+	if len(cs.ConversationChainSyncRollback) == 0 {
+		t.Error("ConversationChainSyncRollback should not be empty")
+	}
+
+	// Expected structure:
+	// - Handshake request
+	// - Handshake response
+	// - FindIntersect
+	// - IntersectFound
+	// - RequestNext
+	// - RollForward (block 1)
+	// - RequestNext
+	// - RollForward (block 2)
+	// - RequestNext
+	// - RollBackward
+	// - RequestNext
+	// - RollForward (new chain)
+	expectedLen := 12
+	if len(cs.ConversationChainSyncRollback) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(cs.ConversationChainSyncRollback),
+		)
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range cs.ConversationChainSyncRollback {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationChainSyncIntersectNotFound tests that the intersect not found fixture is valid
+func TestConversationChainSyncIntersectNotFound(t *testing.T) {
+	if cs.ConversationChainSyncIntersectNotFound == nil {
+		t.Fatal("ConversationChainSyncIntersectNotFound should not be nil")
+	}
+
+	if len(cs.ConversationChainSyncIntersectNotFound) == 0 {
+		t.Error("ConversationChainSyncIntersectNotFound should not be empty")
+	}
+
+	// Expected structure:
+	// - Handshake request
+	// - Handshake response
+	// - FindIntersect
+	// - IntersectNotFound
+	expectedLen := 4
+	if len(cs.ConversationChainSyncIntersectNotFound) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(cs.ConversationChainSyncIntersectNotFound),
+		)
+	}
+
+	// Verify each entry is not nil
+	for i, entry := range cs.ConversationChainSyncIntersectNotFound {
+		if entry == nil {
+			t.Errorf("entry at index %d should not be nil", i)
+		}
+	}
+}
+
+// TestProtocolIDConsistency tests that NtC and NtN protocol IDs are different
+func TestProtocolIDConsistency(t *testing.T) {
+	if chainsync.ProtocolIdNtC == chainsync.ProtocolIdNtN {
+		t.Error("NtC and NtN protocol IDs should be different")
+	}
+}
+
+// TestEntryFieldsDirectAccess tests direct field access on entry types
+func TestEntryFieldsDirectAccess(t *testing.T) {
+	t.Run("ConversationEntryFindIntersect", func(t *testing.T) {
+		points := []pcommon.Point{testPoint}
+		entry := cs.ConversationEntryFindIntersect{Points: points}
+		if len(entry.Points) != 1 {
+			t.Errorf("expected 1 point, got %d", len(entry.Points))
+		}
+		if entry.Points[0].Slot != testPoint.Slot {
+			t.Errorf(
+				"expected slot %d, got %d",
+				testPoint.Slot,
+				entry.Points[0].Slot,
+			)
+		}
+	})
+
+	t.Run("ConversationEntryIntersectFound", func(t *testing.T) {
+		entry := cs.ConversationEntryIntersectFound{
+			Point: testPoint,
+			Tip:   testTip,
+		}
+		if entry.Point.Slot != testPoint.Slot {
+			t.Errorf(
+				"expected slot %d, got %d",
+				testPoint.Slot,
+				entry.Point.Slot,
+			)
+		}
+		if entry.Tip.BlockNumber != testTip.BlockNumber {
+			t.Errorf(
+				"expected block number %d, got %d",
+				testTip.BlockNumber,
+				entry.Tip.BlockNumber,
+			)
+		}
+	})
+
+	t.Run("ConversationEntryIntersectNotFound", func(t *testing.T) {
+		entry := cs.ConversationEntryIntersectNotFound{Tip: testTip}
+		if entry.Tip.BlockNumber != testTip.BlockNumber {
+			t.Errorf(
+				"expected block number %d, got %d",
+				testTip.BlockNumber,
+				entry.Tip.BlockNumber,
+			)
+		}
+	})
+
+	t.Run("ConversationEntryRollForward", func(t *testing.T) {
+		entry := cs.ConversationEntryRollForward{
+			BlockType: 1,
+			BlockCbor: testBlockCbor,
+			Tip:       testTip,
+		}
+		if entry.BlockType != 1 {
+			t.Errorf("expected block type 1, got %d", entry.BlockType)
+		}
+		if len(entry.BlockCbor) != len(testBlockCbor) {
+			t.Errorf(
+				"expected block cbor length %d, got %d",
+				len(testBlockCbor),
+				len(entry.BlockCbor),
+			)
+		}
+		if entry.Tip.BlockNumber != testTip.BlockNumber {
+			t.Errorf(
+				"expected block number %d, got %d",
+				testTip.BlockNumber,
+				entry.Tip.BlockNumber,
+			)
+		}
+	})
+
+	t.Run("ConversationEntryRollForwardNtN", func(t *testing.T) {
+		entry := cs.ConversationEntryRollForwardNtN{
+			Era:       0, // Byron
+			ByronType: 1, // Main block
+			BlockCbor: testBlockCbor,
+			Tip:       testTip,
+		}
+		if entry.Era != 0 {
+			t.Errorf("expected era 0, got %d", entry.Era)
+		}
+		if entry.ByronType != 1 {
+			t.Errorf("expected byron type 1, got %d", entry.ByronType)
+		}
+	})
+
+	t.Run("ConversationEntryRollBackward", func(t *testing.T) {
+		entry := cs.ConversationEntryRollBackward{
+			Point: testPoint,
+			Tip:   testTip,
+		}
+		if entry.Point.Slot != testPoint.Slot {
+			t.Errorf(
+				"expected slot %d, got %d",
+				testPoint.Slot,
+				entry.Point.Slot,
+			)
+		}
+		if entry.Tip.BlockNumber != testTip.BlockNumber {
+			t.Errorf(
+				"expected block number %d, got %d",
+				testTip.BlockNumber,
+				entry.Tip.BlockNumber,
+			)
+		}
+	})
+}
+
+// TestEmptyEntryTypes tests that empty struct entry types can be created
+func TestEmptyEntryTypes(t *testing.T) {
+	t.Run("ConversationEntryRequestNext", func(t *testing.T) {
+		entry := cs.ConversationEntryRequestNext{}
+		// Verify it can be converted to an entry
+		result := entry.ToEntry(true)
+		if result.ProtocolId == 0 {
+			t.Error("expected non-zero protocol ID")
+		}
+	})
+
+	t.Run("ConversationEntryAwaitReply", func(t *testing.T) {
+		entry := cs.ConversationEntryAwaitReply{}
+		result := entry.ToEntry(true)
+		if result.ProtocolId == 0 {
+			t.Error("expected non-zero protocol ID")
+		}
+	})
+
+	t.Run("ConversationEntryDone", func(t *testing.T) {
+		entry := cs.ConversationEntryDone{}
+		result := entry.ToEntry(true)
+		if result.ProtocolId == 0 {
+			t.Error("expected non-zero protocol ID")
+		}
+	})
+}

--- a/chainsync/fixtures.go
+++ b/chainsync/fixtures.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for ChainSync testing
+
+// MockOriginPoint represents the origin point (slot 0, empty hash)
+var MockOriginPoint = pcommon.NewPointOrigin()
+
+// MockBlockHash is a sample block hash for testing
+var MockBlockHash = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// MockBlockHash2 is a second sample block hash for testing rollback scenarios
+var MockBlockHash2 = []byte{
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+	0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+	0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+	0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
+}
+
+// MockBlockHash3 is a third sample block hash for testing new chain after
+// rollback
+var MockBlockHash3 = []byte{
+	0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+	0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+	0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+	0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
+}
+
+// MockTip is a sample chain tip for testing
+var MockTip = pcommon.Tip{
+	Point:       pcommon.NewPoint(1000, MockBlockHash),
+	BlockNumber: 100,
+}
+
+// MockTip2 is a sample chain tip after rollback for testing
+var MockTip2 = pcommon.Tip{
+	Point:       pcommon.NewPoint(500, MockBlockHash2),
+	BlockNumber: 50,
+}
+
+// MockPoint1 represents a point on the chain for testing
+var MockPoint1 = pcommon.NewPoint(100, MockBlockHash)
+
+// MockPoint2 represents a second point on the chain for testing
+var MockPoint2 = pcommon.NewPoint(200, MockBlockHash2)
+
+// MockPoint3 represents a third point on the chain for testing
+var MockPoint3 = pcommon.NewPoint(300, MockBlockHash3)
+
+// MockBlockCbor is sample block CBOR data for testing
+var MockBlockCbor = []byte{
+	0x82, 0x00, 0xa0, // Minimal CBOR array with header
+}
+
+// Pre-defined conversations for common ChainSync scenarios
+
+// ConversationChainSyncFromOrigin is a pre-defined conversation for basic
+// sync from origin:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - FindIntersect request
+// - IntersectFound at origin
+// - RequestNext
+// - RollForward with a mock block
+// - RequestNext
+// - AwaitReply (at tip)
+var ConversationChainSyncFromOrigin = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// FindIntersect at origin
+	NewFindIntersectEntry(true, nil),
+	NewIntersectFoundEntry(true, MockOriginPoint, MockTip),
+	// First RequestNext - returns a block
+	NewRequestNextEntry(true),
+	MustRollForwardEntry(true, 0, MockBlockCbor, MockTip),
+	// Second RequestNext - at tip, await reply
+	NewRequestNextEntry(true),
+	NewAwaitReplyEntry(true),
+}
+
+// ConversationChainSyncRollback is a pre-defined conversation for sync with
+// rollback scenario:
+// - Handshake
+// - FindIntersect
+// - IntersectFound
+// - RollForward (a few blocks)
+// - RollBackward
+// - RollForward (new chain)
+var ConversationChainSyncRollback = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// FindIntersect
+	NewFindIntersectEntry(true, nil),
+	NewIntersectFoundEntry(true, MockPoint1, MockTip),
+	// First RequestNext - RollForward block 1
+	NewRequestNextEntry(true),
+	MustRollForwardEntry(true, 0, MockBlockCbor, MockTip),
+	// Second RequestNext - RollForward block 2
+	NewRequestNextEntry(true),
+	MustRollForwardEntry(true, 0, MockBlockCbor, MockTip),
+	// Third RequestNext - RollBackward (chain reorganization)
+	NewRequestNextEntry(true),
+	NewRollBackwardEntry(true, MockPoint1, MockTip2),
+	// Fourth RequestNext - RollForward on new chain
+	NewRequestNextEntry(true),
+	MustRollForwardEntry(true, 0, MockBlockCbor, MockTip2),
+}
+
+// ConversationChainSyncIntersectNotFound is a pre-defined conversation for
+// when intersection point is not found:
+// - Handshake
+// - FindIntersect
+// - IntersectNotFound
+var ConversationChainSyncIntersectNotFound = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// FindIntersect
+	NewFindIntersectEntry(true, nil),
+	// IntersectNotFound
+	NewIntersectNotFoundEntry(true, MockTip),
+}

--- a/fixtures/blocks.go
+++ b/fixtures/blocks.go
@@ -1,0 +1,389 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/ouroboros-mock/blocks"
+)
+
+// Pre-defined hashes for testing (32 bytes each)
+var (
+	// GenesisHash is the zero hash used as the genesis block's previous hash
+	GenesisHash = make([]byte, 32)
+
+	// TestHash1 through TestHash5 are pre-computed test hashes
+	TestHash1 = hashFromString("test-block-hash-1")
+	TestHash2 = hashFromString("test-block-hash-2")
+	TestHash3 = hashFromString("test-block-hash-3")
+	TestHash4 = hashFromString("test-block-hash-4")
+	TestHash5 = hashFromString("test-block-hash-5")
+)
+
+// hashFromString creates a deterministic 32-byte hash from a string
+func hashFromString(s string) []byte {
+	hash := sha256.Sum256([]byte(s))
+	return hash[:]
+}
+
+// hashFromSlotAndBlock creates a deterministic hash from slot and block number
+func hashFromSlotAndBlock(slot, blockNum uint64) []byte {
+	data := make([]byte, 16)
+	for i := range 8 {
+		// #nosec G115 - i is in range [0,7], so 56-i*8 is in range [0,56]
+		data[i] = byte(slot >> uint(56-i*8))
+		// #nosec G115 - i is in range [0,7], so 56-i*8 is in range [0,56]
+		data[i+8] = byte(blockNum >> uint(56-i*8))
+	}
+	hash := sha256.Sum256(data)
+	return hash[:]
+}
+
+// NewMockByronBlock creates a simple Byron era block for testing
+func NewMockByronBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewByronBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockByronEBB creates a Byron Epoch Boundary Block for testing
+func NewMockByronEBB(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewByronEBBBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockShelleyBlock creates a simple Shelley era block for testing
+func NewMockShelleyBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewShelleyBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockAllegraBlock creates a simple Allegra era block for testing
+func NewMockAllegraBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewAllegraBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockMaryBlock creates a simple Mary era block for testing
+func NewMockMaryBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewMaryBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockAlonzoBlock creates a simple Alonzo era block for testing
+func NewMockAlonzoBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewAlonzoBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockBabbageBlock creates a simple Babbage era block for testing
+func NewMockBabbageBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewBabbageBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockConwayBlock creates a simple Conway era block for testing
+func NewMockConwayBlock(slot, blockNum uint64) (ledger.Block, error) {
+	hash := hashFromSlotAndBlock(slot, blockNum)
+	return blocks.NewConwayBlockBuilder().
+		WithSlot(slot).
+		WithBlockNumber(blockNum).
+		WithHash(hash).
+		WithPrevHash(GenesisHash).
+		Build()
+}
+
+// NewMockConwayChain creates a linked chain of Conway blocks for testing
+func NewMockConwayChain(
+	startSlot, startBlockNum uint64,
+	count int,
+) ([]ledger.Block, error) {
+	return blocks.NewConwayChainBuilder().
+		WithGenesisHash(GenesisHash).
+		WithStartBlockNumber(startBlockNum).
+		WithStartSlot(startSlot).
+		AddBlocks(count).
+		Build()
+}
+
+// ForkScenario represents a chain fork scenario for testing rollback handling
+type ForkScenario struct {
+	// MainChain is the original chain before the fork
+	MainChain []ledger.Block
+	// ForkPoint is the block number where the fork diverges
+	ForkPoint uint64
+	// ForkChain is the alternative chain that replaces part of MainChain
+	ForkChain []ledger.Block
+}
+
+// NewMockForkScenario creates a fork scenario for testing rollback behavior.
+// mainLength is the number of blocks in the main chain (must be > 0).
+// forkPoint is the block number where the fork occurs.
+// forkLength is the number of blocks in the forked chain after the fork point.
+func NewMockForkScenario(
+	mainLength, forkPoint, forkLength int,
+) (*ForkScenario, error) {
+	if mainLength <= 0 {
+		return nil, errors.New("mainLength must be positive")
+	}
+	if forkPoint < 0 || forkPoint >= mainLength {
+		forkPoint = mainLength / 2
+	}
+
+	// Build main chain
+	mainChain, err := blocks.NewConwayChainBuilder().
+		WithGenesisHash(GenesisHash).
+		WithStartBlockNumber(0).
+		WithStartSlot(0).
+		AddBlocks(mainLength).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the common ancestor's hash (block at forkPoint - 1)
+	var forkPrevHash []byte
+	if forkPoint == 0 {
+		forkPrevHash = GenesisHash
+	} else {
+		forkPrevHash = mainChain[forkPoint-1].Hash().Bytes()
+	}
+
+	// Build fork chain starting from the fork point
+	// Use different hashes to create an alternative chain
+	forkChain := make([]ledger.Block, 0, forkLength)
+	prevHash := forkPrevHash
+	// #nosec G115 - forkPoint is validated above
+	forkSlot := uint64(forkPoint)
+
+	for i := range forkLength {
+		// Create a different hash for the fork by adding a suffix
+		// #nosec G115 - i is bounded by forkLength which fits in int
+		slot := forkSlot + uint64(i)
+		// #nosec G115 - forkPoint and i are bounded by slice lengths
+		blockNum := uint64(forkPoint + i)
+		hash := hashFromString(fmt.Sprintf("fork-%d", i))
+
+		block, buildErr := blocks.NewConwayBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(hash).
+			WithPrevHash(prevHash).
+			Build()
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		forkChain = append(forkChain, block)
+		prevHash = hash
+	}
+
+	return &ForkScenario{
+		MainChain: mainChain,
+		// #nosec G115 - forkPoint is validated above
+		ForkPoint: uint64(forkPoint),
+		ForkChain: forkChain,
+	}, nil
+}
+
+// EraTransitionScenario represents an era transition for testing
+type EraTransitionScenario struct {
+	// PreTransitionBlocks are blocks before the era transition
+	PreTransitionBlocks []ledger.Block
+	// PostTransitionBlocks are blocks after the era transition
+	PostTransitionBlocks []ledger.Block
+	// TransitionSlot is the slot where the era changes
+	TransitionSlot uint64
+}
+
+// NewMockByronToShelleyTransition creates a Byron to Shelley era transition.
+// Both byronBlocks and shelleyBlocks must be positive.
+func NewMockByronToShelleyTransition(
+	byronBlocks, shelleyBlocks int,
+) (*EraTransitionScenario, error) {
+	if byronBlocks <= 0 {
+		return nil, errors.New("byronBlocks must be positive")
+	}
+	if shelleyBlocks <= 0 {
+		return nil, errors.New("shelleyBlocks must be positive")
+	}
+
+	// Build Byron chain
+	preBlocks := make([]ledger.Block, 0, byronBlocks)
+	prevHash := GenesisHash
+
+	for i := range byronBlocks {
+		// #nosec G115 - i is bounded by byronBlocks
+		slot := uint64(i) * 20 // Byron uses 20 second slots
+		// #nosec G115 - i is bounded by byronBlocks
+		blockNum := uint64(i)
+		hash := hashFromSlotAndBlock(slot, blockNum)
+
+		block, err := blocks.NewByronBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(hash).
+			WithPrevHash(prevHash).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+
+		preBlocks = append(preBlocks, block)
+		prevHash = hash
+	}
+
+	// Calculate transition slot
+	// #nosec G115 - byronBlocks is a positive int
+	transitionSlot := uint64(byronBlocks) * 20
+
+	// Build Shelley chain continuing from Byron
+	postBlocks := make([]ledger.Block, 0, shelleyBlocks)
+	for i := range shelleyBlocks {
+		// #nosec G115 - i is bounded by shelleyBlocks
+		slot := transitionSlot + uint64(i) // Shelley uses 1 second slots
+		// #nosec G115 - both values fit in uint64
+		blockNum := uint64(byronBlocks + i)
+		hash := hashFromSlotAndBlock(slot, blockNum)
+
+		block, err := blocks.NewShelleyBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(hash).
+			WithPrevHash(prevHash).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+
+		postBlocks = append(postBlocks, block)
+		prevHash = hash
+	}
+
+	return &EraTransitionScenario{
+		PreTransitionBlocks:  preBlocks,
+		PostTransitionBlocks: postBlocks,
+		TransitionSlot:       transitionSlot,
+	}, nil
+}
+
+// NewMockBabbageToConwayTransition creates a Babbage to Conway era transition.
+// Both babbageBlocks and conwayBlocks must be positive.
+func NewMockBabbageToConwayTransition(
+	babbageBlocks, conwayBlocks int,
+) (*EraTransitionScenario, error) {
+	if babbageBlocks <= 0 {
+		return nil, errors.New("babbageBlocks must be positive")
+	}
+	if conwayBlocks <= 0 {
+		return nil, errors.New("conwayBlocks must be positive")
+	}
+
+	// Build Babbage chain
+	preBlocks := make([]ledger.Block, 0, babbageBlocks)
+	prevHash := GenesisHash
+
+	for i := range babbageBlocks {
+		// #nosec G115 - i is bounded by babbageBlocks
+		slot := uint64(i)
+		// #nosec G115 - i is bounded by babbageBlocks
+		blockNum := uint64(i)
+		hash := hashFromSlotAndBlock(slot, blockNum)
+
+		block, err := blocks.NewBabbageBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(hash).
+			WithPrevHash(prevHash).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+
+		preBlocks = append(preBlocks, block)
+		prevHash = hash
+	}
+
+	// Calculate transition slot
+	// #nosec G115 - babbageBlocks is a positive int
+	transitionSlot := uint64(babbageBlocks)
+
+	// Build Conway chain continuing from Babbage
+	postBlocks := make([]ledger.Block, 0, conwayBlocks)
+	for i := range conwayBlocks {
+		// #nosec G115 - i is bounded by conwayBlocks
+		slot := transitionSlot + uint64(i)
+		// #nosec G115 - both values fit in uint64
+		blockNum := uint64(babbageBlocks + i)
+		hash := hashFromSlotAndBlock(slot, blockNum)
+
+		block, err := blocks.NewConwayBlockBuilder().
+			WithSlot(slot).
+			WithBlockNumber(blockNum).
+			WithHash(hash).
+			WithPrevHash(prevHash).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+
+		postBlocks = append(postBlocks, block)
+		prevHash = hash
+	}
+
+	return &EraTransitionScenario{
+		PreTransitionBlocks:  preBlocks,
+		PostTransitionBlocks: postBlocks,
+		TransitionSlot:       transitionSlot,
+	}, nil
+}

--- a/fixtures/blocks_test.go
+++ b/fixtures/blocks_test.go
@@ -1,0 +1,420 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func TestHashFromString(t *testing.T) {
+	hash1 := hashFromString("test")
+	hash2 := hashFromString("test")
+	hash3 := hashFromString("different")
+
+	if len(hash1) != 32 {
+		t.Errorf("expected hash length 32, got %d", len(hash1))
+	}
+
+	// Same input should produce same hash
+	if !bytes.Equal(hash1, hash2) {
+		t.Error("same input should produce same hash")
+	}
+
+	// Different input should produce different hash
+	if bytes.Equal(hash1, hash3) {
+		t.Error("different input should produce different hash")
+	}
+}
+
+func TestHashFromSlotAndBlock(t *testing.T) {
+	hash1 := hashFromSlotAndBlock(100, 50)
+	hash2 := hashFromSlotAndBlock(100, 50)
+	hash3 := hashFromSlotAndBlock(101, 50)
+
+	if len(hash1) != 32 {
+		t.Errorf("expected hash length 32, got %d", len(hash1))
+	}
+
+	// Same input should produce same hash
+	if !bytes.Equal(hash1, hash2) {
+		t.Error("same input should produce same hash")
+	}
+
+	// Different input should produce different hash
+	if bytes.Equal(hash1, hash3) {
+		t.Error("different input should produce different hash")
+	}
+}
+
+func TestPreDefinedHashes(t *testing.T) {
+	if len(GenesisHash) != 32 {
+		t.Errorf("GenesisHash should be 32 bytes, got %d", len(GenesisHash))
+	}
+
+	// Genesis hash should be all zeros
+	for i, b := range GenesisHash {
+		if b != 0 {
+			t.Errorf("GenesisHash[%d] should be 0, got %d", i, b)
+		}
+	}
+
+	hashes := [][]byte{TestHash1, TestHash2, TestHash3, TestHash4, TestHash5}
+	for i, h := range hashes {
+		if len(h) != 32 {
+			t.Errorf("TestHash%d should be 32 bytes, got %d", i+1, len(h))
+		}
+	}
+
+	// All test hashes should be different
+	for i := range len(hashes) - 1 {
+		for j := i + 1; j < len(hashes); j++ {
+			if bytes.Equal(hashes[i], hashes[j]) {
+				t.Errorf(
+					"TestHash%d and TestHash%d should be different",
+					i+1,
+					j+1,
+				)
+			}
+		}
+	}
+}
+
+func TestNewMockByronBlock(t *testing.T) {
+	block, err := NewMockByronBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.SlotNumber() != 100 {
+		t.Errorf("expected slot 100, got %d", block.SlotNumber())
+	}
+	if block.BlockNumber() != 50 {
+		t.Errorf("expected block number 50, got %d", block.BlockNumber())
+	}
+	if block.Era().Id != byron.EraIdByron {
+		t.Errorf("expected Byron era, got %v", block.Era())
+	}
+}
+
+func TestNewMockByronEBB(t *testing.T) {
+	block, err := NewMockByronEBB(0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.Era().Id != byron.EraIdByron {
+		t.Errorf("expected Byron era, got %v", block.Era())
+	}
+}
+
+func TestNewMockShelleyBlock(t *testing.T) {
+	block, err := NewMockShelleyBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.SlotNumber() != 100 {
+		t.Errorf("expected slot 100, got %d", block.SlotNumber())
+	}
+	if block.BlockNumber() != 50 {
+		t.Errorf("expected block number 50, got %d", block.BlockNumber())
+	}
+	if block.Era().Id != shelley.EraIdShelley {
+		t.Errorf("expected Shelley era, got %v", block.Era())
+	}
+}
+
+func TestNewMockAllegraBlock(t *testing.T) {
+	block, err := NewMockAllegraBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.Era().Id != allegra.EraIdAllegra {
+		t.Errorf("expected Allegra era, got %v", block.Era())
+	}
+}
+
+func TestNewMockMaryBlock(t *testing.T) {
+	block, err := NewMockMaryBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.Era().Id != mary.EraIdMary {
+		t.Errorf("expected Mary era, got %v", block.Era())
+	}
+}
+
+func TestNewMockAlonzoBlock(t *testing.T) {
+	block, err := NewMockAlonzoBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.Era().Id != alonzo.EraIdAlonzo {
+		t.Errorf("expected Alonzo era, got %v", block.Era())
+	}
+}
+
+func TestNewMockBabbageBlock(t *testing.T) {
+	block, err := NewMockBabbageBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.Era().Id != babbage.EraIdBabbage {
+		t.Errorf("expected Babbage era, got %v", block.Era())
+	}
+}
+
+func TestNewMockConwayBlock(t *testing.T) {
+	block, err := NewMockConwayBlock(100, 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if block.SlotNumber() != 100 {
+		t.Errorf("expected slot 100, got %d", block.SlotNumber())
+	}
+	if block.BlockNumber() != 50 {
+		t.Errorf("expected block number 50, got %d", block.BlockNumber())
+	}
+	if block.Era().Id != conway.EraIdConway {
+		t.Errorf("expected Conway era, got %v", block.Era())
+	}
+}
+
+func TestNewMockConwayChain(t *testing.T) {
+	chain, err := NewMockConwayChain(100, 50, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(chain) != 5 {
+		t.Fatalf("expected 5 blocks, got %d", len(chain))
+	}
+
+	// Verify chain properties
+	for i, block := range chain {
+		expectedSlot := uint64(100 + i)
+		expectedBlockNum := uint64(50 + i)
+
+		if block.SlotNumber() != expectedSlot {
+			t.Errorf(
+				"block %d: expected slot %d, got %d",
+				i,
+				expectedSlot,
+				block.SlotNumber(),
+			)
+		}
+		if block.BlockNumber() != expectedBlockNum {
+			t.Errorf(
+				"block %d: expected block number %d, got %d",
+				i,
+				expectedBlockNum,
+				block.BlockNumber(),
+			)
+		}
+	}
+
+	// Verify blocks are linked
+	for i := 1; i < len(chain); i++ {
+		prevHash := chain[i].PrevHash()
+		expectedPrev := chain[i-1].Hash()
+		if prevHash != expectedPrev {
+			t.Errorf(
+				"block %d: prevHash does not match previous block's hash",
+				i,
+			)
+		}
+	}
+}
+
+func TestNewMockForkScenario(t *testing.T) {
+	scenario, err := NewMockForkScenario(10, 5, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(scenario.MainChain) != 10 {
+		t.Errorf("expected 10 main blocks, got %d", len(scenario.MainChain))
+	}
+	if scenario.ForkPoint != 5 {
+		t.Errorf("expected fork point 5, got %d", scenario.ForkPoint)
+	}
+	if len(scenario.ForkChain) != 3 {
+		t.Errorf("expected 3 fork blocks, got %d", len(scenario.ForkChain))
+	}
+
+	// Verify fork chain starts from correct point
+	if len(scenario.ForkChain) > 0 {
+		forkStart := scenario.ForkChain[0]
+		expectedPrev := scenario.MainChain[scenario.ForkPoint-1].Hash()
+		if forkStart.PrevHash() != expectedPrev {
+			t.Error(
+				"fork chain should reference main chain block before fork point",
+			)
+		}
+	}
+
+	// Verify fork blocks are linked
+	for i := 1; i < len(scenario.ForkChain); i++ {
+		prevHash := scenario.ForkChain[i].PrevHash()
+		expectedPrev := scenario.ForkChain[i-1].Hash()
+		if prevHash != expectedPrev {
+			t.Errorf(
+				"fork block %d: prevHash does not match previous fork block's hash",
+				i,
+			)
+		}
+	}
+}
+
+func TestNewMockForkScenario_InvalidForkPoint(t *testing.T) {
+	// Fork point beyond main chain length should be adjusted
+	scenario, err := NewMockForkScenario(10, 15, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be adjusted to mainLength / 2
+	if scenario.ForkPoint != 5 {
+		t.Errorf("expected adjusted fork point 5, got %d", scenario.ForkPoint)
+	}
+}
+
+func TestNewMockByronToShelleyTransition(t *testing.T) {
+	scenario, err := NewMockByronToShelleyTransition(5, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(scenario.PreTransitionBlocks) != 5 {
+		t.Errorf(
+			"expected 5 Byron blocks, got %d",
+			len(scenario.PreTransitionBlocks),
+		)
+	}
+	if len(scenario.PostTransitionBlocks) != 3 {
+		t.Errorf(
+			"expected 3 Shelley blocks, got %d",
+			len(scenario.PostTransitionBlocks),
+		)
+	}
+
+	// Verify all pre-transition blocks are Byron
+	for i, block := range scenario.PreTransitionBlocks {
+		if block.Era().Id != byron.EraIdByron {
+			t.Errorf(
+				"pre-transition block %d should be Byron, got %v",
+				i,
+				block.Era(),
+			)
+		}
+	}
+
+	// Verify all post-transition blocks are Shelley
+	for i, block := range scenario.PostTransitionBlocks {
+		if block.Era().Id != shelley.EraIdShelley {
+			t.Errorf(
+				"post-transition block %d should be Shelley, got %v",
+				i,
+				block.Era(),
+			)
+		}
+	}
+
+	// Verify transition slot
+	expectedTransitionSlot := uint64(5 * 20) // Byron uses 20 second slots
+	if scenario.TransitionSlot != expectedTransitionSlot {
+		t.Errorf(
+			"expected transition slot %d, got %d",
+			expectedTransitionSlot,
+			scenario.TransitionSlot,
+		)
+	}
+
+	// Verify Shelley blocks continue from Byron
+	if len(scenario.PreTransitionBlocks) > 0 &&
+		len(scenario.PostTransitionBlocks) > 0 {
+		lastByron := scenario.PreTransitionBlocks[len(scenario.PreTransitionBlocks)-1]
+		firstShelley := scenario.PostTransitionBlocks[0]
+		if firstShelley.PrevHash() != lastByron.Hash() {
+			t.Error("Shelley chain should continue from last Byron block")
+		}
+	}
+}
+
+func TestNewMockBabbageToConwayTransition(t *testing.T) {
+	scenario, err := NewMockBabbageToConwayTransition(5, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(scenario.PreTransitionBlocks) != 5 {
+		t.Errorf(
+			"expected 5 Babbage blocks, got %d",
+			len(scenario.PreTransitionBlocks),
+		)
+	}
+	if len(scenario.PostTransitionBlocks) != 3 {
+		t.Errorf(
+			"expected 3 Conway blocks, got %d",
+			len(scenario.PostTransitionBlocks),
+		)
+	}
+
+	// Verify all pre-transition blocks are Babbage
+	for i, block := range scenario.PreTransitionBlocks {
+		if block.Era().Id != babbage.EraIdBabbage {
+			t.Errorf(
+				"pre-transition block %d should be Babbage, got %v",
+				i,
+				block.Era(),
+			)
+		}
+	}
+
+	// Verify all post-transition blocks are Conway
+	for i, block := range scenario.PostTransitionBlocks {
+		if block.Era().Id != conway.EraIdConway {
+			t.Errorf(
+				"post-transition block %d should be Conway, got %v",
+				i,
+				block.Era(),
+			)
+		}
+	}
+
+	// Verify Conway blocks continue from Babbage
+	if len(scenario.PreTransitionBlocks) > 0 &&
+		len(scenario.PostTransitionBlocks) > 0 {
+		lastBabbage := scenario.PreTransitionBlocks[len(scenario.PreTransitionBlocks)-1]
+		firstConway := scenario.PostTransitionBlocks[0]
+		if firstConway.PrevHash() != lastBabbage.Hash() {
+			t.Error("Conway chain should continue from last Babbage block")
+		}
+	}
+}

--- a/fixtures/genesis.go
+++ b/fixtures/genesis.go
@@ -1,0 +1,307 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"maps"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// newRat creates a new GenesisRat from a numerator and denominator
+func newRat(num, denom int64) *lcommon.GenesisRat {
+	return &lcommon.GenesisRat{Rat: big.NewRat(num, denom)}
+}
+
+// MockByronGenesisConfig provides typical mainnet values for Byron genesis configuration
+var MockByronGenesisConfig = byron.ByronGenesis{
+	// Mainnet start time: September 23, 2017 21:44:51 UTC (Unix timestamp)
+	StartTime: 1506203091,
+	ProtocolConsts: byron.ByronGenesisProtocolConsts{
+		K:             2160, // Security parameter (number of blocks)
+		ProtocolMagic: 764824073,
+	},
+	BlockVersionData: byron.ByronGenesisBlockVersionData{
+		ScriptVersion:     0,
+		SlotDuration:      20000, // 20 seconds in milliseconds
+		MaxBlockSize:      2000000,
+		MaxHeaderSize:     2000000,
+		MaxTxSize:         4096,
+		MaxProposalSize:   700,
+		MpcThd:            20000000000000,
+		HeavyDelThd:       300000000000,
+		UpdateVoteThd:     1000000000000,
+		UpdateProposalThd: 100000000000000,
+		UpdateImplicit:    10000,
+		SoftforkRule: byron.ByronGenesisBlockVersionDataSoftforkRule{
+			InitThd:      900000000000000,
+			MinThd:       600000000000000,
+			ThdDecrement: 50000000000000,
+		},
+		TxFeePolicy: byron.ByronGenesisBlockVersionDataTxFeePolicy{
+			Summand:    155381,
+			Multiplier: 44,
+		},
+		UnlockStakeEpoch: 18446744073709551615, // Max uint64 (never unlock in Byron)
+	},
+	AvvmDistr:        map[string]string{},
+	NonAvvmBalances:  map[string]string{},
+	BootStakeholders: map[string]int{},
+	HeavyDelegation:  map[string]byron.ByronGenesisHeavyDelegation{},
+	VssCerts:         map[string]byron.ByronGenesisVssCert{},
+}
+
+// MockShelleyGenesisConfig provides typical mainnet values for Shelley genesis configuration
+var MockShelleyGenesisConfig = shelley.ShelleyGenesis{
+	// SystemStart is the blockchain origin time (Byron mainnet start: September 23, 2017)
+	// Note: This is NOT when Shelley era started, but when the chain itself started
+	SystemStart:  time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC),
+	NetworkMagic: 764824073, // Mainnet magic
+	NetworkId:    "Mainnet",
+	ActiveSlotsCoeff: lcommon.GenesisRat{
+		Rat: big.NewRat(1, 20),
+	}, // 0.05 (5% active slots)
+	SecurityParam:     2160,                                      // k parameter
+	EpochLength:       432000,                                    // 5 days in slots (432000 * 1 second)
+	SlotsPerKESPeriod: 129600,                                    // ~1.5 days
+	MaxKESEvolutions:  62,                                        // ~93 days max KES validity
+	SlotLength:        lcommon.GenesisRat{Rat: big.NewRat(1, 1)}, // 1 second
+	UpdateQuorum:      5,
+	MaxLovelaceSupply: 45000000000000000, // 45 billion ADA
+	ProtocolParameters: shelley.ShelleyGenesisProtocolParams{
+		MinFeeA:            44,     // Fee coefficient A
+		MinFeeB:            155381, // Fee coefficient B
+		MaxBlockBodySize:   65536,  // 64KB
+		MaxTxSize:          16384,  // 16KB
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,         // 2 ADA
+		PoolDeposit:        500000000,       // 500 ADA
+		MaxEpoch:           18,              // Maximum epoch for pool retirement
+		NOpt:               150,             // Target number of pools
+		A0:                 newRat(3, 10),   // Pool pledge influence (0.3)
+		Rho:                newRat(3, 1000), // Monetary expansion (0.003)
+		Tau:                newRat(2, 10),   // Treasury cut (0.2)
+		Decentralization: newRat(
+			1,
+			1,
+		), // Fully federated (d=1); d=0 would be fully decentralized
+		ProtocolVersion: struct {
+			Major uint `json:"major"`
+			Minor uint `json:"minor"`
+		}{
+			Major: 2,
+			Minor: 0,
+		},
+		MinUtxoValue: 1000000,   // 1 ADA minimum UTxO
+		MinPoolCost:  340000000, // 340 ADA minimum pool cost
+	},
+	GenDelegs:    map[string]map[string]string{},
+	InitialFunds: map[string]uint64{},
+	Staking:      shelley.GenesisStaking{},
+}
+
+// MockAlonzoGenesisConfig provides typical mainnet values for Alonzo genesis configuration.
+// Alonzo introduced Plutus smart contracts and execution unit pricing.
+var MockAlonzoGenesisConfig = alonzo.AlonzoGenesis{
+	LovelacePerUtxoWord:  34482, // Cost per word of UTxO storage (~0.034 ADA)
+	MaxValueSize:         5000,  // Maximum serialized size of a Value
+	CollateralPercentage: 150,   // 150% collateral required for scripts
+	MaxCollateralInputs:  3,     // Maximum number of collateral inputs
+	ExecutionPrices: alonzo.AlonzoGenesisExecutionPrices{
+		Steps: newRat(721, 10000000), // Price per CPU step (~0.0000721 ADA)
+		Mem:   newRat(577, 10000),    // Price per memory unit (~0.0577 ADA)
+	},
+	MaxTxExUnits: alonzo.AlonzoGenesisExUnits{
+		Mem:   10000000,    // 10M memory units per transaction
+		Steps: 10000000000, // 10B CPU steps per transaction
+	},
+	MaxBlockExUnits: alonzo.AlonzoGenesisExUnits{
+		Mem:   50000000,    // 50M memory units per block
+		Steps: 40000000000, // 40B CPU steps per block
+	},
+	CostModels: map[string]alonzo.CostModel{
+		// PlutusV1 cost model with mainnet values (abbreviated - real model has 166 parameters)
+		"PlutusV1": {
+			"addInteger-cpu-arguments-intercept":          205665,
+			"addInteger-cpu-arguments-slope":              812,
+			"addInteger-memory-arguments-intercept":       1,
+			"addInteger-memory-arguments-slope":           1,
+			"appendByteString-cpu-arguments-intercept":    1000,
+			"appendByteString-cpu-arguments-slope":        571,
+			"appendByteString-memory-arguments-intercept": 0,
+			"appendByteString-memory-arguments-slope":     1,
+			"appendString-cpu-arguments-intercept":        1000,
+			"appendString-cpu-arguments-slope":            24177,
+			"appendString-memory-arguments-intercept":     4,
+			"appendString-memory-arguments-slope":         1,
+			"bData-cpu-arguments":                         1000,
+			"bData-memory-arguments":                      32,
+			"blake2b_256-cpu-arguments-intercept":         117366,
+			"blake2b_256-cpu-arguments-slope":             10475,
+			"blake2b_256-memory-arguments":                4,
+			"cekApplyCost-exBudgetCPU":                    23000,
+			"cekApplyCost-exBudgetMemory":                 100,
+			"cekBuiltinCost-exBudgetCPU":                  23000,
+			"cekBuiltinCost-exBudgetMemory":               100,
+			"cekConstCost-exBudgetCPU":                    23000,
+			"cekConstCost-exBudgetMemory":                 100,
+			"cekDelayCost-exBudgetCPU":                    23000,
+			"cekDelayCost-exBudgetMemory":                 100,
+			"cekForceCost-exBudgetCPU":                    23000,
+			"cekForceCost-exBudgetMemory":                 100,
+			"cekLamCost-exBudgetCPU":                      23000,
+			"cekLamCost-exBudgetMemory":                   100,
+			"cekStartupCost-exBudgetCPU":                  100,
+			"cekStartupCost-exBudgetMemory":               100,
+			"cekVarCost-exBudgetCPU":                      23000,
+			"cekVarCost-exBudgetMemory":                   100,
+		},
+	},
+}
+
+// MockConwayGenesisConfig provides typical mainnet values for Conway genesis configuration.
+// Conway introduced on-chain governance with DReps and constitutional committee.
+var MockConwayGenesisConfig = conway.ConwayGenesis{
+	PoolVotingThresholds: conway.ConwayGenesisPoolVotingThresholds{
+		MotionNoConfidence:    newRat(51, 100), // 51%
+		CommitteeNormal:       newRat(51, 100), // 51%
+		CommitteeNoConfidence: newRat(51, 100), // 51%
+		HardForkInitiation:    newRat(51, 100), // 51%
+		PpSecurityGroup:       newRat(51, 100), // 51%
+	},
+	DRepVotingThresholds: conway.ConwayGenesisDRepVotingThresholds{
+		MotionNoConfidence:    newRat(67, 100), // 67%
+		CommitteeNormal:       newRat(67, 100), // 67%
+		CommitteeNoConfidence: newRat(60, 100), // 60%
+		UpdateToConstitution:  newRat(75, 100), // 75%
+		HardForkInitiation:    newRat(60, 100), // 60%
+		PpNetworkGroup:        newRat(67, 100), // 67%
+		PpEconomicGroup:       newRat(67, 100), // 67%
+		PpTechnicalGroup:      newRat(67, 100), // 67%
+		PpGovGroup:            newRat(75, 100), // 75%
+		TreasuryWithdrawal:    newRat(67, 100), // 67%
+	},
+	MinCommitteeSize:           7,             // Minimum constitutional committee size
+	CommitteeTermLimit:         146,           // ~2 years in epochs (73 epochs/year)
+	GovActionValidityPeriod:    6,             // 6 epochs (~30 days)
+	GovActionDeposit:           100000000000,  // 100,000 ADA
+	DRepDeposit:                500000000,     // 500 ADA
+	DRepInactivityPeriod:       20,            // 20 epochs (~100 days)
+	MinFeeRefScriptCostPerByte: newRat(15, 1), // 15 lovelace per byte
+	PlutusV3CostModel:          []int64{},     // Empty for mock, would contain cost model parameters
+	Constitution: conway.ConwayGenesisConstitution{
+		Anchor: conway.ConwayGenesisConstitutionAnchor{
+			Url:      "https://constitution.gov.cardano.org",
+			DataHash: "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	},
+	Committee: conway.ConwayGenesisCommittee{
+		Members: map[string]int{},
+		Threshold: map[string]int{
+			"numerator":   2,
+			"denominator": 3,
+		}, // 2/3 majority
+	},
+}
+
+// NewMockByronGenesis returns a copy of the mock Byron genesis configuration.
+// This can be modified without affecting the global MockByronGenesisConfig.
+func NewMockByronGenesis() byron.ByronGenesis {
+	genesis := MockByronGenesisConfig
+	// Deep copy maps
+	genesis.AvvmDistr = make(map[string]string)
+	genesis.NonAvvmBalances = make(map[string]string)
+	genesis.BootStakeholders = make(map[string]int)
+	genesis.HeavyDelegation = make(map[string]byron.ByronGenesisHeavyDelegation)
+	genesis.VssCerts = make(map[string]byron.ByronGenesisVssCert)
+	return genesis
+}
+
+// NewMockShelleyGenesis returns a copy of the mock Shelley genesis configuration.
+// This can be modified without affecting the global MockShelleyGenesisConfig.
+func NewMockShelleyGenesis() shelley.ShelleyGenesis {
+	genesis := MockShelleyGenesisConfig
+	// Deep copy maps
+	genesis.GenDelegs = make(map[string]map[string]string)
+	genesis.InitialFunds = make(map[string]uint64)
+	// Deep copy rationals (they contain pointers)
+	genesis.ActiveSlotsCoeff = lcommon.GenesisRat{Rat: big.NewRat(1, 20)}
+	genesis.SlotLength = lcommon.GenesisRat{Rat: big.NewRat(1, 1)}
+	genesis.ProtocolParameters.A0 = newRat(3, 10)
+	genesis.ProtocolParameters.Rho = newRat(3, 1000)
+	genesis.ProtocolParameters.Tau = newRat(2, 10)
+	genesis.ProtocolParameters.Decentralization = newRat(1, 1)
+	return genesis
+}
+
+// NewMockAlonzoGenesis returns a copy of the mock Alonzo genesis configuration.
+// This can be modified without affecting the global MockAlonzoGenesisConfig.
+func NewMockAlonzoGenesis() alonzo.AlonzoGenesis {
+	genesis := MockAlonzoGenesisConfig
+	// Deep copy maps
+	genesis.CostModels = make(map[string]alonzo.CostModel)
+	for k, v := range MockAlonzoGenesisConfig.CostModels {
+		costModel := make(alonzo.CostModel)
+		maps.Copy(costModel, v)
+		genesis.CostModels[k] = costModel
+	}
+	// Deep copy rationals (they contain pointers)
+	genesis.ExecutionPrices = alonzo.AlonzoGenesisExecutionPrices{
+		Steps: newRat(721, 10000000),
+		Mem:   newRat(577, 10000),
+	}
+	return genesis
+}
+
+// NewMockConwayGenesis returns a copy of the mock Conway genesis configuration.
+// This can be modified without affecting the global MockConwayGenesisConfig.
+func NewMockConwayGenesis() conway.ConwayGenesis {
+	genesis := MockConwayGenesisConfig
+	// Deep copy maps and slices
+	genesis.PlutusV3CostModel = make([]int64, 0)
+	genesis.Committee.Members = make(map[string]int)
+	genesis.Committee.Threshold = map[string]int{
+		"numerator":   2,
+		"denominator": 3,
+	}
+	// Deep copy rationals (they contain pointers)
+	genesis.PoolVotingThresholds = conway.ConwayGenesisPoolVotingThresholds{
+		MotionNoConfidence:    newRat(51, 100),
+		CommitteeNormal:       newRat(51, 100),
+		CommitteeNoConfidence: newRat(51, 100),
+		HardForkInitiation:    newRat(51, 100),
+		PpSecurityGroup:       newRat(51, 100),
+	}
+	genesis.DRepVotingThresholds = conway.ConwayGenesisDRepVotingThresholds{
+		MotionNoConfidence:    newRat(67, 100),
+		CommitteeNormal:       newRat(67, 100),
+		CommitteeNoConfidence: newRat(60, 100),
+		UpdateToConstitution:  newRat(75, 100),
+		HardForkInitiation:    newRat(60, 100),
+		PpNetworkGroup:        newRat(67, 100),
+		PpEconomicGroup:       newRat(67, 100),
+		PpTechnicalGroup:      newRat(67, 100),
+		PpGovGroup:            newRat(75, 100),
+		TreasuryWithdrawal:    newRat(67, 100),
+	}
+	genesis.MinFeeRefScriptCostPerByte = newRat(15, 1)
+	return genesis
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.24.1
 
 require (
 	github.com/blinklabs-io/gouroboros v0.147.0
+	github.com/blinklabs-io/plutigo v0.0.18
+	github.com/utxorpc/go-codegen v0.18.1
 	go.uber.org/goleak v1.3.0
 )
 
@@ -13,7 +15,6 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
-	github.com/blinklabs-io/plutigo v0.0.18 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
@@ -26,7 +27,6 @@ require (
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
-	github.com/utxorpc/go-codegen v0.18.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect

--- a/ledger/governance.go
+++ b/ledger/governance.go
@@ -1,0 +1,504 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// CommitteeMemberBuilder defines an interface for building mock committee member state
+type CommitteeMemberBuilder interface {
+	WithColdKey(key []byte) CommitteeMemberBuilder
+	WithHotKey(key []byte) CommitteeMemberBuilder
+	WithExpiryEpoch(epoch uint64) CommitteeMemberBuilder
+	WithResigned(resigned bool) CommitteeMemberBuilder
+	WithResignAnchor(url string, dataHash []byte) CommitteeMemberBuilder
+	Build() (*CommitteeMember, error)
+}
+
+// CommitteeMember represents a committee member state for mock purposes
+type CommitteeMember struct {
+	ColdCredential lcommon.Credential
+	HotCredential  lcommon.Credential
+	ExpiryEpoch    uint64
+	Resigned       bool
+	ResignAnchor   *lcommon.GovAnchor
+}
+
+// committeeMemberBuilder implements CommitteeMemberBuilder
+type committeeMemberBuilder struct {
+	coldKey           []byte
+	hotKey            []byte
+	expiryEpoch       uint64
+	resigned          bool
+	resignAnchor      *lcommon.GovAnchor
+	resignDataHashErr error // Stores dataHash validation error for deferred reporting
+}
+
+// NewCommitteeMemberBuilder creates a new CommitteeMemberBuilder
+func NewCommitteeMemberBuilder() CommitteeMemberBuilder {
+	return &committeeMemberBuilder{}
+}
+
+// WithColdKey sets the cold key credential for the committee member
+func (b *committeeMemberBuilder) WithColdKey(
+	key []byte,
+) CommitteeMemberBuilder {
+	b.coldKey = key
+	return b
+}
+
+// WithHotKey sets the hot key credential for the committee member
+func (b *committeeMemberBuilder) WithHotKey(key []byte) CommitteeMemberBuilder {
+	b.hotKey = key
+	return b
+}
+
+// WithExpiryEpoch sets the expiry epoch for the committee member
+func (b *committeeMemberBuilder) WithExpiryEpoch(
+	epoch uint64,
+) CommitteeMemberBuilder {
+	b.expiryEpoch = epoch
+	return b
+}
+
+// WithResigned sets whether the committee member has resigned
+func (b *committeeMemberBuilder) WithResigned(
+	resigned bool,
+) CommitteeMemberBuilder {
+	b.resigned = resigned
+	return b
+}
+
+// WithResignAnchor sets the resignation anchor for the committee member
+// If dataHash is provided but not exactly 32 bytes, Build() will return an error
+func (b *committeeMemberBuilder) WithResignAnchor(
+	url string,
+	dataHash []byte,
+) CommitteeMemberBuilder {
+	if url != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: url,
+		}
+		if len(dataHash) > 0 {
+			if len(dataHash) != 32 {
+				b.resignDataHashErr = fmt.Errorf(
+					"resign anchor dataHash must be exactly 32 bytes, got %d",
+					len(dataHash),
+				)
+			} else {
+				// Clear any previous error when valid hash is provided
+				b.resignDataHashErr = nil
+				copy(anchor.DataHash[:], dataHash)
+			}
+		}
+		b.resignAnchor = anchor
+	}
+	return b
+}
+
+// Build constructs a CommitteeMember from the builder state
+func (b *committeeMemberBuilder) Build() (*CommitteeMember, error) {
+	if len(b.coldKey) == 0 {
+		return nil, errors.New("cold key is required")
+	}
+	// Return any stored validation errors
+	if b.resignDataHashErr != nil {
+		return nil, b.resignDataHashErr
+	}
+
+	member := &CommitteeMember{
+		ColdCredential: lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.coldKey),
+		},
+		ExpiryEpoch:  b.expiryEpoch,
+		Resigned:     b.resigned,
+		ResignAnchor: b.resignAnchor,
+	}
+
+	if len(b.hotKey) > 0 {
+		member.HotCredential = lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.hotKey),
+		}
+	}
+
+	return member, nil
+}
+
+// DRepRegistrationBuilder defines an interface for building mock DRep registrations
+type DRepRegistrationBuilder interface {
+	WithCredential(cred []byte) DRepRegistrationBuilder
+	WithAnchor(url string, dataHash []byte) DRepRegistrationBuilder
+	WithDeposit(lovelace uint64) DRepRegistrationBuilder
+	Build() (*lcommon.RegistrationDrepCertificate, error)
+}
+
+// drepRegistrationBuilder implements DRepRegistrationBuilder
+type drepRegistrationBuilder struct {
+	credential []byte
+	anchorURL  string
+	dataHash   []byte
+	deposit    uint64
+}
+
+// NewDRepRegistrationBuilder creates a new DRepRegistrationBuilder
+func NewDRepRegistrationBuilder() DRepRegistrationBuilder {
+	return &drepRegistrationBuilder{}
+}
+
+// WithCredential sets the DRep credential
+func (b *drepRegistrationBuilder) WithCredential(
+	cred []byte,
+) DRepRegistrationBuilder {
+	b.credential = cred
+	return b
+}
+
+// WithAnchor sets the anchor URL and data hash for the DRep registration
+func (b *drepRegistrationBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) DRepRegistrationBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// WithDeposit sets the deposit amount in lovelace
+func (b *drepRegistrationBuilder) WithDeposit(
+	lovelace uint64,
+) DRepRegistrationBuilder {
+	b.deposit = lovelace
+	return b
+}
+
+// Build constructs a RegistrationDrepCertificate from the builder state
+func (b *drepRegistrationBuilder) Build() (*lcommon.RegistrationDrepCertificate, error) {
+	if len(b.credential) == 0 {
+		return nil, errors.New("credential is required")
+	}
+
+	// Validate deposit doesn't overflow int64
+	if b.deposit > uint64(math.MaxInt64) {
+		return nil, fmt.Errorf(
+			"deposit %d exceeds maximum int64 value",
+			b.deposit,
+		)
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	cert := &lcommon.RegistrationDrepCertificate{
+		CertType: uint(lcommon.CertificateTypeRegistrationDrep),
+		DrepCredential: lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.credential),
+		},
+		Amount: int64(b.deposit),
+	}
+
+	if b.anchorURL != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: b.anchorURL,
+		}
+		if len(b.dataHash) > 0 {
+			copy(anchor.DataHash[:], b.dataHash)
+		}
+		cert.Anchor = anchor
+	}
+
+	return cert, nil
+}
+
+// ConstitutionBuilder defines an interface for building mock constitutions
+type ConstitutionBuilder interface {
+	WithAnchor(url string, dataHash []byte) ConstitutionBuilder
+	WithScriptHash(hash []byte) ConstitutionBuilder
+	Build() (*Constitution, error)
+}
+
+// Constitution represents a constitution for mock purposes
+type Constitution struct {
+	Anchor     lcommon.GovAnchor
+	ScriptHash []byte
+}
+
+// constitutionBuilder implements ConstitutionBuilder
+type constitutionBuilder struct {
+	anchorURL  string
+	dataHash   []byte
+	scriptHash []byte
+}
+
+// NewConstitutionBuilder creates a new ConstitutionBuilder
+func NewConstitutionBuilder() ConstitutionBuilder {
+	return &constitutionBuilder{}
+}
+
+// WithAnchor sets the anchor URL and data hash for the constitution
+func (b *constitutionBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) ConstitutionBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// WithScriptHash sets the optional script hash for the constitution
+func (b *constitutionBuilder) WithScriptHash(hash []byte) ConstitutionBuilder {
+	b.scriptHash = hash
+	return b
+}
+
+// Build constructs a Constitution from the builder state
+func (b *constitutionBuilder) Build() (*Constitution, error) {
+	if b.anchorURL == "" {
+		return nil, errors.New("anchor URL is required")
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	// Validate scriptHash length if provided (Blake2b224 is 28 bytes)
+	if len(b.scriptHash) > 0 && len(b.scriptHash) != 28 {
+		return nil, fmt.Errorf(
+			"scriptHash must be exactly 28 bytes, got %d",
+			len(b.scriptHash),
+		)
+	}
+
+	constitution := &Constitution{
+		Anchor: lcommon.GovAnchor{
+			Url: b.anchorURL,
+		},
+		ScriptHash: b.scriptHash,
+	}
+
+	if len(b.dataHash) > 0 {
+		copy(constitution.Anchor.DataHash[:], b.dataHash)
+	}
+
+	return constitution, nil
+}
+
+// GovAnchorBuilder defines an interface for building governance anchors
+type GovAnchorBuilder interface {
+	WithURL(url string) GovAnchorBuilder
+	WithDataHash(hash []byte) GovAnchorBuilder
+	Build() (*lcommon.GovAnchor, error)
+}
+
+// govAnchorBuilder implements GovAnchorBuilder
+type govAnchorBuilder struct {
+	url      string
+	dataHash []byte
+}
+
+// NewGovAnchorBuilder creates a new GovAnchorBuilder
+func NewGovAnchorBuilder() GovAnchorBuilder {
+	return &govAnchorBuilder{}
+}
+
+// WithURL sets the URL for the governance anchor
+func (b *govAnchorBuilder) WithURL(url string) GovAnchorBuilder {
+	b.url = url
+	return b
+}
+
+// WithDataHash sets the data hash for the governance anchor
+func (b *govAnchorBuilder) WithDataHash(hash []byte) GovAnchorBuilder {
+	b.dataHash = hash
+	return b
+}
+
+// Build constructs a GovAnchor from the builder state
+func (b *govAnchorBuilder) Build() (*lcommon.GovAnchor, error) {
+	if b.url == "" {
+		return nil, errors.New("URL is required")
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	anchor := &lcommon.GovAnchor{
+		Url: b.url,
+	}
+
+	if len(b.dataHash) > 0 {
+		copy(anchor.DataHash[:], b.dataHash)
+	}
+
+	return anchor, nil
+}
+
+// VoterBuilder defines an interface for building mock voters
+type VoterBuilder interface {
+	WithType(voterType uint8) VoterBuilder
+	WithHash(hash []byte) VoterBuilder
+	Build() (*lcommon.Voter, error)
+}
+
+// voterBuilder implements VoterBuilder
+type voterBuilder struct {
+	voterType uint8
+	hash      []byte
+}
+
+// NewVoterBuilder creates a new VoterBuilder
+func NewVoterBuilder() VoterBuilder {
+	return &voterBuilder{}
+}
+
+// WithType sets the voter type (constitutional committee, drep, or pool)
+func (b *voterBuilder) WithType(voterType uint8) VoterBuilder {
+	b.voterType = voterType
+	return b
+}
+
+// WithHash sets the credential hash for the voter
+func (b *voterBuilder) WithHash(hash []byte) VoterBuilder {
+	b.hash = hash
+	return b
+}
+
+// Build constructs a Voter from the builder state
+func (b *voterBuilder) Build() (*lcommon.Voter, error) {
+	if len(b.hash) == 0 {
+		return nil, errors.New("hash is required")
+	}
+	// Validate hash length (Blake2b224 is 28 bytes)
+	if len(b.hash) != 28 {
+		return nil, fmt.Errorf(
+			"hash must be exactly 28 bytes, got %d",
+			len(b.hash),
+		)
+	}
+	// Validate voter type (0-4 per CIP-1694):
+	// 0=CC hot key hash, 1=CC hot script hash, 2=DRep key hash,
+	// 3=DRep script hash, 4=staking pool key hash
+	if b.voterType > 4 {
+		return nil, fmt.Errorf(
+			"invalid voter type %d, must be 0-4",
+			b.voterType,
+		)
+	}
+
+	voter := &lcommon.Voter{
+		Type: b.voterType,
+	}
+	copy(voter.Hash[:], b.hash)
+
+	return voter, nil
+}
+
+// VotingProcedureBuilder defines an interface for building mock voting procedures
+type VotingProcedureBuilder interface {
+	WithVote(vote uint8) VotingProcedureBuilder
+	WithAnchor(url string, dataHash []byte) VotingProcedureBuilder
+	Build() (*lcommon.VotingProcedure, error)
+}
+
+// votingProcedureBuilder implements VotingProcedureBuilder
+type votingProcedureBuilder struct {
+	vote      uint8
+	voteSet   bool // Tracks whether WithVote was called
+	anchorURL string
+	dataHash  []byte
+}
+
+// NewVotingProcedureBuilder creates a new VotingProcedureBuilder
+func NewVotingProcedureBuilder() VotingProcedureBuilder {
+	return &votingProcedureBuilder{}
+}
+
+// WithVote sets the vote value (yes, no, or abstain)
+func (b *votingProcedureBuilder) WithVote(vote uint8) VotingProcedureBuilder {
+	b.vote = vote
+	b.voteSet = true
+	return b
+}
+
+// WithAnchor sets the optional anchor for the voting procedure
+func (b *votingProcedureBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) VotingProcedureBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// Build constructs a VotingProcedure from the builder state
+func (b *votingProcedureBuilder) Build() (*lcommon.VotingProcedure, error) {
+	// Require explicit vote setting to avoid unintentional defaults
+	if !b.voteSet {
+		return nil, errors.New(
+			"vote is required; call WithVote(0), WithVote(1), or WithVote(2)",
+		)
+	}
+	// Validate vote value (0=no, 1=yes, 2=abstain)
+	if b.vote > 2 {
+		return nil, fmt.Errorf(
+			"invalid vote value %d, must be 0 (no), 1 (yes), or 2 (abstain)",
+			b.vote,
+		)
+	}
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	procedure := &lcommon.VotingProcedure{
+		Vote: b.vote,
+	}
+
+	if b.anchorURL != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: b.anchorURL,
+		}
+		if len(b.dataHash) > 0 {
+			copy(anchor.DataHash[:], b.dataHash)
+		}
+		procedure.Anchor = anchor
+	}
+
+	return procedure, nil
+}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1,0 +1,1867 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+	"time"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
+)
+
+// Test helper to create a sample transaction ID
+func sampleTxId() []byte {
+	return bytes.Repeat([]byte{0xab}, 32)
+}
+
+// Test helper to create a sample address (testnet base address)
+// Using a valid testnet address for testing purposes
+func sampleAddress() string {
+	return "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
+}
+
+// Test helper to create a sample policy ID
+func samplePolicyId() []byte {
+	return bytes.Repeat([]byte{0xcd}, 28)
+}
+
+// Test helper to create a sample key hash
+func sampleKeyHash() []byte {
+	return bytes.Repeat([]byte{0xef}, 28)
+}
+
+// =============================================================================
+// UtxoBuilder Tests
+// =============================================================================
+
+func TestNewUtxoBuilder(t *testing.T) {
+	builder := ledger.NewUtxoBuilder()
+	if builder == nil {
+		t.Fatal("NewUtxoBuilder() returned nil")
+	}
+}
+
+func TestUtxoBuilder_WithTxId(t *testing.T) {
+	txId := sampleTxId()
+	builder := ledger.NewUtxoBuilder().WithTxId(txId)
+	if builder == nil {
+		t.Fatal("WithTxId() returned nil")
+	}
+}
+
+func TestUtxoBuilder_WithIndex(t *testing.T) {
+	builder := ledger.NewUtxoBuilder().WithIndex(5)
+	if builder == nil {
+		t.Fatal("WithIndex() returned nil")
+	}
+}
+
+func TestUtxoBuilder_WithAddress(t *testing.T) {
+	builder := ledger.NewUtxoBuilder().WithAddress(sampleAddress())
+	if builder == nil {
+		t.Fatal("WithAddress() returned nil")
+	}
+}
+
+func TestUtxoBuilder_WithLovelace(t *testing.T) {
+	builder := ledger.NewUtxoBuilder().WithLovelace(5000000)
+	if builder == nil {
+		t.Fatal("WithLovelace() returned nil")
+	}
+}
+
+func TestUtxoBuilder_WithAssets(t *testing.T) {
+	assets := []ledger.Asset{
+		{
+			PolicyId:  samplePolicyId(),
+			AssetName: []byte("TestToken"),
+			Amount:    1000,
+		},
+	}
+	builder := ledger.NewUtxoBuilder().WithAssets(assets...)
+	if builder == nil {
+		t.Fatal("WithAssets() returned nil")
+	}
+}
+
+func TestUtxoBuilder_Build_Success(t *testing.T) {
+	txId := sampleTxId()
+	addr := sampleAddress()
+	lovelace := uint64(5000000)
+	index := uint32(0)
+
+	utxo, err := ledger.NewUtxoBuilder().
+		WithTxId(txId).
+		WithIndex(index).
+		WithAddress(addr).
+		WithLovelace(lovelace).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	// Verify the UTxO input
+	if utxo.Id == nil {
+		t.Fatal("Built UTxO has nil Id")
+	}
+	if utxo.Id.Index() != index {
+		t.Errorf("Expected index %d, got %d", index, utxo.Id.Index())
+	}
+
+	// Verify the UTxO output
+	if utxo.Output == nil {
+		t.Fatal("Built UTxO has nil Output")
+	}
+	if utxo.Output.Amount().Cmp(big.NewInt(int64(lovelace))) != 0 {
+		t.Errorf("Expected amount %d, got %s", lovelace, utxo.Output.Amount())
+	}
+}
+
+func TestUtxoBuilder_Build_MissingTxId(t *testing.T) {
+	_, err := ledger.NewUtxoBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when TxId is missing")
+	}
+}
+
+func TestUtxoBuilder_WithMultipleAssets(t *testing.T) {
+	assets := []ledger.Asset{
+		{
+			PolicyId:  samplePolicyId(),
+			AssetName: []byte("Token1"),
+			Amount:    100,
+		},
+		{
+			PolicyId:  samplePolicyId(),
+			AssetName: []byte("Token2"),
+			Amount:    200,
+		},
+	}
+
+	utxo, err := ledger.NewUtxoBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(0).
+		WithAddress(sampleAddress()).
+		WithLovelace(2000000).
+		WithAssets(assets...).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if utxo.Output.Assets() == nil {
+		t.Fatal("Expected assets to be set")
+	}
+}
+
+func TestUtxoBuilder_ChainedMethods(t *testing.T) {
+	// Test that all methods can be chained
+	utxo, err := ledger.NewUtxoBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(1).
+		WithAddress(sampleAddress()).
+		WithLovelace(10000000).
+		WithAssets(ledger.Asset{
+			PolicyId:  samplePolicyId(),
+			AssetName: []byte("Test"),
+			Amount:    50,
+		}).
+		WithDatum(nil).
+		WithDatumHash(nil).
+		WithScriptRef(nil).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Chained Build() returned error: %v", err)
+	}
+
+	if utxo.Id.Index() != 1 {
+		t.Errorf("Expected index 1, got %d", utxo.Id.Index())
+	}
+}
+
+// =============================================================================
+// LedgerStateBuilder Tests
+// =============================================================================
+
+func TestNewLedgerStateBuilder(t *testing.T) {
+	builder := ledger.NewLedgerStateBuilder()
+	if builder == nil {
+		t.Fatal("NewLedgerStateBuilder() returned nil")
+	}
+}
+
+func TestLedgerStateBuilder_WithNetworkId(t *testing.T) {
+	networkId := uint(1) // mainnet
+	state := ledger.NewLedgerStateBuilder().
+		WithNetworkId(networkId).
+		Build()
+
+	if state.NetworkId() != networkId {
+		t.Errorf("Expected NetworkId %d, got %d", networkId, state.NetworkId())
+	}
+}
+
+func TestLedgerStateBuilder_WithAdaPots(t *testing.T) {
+	pots := lcommon.AdaPots{
+		Reserves: 10000000000000,
+		Treasury: 500000000000,
+		Rewards:  100000000000,
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithAdaPots(pots).
+		Build()
+
+	result := state.GetAdaPots()
+	if result.Reserves != pots.Reserves {
+		t.Errorf("Expected Reserves %d, got %d", pots.Reserves, result.Reserves)
+	}
+	if result.Treasury != pots.Treasury {
+		t.Errorf("Expected Treasury %d, got %d", pots.Treasury, result.Treasury)
+	}
+	if result.Rewards != pots.Rewards {
+		t.Errorf("Expected Rewards %d, got %d", pots.Rewards, result.Rewards)
+	}
+}
+
+func TestLedgerStateBuilder_WithUtxos(t *testing.T) {
+	// Create a UTxO
+	utxo, err := ledger.NewUtxoBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(0).
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build UTxO: %v", err)
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithUtxos([]lcommon.Utxo{utxo}).
+		Build()
+
+	// Look up the UTxO
+	result, err := state.UtxoById(utxo.Id)
+	if err != nil {
+		t.Fatalf("UtxoById returned error: %v", err)
+	}
+
+	if result.Output.Amount().Cmp(utxo.Output.Amount()) != 0 {
+		t.Errorf(
+			"Expected amount %s, got %s",
+			utxo.Output.Amount(),
+			result.Output.Amount(),
+		)
+	}
+}
+
+func TestLedgerStateBuilder_WithUtxoById_Callback(t *testing.T) {
+	txId := sampleTxId()
+	expectedAmount := uint64(7000000)
+
+	callback := func(id lcommon.TransactionInput) (lcommon.Utxo, error) {
+		// Return a mock UTxO
+		utxo, err := ledger.NewUtxoBuilder().
+			WithTxId(txId).
+			WithIndex(id.Index()).
+			WithAddress(sampleAddress()).
+			WithLovelace(expectedAmount).
+			Build()
+		return utxo, err
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithUtxoById(callback).
+		Build()
+
+	// Create input to look up
+	input, _ := ledger.NewTransactionInputBuilder().
+		WithTxId(txId).
+		WithIndex(0).
+		Build()
+
+	result, err := state.UtxoById(input)
+	if err != nil {
+		t.Fatalf("UtxoById returned error: %v", err)
+	}
+
+	if result.Output.Amount().Cmp(big.NewInt(int64(expectedAmount))) != 0 {
+		t.Errorf(
+			"Expected amount %d, got %s",
+			expectedAmount,
+			result.Output.Amount(),
+		)
+	}
+}
+
+func TestLedgerStateBuilder_WithSlotToTime(t *testing.T) {
+	expectedTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	callback := func(slot uint64) (time.Time, error) {
+		return expectedTime, nil
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithSlotToTime(callback).
+		Build()
+
+	result, err := state.SlotToTime(12345)
+	if err != nil {
+		t.Fatalf("SlotToTime returned error: %v", err)
+	}
+
+	if !result.Equal(expectedTime) {
+		t.Errorf("Expected time %v, got %v", expectedTime, result)
+	}
+}
+
+func TestLedgerStateBuilder_WithTimeToSlot(t *testing.T) {
+	expectedSlot := uint64(54321)
+
+	callback := func(t time.Time) (uint64, error) {
+		return expectedSlot, nil
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithTimeToSlot(callback).
+		Build()
+
+	result, err := state.TimeToSlot(time.Now())
+	if err != nil {
+		t.Fatalf("TimeToSlot returned error: %v", err)
+	}
+
+	if result != expectedSlot {
+		t.Errorf("Expected slot %d, got %d", expectedSlot, result)
+	}
+}
+
+func TestLedgerStateBuilder_TreasuryValue(t *testing.T) {
+	expectedTreasury := uint64(1000000000000)
+
+	callback := func() (uint64, error) {
+		return expectedTreasury, nil
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithTreasuryValue(callback).
+		Build()
+
+	result, err := state.TreasuryValue()
+	if err != nil {
+		t.Fatalf("TreasuryValue returned error: %v", err)
+	}
+
+	if result != expectedTreasury {
+		t.Errorf("Expected treasury %d, got %d", expectedTreasury, result)
+	}
+}
+
+func TestLedgerStateBuilder_TreasuryValue_FromAdaPots(t *testing.T) {
+	expectedTreasury := uint64(500000000000)
+
+	state := ledger.NewLedgerStateBuilder().
+		WithAdaPots(lcommon.AdaPots{
+			Treasury: expectedTreasury,
+		}).
+		Build()
+
+	result, err := state.TreasuryValue()
+	if err != nil {
+		t.Fatalf("TreasuryValue returned error: %v", err)
+	}
+
+	if result != expectedTreasury {
+		t.Errorf("Expected treasury %d, got %d", expectedTreasury, result)
+	}
+}
+
+func TestLedgerStateBuilder_WithCostModels(t *testing.T) {
+	expectedCostModels := map[ledger.PlutusLanguage]ledger.CostModel{
+		ledger.PlutusV1: make([]int64, 166),
+		ledger.PlutusV2: make([]int64, 175),
+	}
+
+	callback := func() map[ledger.PlutusLanguage]ledger.CostModel {
+		return expectedCostModels
+	}
+
+	state := ledger.NewLedgerStateBuilder().
+		WithCostModels(callback).
+		Build()
+
+	result := state.CostModels()
+	if len(result) != len(expectedCostModels) {
+		t.Errorf(
+			"Expected %d cost models, got %d",
+			len(expectedCostModels),
+			len(result),
+		)
+	}
+}
+
+func TestLedgerState_UpdateAdaPots(t *testing.T) {
+	state := ledger.NewLedgerStateBuilder().Build()
+
+	newPots := lcommon.AdaPots{
+		Reserves: 5000000000000,
+		Treasury: 250000000000,
+		Rewards:  50000000000,
+	}
+
+	err := state.UpdateAdaPots(newPots)
+	if err != nil {
+		t.Fatalf("UpdateAdaPots returned error: %v", err)
+	}
+
+	result := state.GetAdaPots()
+	if result.Treasury != newPots.Treasury {
+		t.Errorf(
+			"Expected Treasury %d, got %d",
+			newPots.Treasury,
+			result.Treasury,
+		)
+	}
+}
+
+func TestLedgerState_DefaultBehavior(t *testing.T) {
+	state := ledger.NewLedgerStateBuilder().Build()
+
+	// Test default UtxoById returns ErrNotFound
+	input, _ := ledger.NewTransactionInputBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(0).
+		Build()
+	_, err := state.UtxoById(input)
+	if err != ledger.ErrNotFound {
+		t.Errorf("Expected ErrNotFound, got %v", err)
+	}
+
+	// Test default StakeRegistration returns empty slice
+	certs, err := state.StakeRegistration(sampleKeyHash())
+	if err != nil {
+		t.Errorf("StakeRegistration should not return error: %v", err)
+	}
+	if len(certs) != 0 {
+		t.Errorf("Expected empty certs, got %d", len(certs))
+	}
+
+	// Test default SlotToTime returns zero time
+	slotTime, err := state.SlotToTime(0)
+	if err != nil {
+		t.Errorf("SlotToTime should not return error: %v", err)
+	}
+	if !slotTime.IsZero() {
+		t.Errorf("Expected zero time, got %v", slotTime)
+	}
+
+	// Test default CostModels returns empty map
+	costModels := state.CostModels()
+	if len(costModels) != 0 {
+		t.Errorf("Expected empty cost models, got %d", len(costModels))
+	}
+}
+
+// =============================================================================
+// PoolBuilder Tests
+// =============================================================================
+
+func TestNewPoolBuilder(t *testing.T) {
+	builder := ledger.NewPoolBuilder()
+	if builder == nil {
+		t.Fatal("NewPoolBuilder() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithOperator(t *testing.T) {
+	builder := ledger.NewPoolBuilder().WithOperator(sampleKeyHash())
+	if builder == nil {
+		t.Fatal("WithOperator() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithVrfKeyHash(t *testing.T) {
+	vrfHash := bytes.Repeat([]byte{0x12}, 32)
+	builder := ledger.NewPoolBuilder().WithVrfKeyHash(vrfHash)
+	if builder == nil {
+		t.Fatal("WithVrfKeyHash() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithPledge(t *testing.T) {
+	builder := ledger.NewPoolBuilder().WithPledge(100000000000)
+	if builder == nil {
+		t.Fatal("WithPledge() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithCost(t *testing.T) {
+	builder := ledger.NewPoolBuilder().WithCost(340000000)
+	if builder == nil {
+		t.Fatal("WithCost() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithMargin(t *testing.T) {
+	builder := ledger.NewPoolBuilder().WithMargin(1, 100)
+	if builder == nil {
+		t.Fatal("WithMargin() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithOwners(t *testing.T) {
+	owners := [][]byte{
+		sampleKeyHash(),
+		bytes.Repeat([]byte{0x01}, 28),
+	}
+	builder := ledger.NewPoolBuilder().WithOwners(owners...)
+	if builder == nil {
+		t.Fatal("WithOwners() returned nil")
+	}
+}
+
+func TestPoolBuilder_WithMetadata(t *testing.T) {
+	url := "https://example.com/pool.json"
+	hash := bytes.Repeat([]byte{0x99}, 32)
+	builder := ledger.NewPoolBuilder().WithMetadata(url, hash)
+	if builder == nil {
+		t.Fatal("WithMetadata() returned nil")
+	}
+}
+
+func TestPoolBuilder_Build(t *testing.T) {
+	operatorHash := sampleKeyHash()
+	vrfHash := bytes.Repeat([]byte{0x12}, 32)
+	pledge := uint64(100000000000)
+	cost := uint64(340000000)
+
+	cert, err := ledger.NewPoolBuilder().
+		WithOperator(operatorHash).
+		WithVrfKeyHash(vrfHash).
+		WithPledge(pledge).
+		WithCost(cost).
+		WithMargin(1, 100).
+		WithOwners(operatorHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if cert.Pledge != pledge {
+		t.Errorf("Expected pledge %d, got %d", pledge, cert.Pledge)
+	}
+
+	if cert.Cost != cost {
+		t.Errorf("Expected cost %d, got %d", cost, cert.Cost)
+	}
+
+	if len(cert.PoolOwners) != 1 {
+		t.Errorf("Expected 1 owner, got %d", len(cert.PoolOwners))
+	}
+}
+
+// =============================================================================
+// AdaPotsBuilder Tests
+// =============================================================================
+
+func TestNewAdaPotsBuilder(t *testing.T) {
+	builder := ledger.NewAdaPotsBuilder()
+	if builder == nil {
+		t.Fatal("NewAdaPotsBuilder() returned nil")
+	}
+}
+
+func TestAdaPotsBuilder_WithReserves(t *testing.T) {
+	builder := ledger.NewAdaPotsBuilder().WithReserves(10000000000000)
+	if builder == nil {
+		t.Fatal("WithReserves() returned nil")
+	}
+}
+
+func TestAdaPotsBuilder_WithTreasury(t *testing.T) {
+	builder := ledger.NewAdaPotsBuilder().WithTreasury(500000000000)
+	if builder == nil {
+		t.Fatal("WithTreasury() returned nil")
+	}
+}
+
+func TestAdaPotsBuilder_WithRewards(t *testing.T) {
+	builder := ledger.NewAdaPotsBuilder().WithRewards(100000000000)
+	if builder == nil {
+		t.Fatal("WithRewards() returned nil")
+	}
+}
+
+func TestAdaPotsBuilder_Build(t *testing.T) {
+	reserves := uint64(10000000000000)
+	treasury := uint64(500000000000)
+	rewards := uint64(100000000000)
+
+	pots, err := ledger.NewAdaPotsBuilder().
+		WithReserves(reserves).
+		WithTreasury(treasury).
+		WithRewards(rewards).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if pots.Reserves != reserves {
+		t.Errorf("Expected Reserves %d, got %d", reserves, pots.Reserves)
+	}
+
+	if pots.Treasury != treasury {
+		t.Errorf("Expected Treasury %d, got %d", treasury, pots.Treasury)
+	}
+
+	if pots.Rewards != rewards {
+		t.Errorf("Expected Rewards %d, got %d", rewards, pots.Rewards)
+	}
+}
+
+// =============================================================================
+// RewardSnapshotBuilder Tests
+// =============================================================================
+
+func TestNewRewardSnapshotBuilder(t *testing.T) {
+	builder := ledger.NewRewardSnapshotBuilder()
+	if builder == nil {
+		t.Fatal("NewRewardSnapshotBuilder() returned nil")
+	}
+}
+
+func TestRewardSnapshotBuilder_WithTotalActiveStake(t *testing.T) {
+	builder := ledger.NewRewardSnapshotBuilder().
+		WithTotalActiveStake(32000000000000000)
+	if builder == nil {
+		t.Fatal("WithTotalActiveStake() returned nil")
+	}
+}
+
+func TestRewardSnapshotBuilder_Build(t *testing.T) {
+	totalStake := uint64(32000000000000000)
+
+	snapshot, err := ledger.NewRewardSnapshotBuilder().
+		WithTotalActiveStake(totalStake).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if snapshot.TotalActiveStake != totalStake {
+		t.Errorf(
+			"Expected TotalActiveStake %d, got %d",
+			totalStake,
+			snapshot.TotalActiveStake,
+		)
+	}
+}
+
+// =============================================================================
+// CommitteeMemberBuilder Tests
+// =============================================================================
+
+func TestNewCommitteeMemberBuilder(t *testing.T) {
+	builder := ledger.NewCommitteeMemberBuilder()
+	if builder == nil {
+		t.Fatal("NewCommitteeMemberBuilder() returned nil")
+	}
+}
+
+func TestCommitteeMemberBuilder_WithColdKey(t *testing.T) {
+	builder := ledger.NewCommitteeMemberBuilder().WithColdKey(sampleKeyHash())
+	if builder == nil {
+		t.Fatal("WithColdKey() returned nil")
+	}
+}
+
+func TestCommitteeMemberBuilder_WithHotKey(t *testing.T) {
+	builder := ledger.NewCommitteeMemberBuilder().
+		WithColdKey(sampleKeyHash()).
+		WithHotKey(bytes.Repeat([]byte{0x01}, 28))
+	if builder == nil {
+		t.Fatal("WithHotKey() returned nil")
+	}
+}
+
+func TestCommitteeMemberBuilder_WithExpiryEpoch(t *testing.T) {
+	builder := ledger.NewCommitteeMemberBuilder().
+		WithColdKey(sampleKeyHash()).
+		WithExpiryEpoch(500)
+	if builder == nil {
+		t.Fatal("WithExpiryEpoch() returned nil")
+	}
+}
+
+func TestCommitteeMemberBuilder_WithResigned(t *testing.T) {
+	builder := ledger.NewCommitteeMemberBuilder().
+		WithColdKey(sampleKeyHash()).
+		WithResigned(true)
+	if builder == nil {
+		t.Fatal("WithResigned() returned nil")
+	}
+}
+
+func TestCommitteeMemberBuilder_Build_Success(t *testing.T) {
+	coldKey := sampleKeyHash()
+	hotKey := bytes.Repeat([]byte{0x01}, 28)
+	expiryEpoch := uint64(500)
+
+	member, err := ledger.NewCommitteeMemberBuilder().
+		WithColdKey(coldKey).
+		WithHotKey(hotKey).
+		WithExpiryEpoch(expiryEpoch).
+		WithResigned(false).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if member.ExpiryEpoch != expiryEpoch {
+		t.Errorf(
+			"Expected ExpiryEpoch %d, got %d",
+			expiryEpoch,
+			member.ExpiryEpoch,
+		)
+	}
+
+	if member.Resigned {
+		t.Error("Expected Resigned to be false")
+	}
+}
+
+func TestCommitteeMemberBuilder_Build_MissingColdKey(t *testing.T) {
+	_, err := ledger.NewCommitteeMemberBuilder().
+		WithExpiryEpoch(500).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when cold key is missing")
+	}
+}
+
+// =============================================================================
+// DRepRegistrationBuilder Tests
+// =============================================================================
+
+func TestNewDRepRegistrationBuilder(t *testing.T) {
+	builder := ledger.NewDRepRegistrationBuilder()
+	if builder == nil {
+		t.Fatal("NewDRepRegistrationBuilder() returned nil")
+	}
+}
+
+func TestDRepRegistrationBuilder_WithCredential(t *testing.T) {
+	builder := ledger.NewDRepRegistrationBuilder().
+		WithCredential(sampleKeyHash())
+	if builder == nil {
+		t.Fatal("WithCredential() returned nil")
+	}
+}
+
+func TestDRepRegistrationBuilder_WithAnchor(t *testing.T) {
+	builder := ledger.NewDRepRegistrationBuilder().
+		WithCredential(sampleKeyHash()).
+		WithAnchor("https://example.com/drep.json", bytes.Repeat([]byte{0x55}, 32))
+	if builder == nil {
+		t.Fatal("WithAnchor() returned nil")
+	}
+}
+
+func TestDRepRegistrationBuilder_WithDeposit(t *testing.T) {
+	builder := ledger.NewDRepRegistrationBuilder().
+		WithCredential(sampleKeyHash()).
+		WithDeposit(500000000)
+	if builder == nil {
+		t.Fatal("WithDeposit() returned nil")
+	}
+}
+
+func TestDRepRegistrationBuilder_Build_Success(t *testing.T) {
+	cred := sampleKeyHash()
+	deposit := uint64(500000000)
+	anchorUrl := "https://example.com/drep.json"
+
+	cert, err := ledger.NewDRepRegistrationBuilder().
+		WithCredential(cred).
+		WithDeposit(deposit).
+		WithAnchor(anchorUrl, bytes.Repeat([]byte{0x55}, 32)).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if cert.Amount != int64(deposit) {
+		t.Errorf("Expected Amount %d, got %d", deposit, cert.Amount)
+	}
+
+	if cert.Anchor == nil {
+		t.Fatal("Expected Anchor to be set")
+	}
+
+	if cert.Anchor.Url != anchorUrl {
+		t.Errorf("Expected anchor URL %s, got %s", anchorUrl, cert.Anchor.Url)
+	}
+}
+
+func TestDRepRegistrationBuilder_Build_MissingCredential(t *testing.T) {
+	_, err := ledger.NewDRepRegistrationBuilder().
+		WithDeposit(500000000).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when credential is missing")
+	}
+}
+
+// =============================================================================
+// ConstitutionBuilder Tests
+// =============================================================================
+
+func TestNewConstitutionBuilder(t *testing.T) {
+	builder := ledger.NewConstitutionBuilder()
+	if builder == nil {
+		t.Fatal("NewConstitutionBuilder() returned nil")
+	}
+}
+
+func TestConstitutionBuilder_WithAnchor(t *testing.T) {
+	builder := ledger.NewConstitutionBuilder().
+		WithAnchor("https://example.com/constitution.txt", bytes.Repeat([]byte{0x77}, 32))
+	if builder == nil {
+		t.Fatal("WithAnchor() returned nil")
+	}
+}
+
+func TestConstitutionBuilder_WithScriptHash(t *testing.T) {
+	builder := ledger.NewConstitutionBuilder().
+		WithAnchor("https://example.com/constitution.txt", nil).
+		WithScriptHash(sampleKeyHash())
+	if builder == nil {
+		t.Fatal("WithScriptHash() returned nil")
+	}
+}
+
+func TestConstitutionBuilder_Build_Success(t *testing.T) {
+	anchorUrl := "https://example.com/constitution.txt"
+	dataHash := bytes.Repeat([]byte{0x77}, 32)
+	scriptHash := sampleKeyHash()
+
+	constitution, err := ledger.NewConstitutionBuilder().
+		WithAnchor(anchorUrl, dataHash).
+		WithScriptHash(scriptHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if constitution.Anchor.Url != anchorUrl {
+		t.Errorf(
+			"Expected anchor URL %s, got %s",
+			anchorUrl,
+			constitution.Anchor.Url,
+		)
+	}
+
+	if !bytes.Equal(constitution.ScriptHash, scriptHash) {
+		t.Errorf("Expected ScriptHash to match")
+	}
+}
+
+func TestConstitutionBuilder_Build_MissingAnchorURL(t *testing.T) {
+	_, err := ledger.NewConstitutionBuilder().
+		WithScriptHash(sampleKeyHash()).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when anchor URL is missing")
+	}
+}
+
+// =============================================================================
+// GovAnchorBuilder Tests
+// =============================================================================
+
+func TestNewGovAnchorBuilder(t *testing.T) {
+	builder := ledger.NewGovAnchorBuilder()
+	if builder == nil {
+		t.Fatal("NewGovAnchorBuilder() returned nil")
+	}
+}
+
+func TestGovAnchorBuilder_WithURL(t *testing.T) {
+	builder := ledger.NewGovAnchorBuilder().
+		WithURL("https://example.com/proposal.json")
+	if builder == nil {
+		t.Fatal("WithURL() returned nil")
+	}
+}
+
+func TestGovAnchorBuilder_WithDataHash(t *testing.T) {
+	builder := ledger.NewGovAnchorBuilder().
+		WithURL("https://example.com/proposal.json").
+		WithDataHash(bytes.Repeat([]byte{0x88}, 32))
+	if builder == nil {
+		t.Fatal("WithDataHash() returned nil")
+	}
+}
+
+func TestGovAnchorBuilder_Build_Success(t *testing.T) {
+	url := "https://example.com/proposal.json"
+	dataHash := bytes.Repeat([]byte{0x88}, 32)
+
+	anchor, err := ledger.NewGovAnchorBuilder().
+		WithURL(url).
+		WithDataHash(dataHash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if anchor.Url != url {
+		t.Errorf("Expected URL %s, got %s", url, anchor.Url)
+	}
+}
+
+func TestGovAnchorBuilder_Build_MissingURL(t *testing.T) {
+	_, err := ledger.NewGovAnchorBuilder().
+		WithDataHash(bytes.Repeat([]byte{0x88}, 32)).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when URL is missing")
+	}
+}
+
+// =============================================================================
+// VoterBuilder Tests
+// =============================================================================
+
+func TestNewVoterBuilder(t *testing.T) {
+	builder := ledger.NewVoterBuilder()
+	if builder == nil {
+		t.Fatal("NewVoterBuilder() returned nil")
+	}
+}
+
+func TestVoterBuilder_WithType(t *testing.T) {
+	builder := ledger.NewVoterBuilder().WithType(1) // DRep
+	if builder == nil {
+		t.Fatal("WithType() returned nil")
+	}
+}
+
+func TestVoterBuilder_WithHash(t *testing.T) {
+	builder := ledger.NewVoterBuilder().
+		WithType(1).
+		WithHash(sampleKeyHash())
+	if builder == nil {
+		t.Fatal("WithHash() returned nil")
+	}
+}
+
+func TestVoterBuilder_Build_Success(t *testing.T) {
+	voterType := uint8(1)
+	hash := sampleKeyHash()
+
+	voter, err := ledger.NewVoterBuilder().
+		WithType(voterType).
+		WithHash(hash).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if voter.Type != voterType {
+		t.Errorf("Expected Type %d, got %d", voterType, voter.Type)
+	}
+}
+
+func TestVoterBuilder_Build_MissingHash(t *testing.T) {
+	_, err := ledger.NewVoterBuilder().
+		WithType(1).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when hash is missing")
+	}
+}
+
+// =============================================================================
+// VotingProcedureBuilder Tests
+// =============================================================================
+
+func TestNewVotingProcedureBuilder(t *testing.T) {
+	builder := ledger.NewVotingProcedureBuilder()
+	if builder == nil {
+		t.Fatal("NewVotingProcedureBuilder() returned nil")
+	}
+}
+
+func TestVotingProcedureBuilder_WithVote(t *testing.T) {
+	builder := ledger.NewVotingProcedureBuilder().WithVote(1) // Yes
+	if builder == nil {
+		t.Fatal("WithVote() returned nil")
+	}
+}
+
+func TestVotingProcedureBuilder_WithAnchor(t *testing.T) {
+	builder := ledger.NewVotingProcedureBuilder().
+		WithVote(1).
+		WithAnchor("https://example.com/rationale.json", bytes.Repeat([]byte{0x99}, 32))
+	if builder == nil {
+		t.Fatal("WithAnchor() returned nil")
+	}
+}
+
+func TestVotingProcedureBuilder_Build_Success(t *testing.T) {
+	vote := uint8(1) // Yes
+	anchorUrl := "https://example.com/rationale.json"
+
+	procedure, err := ledger.NewVotingProcedureBuilder().
+		WithVote(vote).
+		WithAnchor(anchorUrl, bytes.Repeat([]byte{0x99}, 32)).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if procedure.Vote != vote {
+		t.Errorf("Expected Vote %d, got %d", vote, procedure.Vote)
+	}
+
+	if procedure.Anchor == nil {
+		t.Fatal("Expected Anchor to be set")
+	}
+
+	if procedure.Anchor.Url != anchorUrl {
+		t.Errorf(
+			"Expected anchor URL %s, got %s",
+			anchorUrl,
+			procedure.Anchor.Url,
+		)
+	}
+}
+
+func TestVotingProcedureBuilder_Build_WithoutAnchor(t *testing.T) {
+	vote := uint8(0) // No
+
+	procedure, err := ledger.NewVotingProcedureBuilder().
+		WithVote(vote).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if procedure.Vote != vote {
+		t.Errorf("Expected Vote %d, got %d", vote, procedure.Vote)
+	}
+
+	if procedure.Anchor != nil {
+		t.Error("Expected Anchor to be nil")
+	}
+}
+
+func TestVotingProcedureBuilder_Build_WithoutVote(t *testing.T) {
+	// Build without calling WithVote should return an error
+	_, err := ledger.NewVotingProcedureBuilder().Build()
+
+	if err == nil {
+		t.Fatal("Build() without WithVote() should return an error")
+	}
+}
+
+func TestVotingProcedureBuilder_Build_InvalidVote(t *testing.T) {
+	// Invalid vote value (>2) should return an error
+	_, err := ledger.NewVotingProcedureBuilder().
+		WithVote(3).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() with invalid vote value should return an error")
+	}
+}
+
+// =============================================================================
+// TransactionBuilder Tests
+// =============================================================================
+
+func TestNewTransactionBuilder(t *testing.T) {
+	builder := ledger.NewTransactionBuilder()
+	if builder == nil {
+		t.Fatal("NewTransactionBuilder() returned nil")
+	}
+}
+
+func TestTransactionBuilder_WithId(t *testing.T) {
+	builder := ledger.NewTransactionBuilder().WithId(sampleTxId())
+	if builder == nil {
+		t.Fatal("WithId() returned nil")
+	}
+}
+
+func TestTransactionBuilder_WithFee(t *testing.T) {
+	builder := ledger.NewTransactionBuilder().WithFee(200000)
+	if builder == nil {
+		t.Fatal("WithFee() returned nil")
+	}
+}
+
+func TestTransactionBuilder_WithTTL(t *testing.T) {
+	builder := ledger.NewTransactionBuilder().WithTTL(100000000)
+	if builder == nil {
+		t.Fatal("WithTTL() returned nil")
+	}
+}
+
+func TestTransactionBuilder_WithValid(t *testing.T) {
+	builder := ledger.NewTransactionBuilder().WithValid(true)
+	if builder == nil {
+		t.Fatal("WithValid() returned nil")
+	}
+}
+
+func TestTransactionBuilder_Build_MissingInputs(t *testing.T) {
+	output, _ := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+
+	_, err := ledger.NewTransactionBuilder().
+		WithId(sampleTxId()).
+		WithOutputs(output).
+		WithFee(200000).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when inputs are missing")
+	}
+}
+
+func TestTransactionBuilder_Build_MissingOutputs(t *testing.T) {
+	input, _ := ledger.NewTransactionInputBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(0).
+		Build()
+
+	_, err := ledger.NewTransactionBuilder().
+		WithId(sampleTxId()).
+		WithInputs(input).
+		WithFee(200000).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when outputs are missing")
+	}
+}
+
+func TestTransactionBuilder_Build_Success(t *testing.T) {
+	txId := sampleTxId()
+	fee := uint64(200000)
+	ttl := uint64(100000000)
+
+	input, _ := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x11}, 32)).
+		WithIndex(0).
+		Build()
+
+	output, _ := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+
+	tx, err := ledger.NewTransactionBuilder().
+		WithId(txId).
+		WithInputs(input).
+		WithOutputs(output).
+		WithFee(fee).
+		WithTTL(ttl).
+		WithValid(true).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if tx.Fee().Cmp(big.NewInt(int64(fee))) != 0 {
+		t.Errorf("Expected fee %d, got %s", fee, tx.Fee())
+	}
+
+	if tx.TTL() != ttl {
+		t.Errorf("Expected TTL %d, got %d", ttl, tx.TTL())
+	}
+
+	if !tx.IsValid() {
+		t.Error("Expected transaction to be valid")
+	}
+
+	if len(tx.Inputs()) != 1 {
+		t.Errorf("Expected 1 input, got %d", len(tx.Inputs()))
+	}
+
+	if len(tx.Outputs()) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tx.Outputs()))
+	}
+}
+
+// =============================================================================
+// TransactionInputBuilder Tests
+// =============================================================================
+
+func TestNewTransactionInputBuilder(t *testing.T) {
+	builder := ledger.NewTransactionInputBuilder()
+	if builder == nil {
+		t.Fatal("NewTransactionInputBuilder() returned nil")
+	}
+}
+
+func TestTransactionInputBuilder_WithTxId(t *testing.T) {
+	builder := ledger.NewTransactionInputBuilder().WithTxId(sampleTxId())
+	if builder == nil {
+		t.Fatal("WithTxId() returned nil")
+	}
+}
+
+func TestTransactionInputBuilder_WithIndex(t *testing.T) {
+	builder := ledger.NewTransactionInputBuilder().
+		WithTxId(sampleTxId()).
+		WithIndex(5)
+	if builder == nil {
+		t.Fatal("WithIndex() returned nil")
+	}
+}
+
+func TestTransactionInputBuilder_Build_Success(t *testing.T) {
+	txId := sampleTxId()
+	index := uint32(3)
+
+	input, err := ledger.NewTransactionInputBuilder().
+		WithTxId(txId).
+		WithIndex(index).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if input.Index() != index {
+		t.Errorf("Expected index %d, got %d", index, input.Index())
+	}
+}
+
+func TestTransactionInputBuilder_Build_MissingTxId(t *testing.T) {
+	_, err := ledger.NewTransactionInputBuilder().
+		WithIndex(0).
+		Build()
+
+	if err == nil {
+		t.Fatal("Build() should return error when TxId is missing")
+	}
+}
+
+// =============================================================================
+// TransactionOutputBuilder Tests
+// =============================================================================
+
+func TestNewTransactionOutputBuilder(t *testing.T) {
+	builder := ledger.NewTransactionOutputBuilder()
+	if builder == nil {
+		t.Fatal("NewTransactionOutputBuilder() returned nil")
+	}
+}
+
+func TestTransactionOutputBuilder_WithAddress(t *testing.T) {
+	builder := ledger.NewTransactionOutputBuilder().WithAddress(sampleAddress())
+	if builder == nil {
+		t.Fatal("WithAddress() returned nil")
+	}
+}
+
+func TestTransactionOutputBuilder_WithLovelace(t *testing.T) {
+	builder := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000)
+	if builder == nil {
+		t.Fatal("WithLovelace() returned nil")
+	}
+}
+
+func TestTransactionOutputBuilder_WithAssets(t *testing.T) {
+	assets := []ledger.Asset{
+		{
+			PolicyId:  samplePolicyId(),
+			AssetName: []byte("Token"),
+			Amount:    100,
+		},
+	}
+	builder := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(2000000).
+		WithAssets(assets...)
+	if builder == nil {
+		t.Fatal("WithAssets() returned nil")
+	}
+}
+
+func TestTransactionOutputBuilder_Build_Success(t *testing.T) {
+	addr := sampleAddress()
+	lovelace := uint64(5000000)
+
+	output, err := ledger.NewTransactionOutputBuilder().
+		WithAddress(addr).
+		WithLovelace(lovelace).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	if output.Amount().Cmp(big.NewInt(int64(lovelace))) != 0 {
+		t.Errorf("Expected amount %d, got %s", lovelace, output.Amount())
+	}
+}
+
+func TestTransactionOutputBuilder_Build_WithInvalidAddress(t *testing.T) {
+	// Building with invalid address still produces an output
+	// The validation in Build() checks if address.String() == ""
+	// When an invalid address is provided, WithAddress stores an empty Address{}
+	// which may still have a non-empty string representation
+	builder := ledger.NewTransactionOutputBuilder().
+		WithAddress("invalid-address").
+		WithLovelace(5000000)
+
+	// The current implementation is lenient - it allows building
+	// even with addresses that failed parsing
+	output, err := builder.Build()
+	if err != nil {
+		// If error is returned, that's acceptable behavior
+		return
+	}
+
+	// If no error, the output should still have the lovelace amount set
+	if output.Amount().Cmp(big.NewInt(5000000)) != 0 {
+		t.Errorf("Expected amount 5000000, got %s", output.Amount())
+	}
+}
+
+// =============================================================================
+// Protocol Parameters Tests
+// =============================================================================
+
+func TestNewMockByronProtocolParams(t *testing.T) {
+	params := ledger.NewMockByronProtocolParams()
+
+	if params.SlotDuration != 20000 {
+		t.Errorf("Expected SlotDuration 20000, got %d", params.SlotDuration)
+	}
+
+	if params.MaxBlockSize != 2000000 {
+		t.Errorf("Expected MaxBlockSize 2000000, got %d", params.MaxBlockSize)
+	}
+
+	if params.TxFeePolicy[0] != 155381 {
+		t.Errorf(
+			"Expected TxFeePolicy[0] 155381, got %d",
+			params.TxFeePolicy[0],
+		)
+	}
+}
+
+func TestNewMockShelleyProtocolParams(t *testing.T) {
+	params := ledger.NewMockShelleyProtocolParams()
+
+	if params.MinFeeA != 44 {
+		t.Errorf("Expected MinFeeA 44, got %d", params.MinFeeA)
+	}
+
+	if params.MinFeeB != 155381 {
+		t.Errorf("Expected MinFeeB 155381, got %d", params.MinFeeB)
+	}
+
+	if params.KeyDeposit != 2000000 {
+		t.Errorf("Expected KeyDeposit 2000000, got %d", params.KeyDeposit)
+	}
+
+	if params.PoolDeposit != 500000000 {
+		t.Errorf("Expected PoolDeposit 500000000, got %d", params.PoolDeposit)
+	}
+
+	if params.ProtocolMajor != 2 {
+		t.Errorf("Expected ProtocolMajor 2, got %d", params.ProtocolMajor)
+	}
+}
+
+func TestNewMockAllegraProtocolParams(t *testing.T) {
+	params := ledger.NewMockAllegraProtocolParams()
+
+	// Should inherit Shelley values
+	if params.MinFeeA != 44 {
+		t.Errorf("Expected MinFeeA 44, got %d", params.MinFeeA)
+	}
+
+	// But have Allegra protocol version
+	if params.ProtocolMajor != 3 {
+		t.Errorf("Expected ProtocolMajor 3, got %d", params.ProtocolMajor)
+	}
+}
+
+func TestNewMockMaryProtocolParams(t *testing.T) {
+	params := ledger.NewMockMaryProtocolParams()
+
+	if params.ProtocolMajor != 4 {
+		t.Errorf("Expected ProtocolMajor 4, got %d", params.ProtocolMajor)
+	}
+
+	if params.NOpt != 500 {
+		t.Errorf("Expected NOpt 500, got %d", params.NOpt)
+	}
+
+	if params.MinPoolCost != 340000000 {
+		t.Errorf("Expected MinPoolCost 340000000, got %d", params.MinPoolCost)
+	}
+}
+
+func TestNewMockAlonzoProtocolParams(t *testing.T) {
+	params := ledger.NewMockAlonzoProtocolParams()
+
+	if params.ProtocolMajor != 5 {
+		t.Errorf("Expected ProtocolMajor 5, got %d", params.ProtocolMajor)
+	}
+
+	if params.AdaPerUtxoByte != 4310 {
+		t.Errorf("Expected AdaPerUtxoByte 4310, got %d", params.AdaPerUtxoByte)
+	}
+
+	// Check PlutusV1 cost model exists
+	if _, ok := params.CostModels[0]; !ok {
+		t.Error("Expected PlutusV1 cost model to exist")
+	}
+
+	if params.MaxCollateralInputs != 3 {
+		t.Errorf(
+			"Expected MaxCollateralInputs 3, got %d",
+			params.MaxCollateralInputs,
+		)
+	}
+
+	if params.CollateralPercentage != 150 {
+		t.Errorf(
+			"Expected CollateralPercentage 150, got %d",
+			params.CollateralPercentage,
+		)
+	}
+}
+
+func TestNewMockBabbageProtocolParams(t *testing.T) {
+	params := ledger.NewMockBabbageProtocolParams()
+
+	if params.ProtocolMajor != 7 {
+		t.Errorf("Expected ProtocolMajor 7, got %d", params.ProtocolMajor)
+	}
+
+	if params.MaxBlockBodySize != 90112 {
+		t.Errorf(
+			"Expected MaxBlockBodySize 90112, got %d",
+			params.MaxBlockBodySize,
+		)
+	}
+
+	// Check PlutusV1 and PlutusV2 cost models exist
+	if _, ok := params.CostModels[0]; !ok {
+		t.Error("Expected PlutusV1 cost model to exist")
+	}
+	if _, ok := params.CostModels[1]; !ok {
+		t.Error("Expected PlutusV2 cost model to exist")
+	}
+
+	if params.MinPoolCost != 170000000 {
+		t.Errorf("Expected MinPoolCost 170000000, got %d", params.MinPoolCost)
+	}
+}
+
+func TestNewMockConwayProtocolParams(t *testing.T) {
+	params := ledger.NewMockConwayProtocolParams()
+
+	if params.ProtocolVersion.Major != 9 {
+		t.Errorf(
+			"Expected ProtocolVersion.Major 9, got %d",
+			params.ProtocolVersion.Major,
+		)
+	}
+
+	// Check all Plutus cost models exist
+	if _, ok := params.CostModels[0]; !ok {
+		t.Error("Expected PlutusV1 cost model to exist")
+	}
+	if _, ok := params.CostModels[1]; !ok {
+		t.Error("Expected PlutusV2 cost model to exist")
+	}
+	if _, ok := params.CostModels[2]; !ok {
+		t.Error("Expected PlutusV3 cost model to exist")
+	}
+
+	// Check governance parameters
+	if params.MinCommitteeSize != 7 {
+		t.Errorf("Expected MinCommitteeSize 7, got %d", params.MinCommitteeSize)
+	}
+
+	if params.GovActionValidityPeriod != 6 {
+		t.Errorf(
+			"Expected GovActionValidityPeriod 6, got %d",
+			params.GovActionValidityPeriod,
+		)
+	}
+
+	if params.GovActionDeposit != 100000000000 {
+		t.Errorf(
+			"Expected GovActionDeposit 100000000000, got %d",
+			params.GovActionDeposit,
+		)
+	}
+
+	if params.DRepDeposit != 500000000 {
+		t.Errorf("Expected DRepDeposit 500000000, got %d", params.DRepDeposit)
+	}
+
+	if params.DRepInactivityPeriod != 20 {
+		t.Errorf(
+			"Expected DRepInactivityPeriod 20, got %d",
+			params.DRepInactivityPeriod,
+		)
+	}
+}
+
+// =============================================================================
+// Helper Function Tests
+// =============================================================================
+
+func TestNewSimpleTransaction(t *testing.T) {
+	txId := sampleTxId()
+	fee := uint64(200000)
+
+	input, _ := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x11}, 32)).
+		WithIndex(0).
+		Build()
+
+	output, _ := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+
+	tx, err := ledger.NewSimpleTransaction(
+		txId,
+		[]lcommon.TransactionInput{input},
+		[]lcommon.TransactionOutput{output},
+		fee,
+	)
+
+	if err != nil {
+		t.Fatalf("NewSimpleTransaction returned error: %v", err)
+	}
+
+	if tx.Fee().Cmp(big.NewInt(int64(fee))) != 0 {
+		t.Errorf("Expected fee %d, got %s", fee, tx.Fee())
+	}
+}
+
+func TestNewSimpleTransactionInput(t *testing.T) {
+	txId := sampleTxId()
+	index := uint32(5)
+
+	input, err := ledger.NewSimpleTransactionInput(txId, index)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionInput returned error: %v", err)
+	}
+
+	if input.Index() != index {
+		t.Errorf("Expected index %d, got %d", index, input.Index())
+	}
+}
+
+func TestNewSimpleTransactionOutput(t *testing.T) {
+	addr := sampleAddress()
+	lovelace := uint64(10000000)
+
+	output, err := ledger.NewSimpleTransactionOutput(addr, lovelace)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionOutput returned error: %v", err)
+	}
+
+	if output.Amount().Cmp(big.NewInt(int64(lovelace))) != 0 {
+		t.Errorf("Expected amount %d, got %s", lovelace, output.Amount())
+	}
+}
+
+// =============================================================================
+// MockTransactionInput Tests
+// =============================================================================
+
+func TestMockTransactionInput_String(t *testing.T) {
+	input, err := ledger.NewSimpleTransactionInput(sampleTxId(), 0)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionInput() returned error: %v", err)
+	}
+	str := input.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+}
+
+func TestMockTransactionInput_Utxorpc(t *testing.T) {
+	input, err := ledger.NewSimpleTransactionInput(sampleTxId(), 3)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionInput() returned error: %v", err)
+	}
+	utxorpc, err := input.Utxorpc()
+	if err != nil {
+		t.Fatalf("Utxorpc() returned error: %v", err)
+	}
+	if utxorpc.OutputIndex != 3 {
+		t.Errorf("Expected OutputIndex 3, got %d", utxorpc.OutputIndex)
+	}
+}
+
+// =============================================================================
+// MockTransactionOutput Tests
+// =============================================================================
+
+func TestMockTransactionOutput_String(t *testing.T) {
+	output, err := ledger.NewSimpleTransactionOutput(sampleAddress(), 5000000)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionOutput() returned error: %v", err)
+	}
+	str := output.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+}
+
+func TestMockTransactionOutput_Utxorpc(t *testing.T) {
+	output, err := ledger.NewSimpleTransactionOutput(sampleAddress(), 5000000)
+	if err != nil {
+		t.Fatalf("NewSimpleTransactionOutput() returned error: %v", err)
+	}
+	utxorpc, err := output.Utxorpc()
+	if err != nil {
+		t.Fatalf("Utxorpc() returned error: %v", err)
+	}
+	if utxorpc.Address == nil {
+		t.Error("Expected Address to be set")
+	}
+}
+
+// =============================================================================
+// MockTransaction Method Tests
+// =============================================================================
+
+func TestMockTransaction_Produced(t *testing.T) {
+	input, err := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x11}, 32)).
+		WithIndex(0).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionInputBuilder().Build() returned error: %v", err)
+	}
+
+	output1, err := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(3000000).
+		Build()
+	if err != nil {
+		t.Fatalf(
+			"NewTransactionOutputBuilder().Build() returned error: %v",
+			err,
+		)
+	}
+
+	output2, err := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(2000000).
+		Build()
+	if err != nil {
+		t.Fatalf(
+			"NewTransactionOutputBuilder().Build() returned error: %v",
+			err,
+		)
+	}
+
+	tx, err := ledger.NewTransactionBuilder().
+		WithId(sampleTxId()).
+		WithInputs(input).
+		WithOutputs(output1, output2).
+		WithFee(200000).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionBuilder().Build() returned error: %v", err)
+	}
+
+	produced := tx.Produced()
+	if produced == nil {
+		t.Fatal("Produced() returned nil")
+	}
+	if len(produced) != 2 {
+		t.Errorf("Expected 2 produced UTxOs, got %d", len(produced))
+	}
+
+	if produced[0].Id.Index() != 0 {
+		t.Errorf(
+			"Expected first produced UTxO index 0, got %d",
+			produced[0].Id.Index(),
+		)
+	}
+
+	if produced[1].Id.Index() != 1 {
+		t.Errorf(
+			"Expected second produced UTxO index 1, got %d",
+			produced[1].Id.Index(),
+		)
+	}
+}
+
+func TestMockTransaction_Consumed(t *testing.T) {
+	input1, err := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x11}, 32)).
+		WithIndex(0).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionInputBuilder().Build() returned error: %v", err)
+	}
+
+	input2, err := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x22}, 32)).
+		WithIndex(1).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionInputBuilder().Build() returned error: %v", err)
+	}
+
+	output, err := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+	if err != nil {
+		t.Fatalf(
+			"NewTransactionOutputBuilder().Build() returned error: %v",
+			err,
+		)
+	}
+
+	tx, err := ledger.NewTransactionBuilder().
+		WithId(sampleTxId()).
+		WithInputs(input1, input2).
+		WithOutputs(output).
+		WithFee(200000).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionBuilder().Build() returned error: %v", err)
+	}
+
+	consumed := tx.Consumed()
+	if len(consumed) != 2 {
+		t.Errorf("Expected 2 consumed inputs, got %d", len(consumed))
+	}
+}
+
+func TestMockTransaction_Witnesses(t *testing.T) {
+	input, err := ledger.NewTransactionInputBuilder().
+		WithTxId(bytes.Repeat([]byte{0x11}, 32)).
+		WithIndex(0).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionInputBuilder().Build() returned error: %v", err)
+	}
+
+	output, err := ledger.NewTransactionOutputBuilder().
+		WithAddress(sampleAddress()).
+		WithLovelace(5000000).
+		Build()
+	if err != nil {
+		t.Fatalf(
+			"NewTransactionOutputBuilder().Build() returned error: %v",
+			err,
+		)
+	}
+
+	tx, err := ledger.NewTransactionBuilder().
+		WithId(sampleTxId()).
+		WithInputs(input).
+		WithOutputs(output).
+		WithFee(200000).
+		Build()
+	if err != nil {
+		t.Fatalf("NewTransactionBuilder().Build() returned error: %v", err)
+	}
+
+	witnesses := tx.Witnesses()
+	if witnesses == nil {
+		t.Fatal("Expected Witnesses() to return non-nil value")
+	}
+}
+
+// =============================================================================
+// Plutus Language Constants Tests
+// =============================================================================
+
+func TestPlutusLanguageConstants(t *testing.T) {
+	if ledger.PlutusV1 != 1 {
+		t.Errorf("Expected PlutusV1 to be 1, got %d", ledger.PlutusV1)
+	}
+
+	if ledger.PlutusV2 != 2 {
+		t.Errorf("Expected PlutusV2 to be 2, got %d", ledger.PlutusV2)
+	}
+
+	if ledger.PlutusV3 != 3 {
+		t.Errorf("Expected PlutusV3 to be 3, got %d", ledger.PlutusV3)
+	}
+}
+
+// =============================================================================
+// ErrNotFound Tests
+// =============================================================================
+
+func TestErrNotFound(t *testing.T) {
+	if ledger.ErrNotFound == nil {
+		t.Fatal("ErrNotFound should not be nil")
+	}
+
+	if ledger.ErrNotFound.Error() != "ledger: not found" {
+		t.Errorf(
+			"Expected error message 'ledger: not found', got '%s'",
+			ledger.ErrNotFound.Error(),
+		)
+	}
+}

--- a/ledger/pools.go
+++ b/ledger/pools.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// PoolBuilder defines an interface for building mock pool registration certificates
+type PoolBuilder interface {
+	WithOperator(keyHash []byte) PoolBuilder
+	WithVrfKeyHash(hash []byte) PoolBuilder
+	WithPledge(lovelace uint64) PoolBuilder
+	WithCost(lovelace uint64) PoolBuilder
+	WithMargin(numerator, denominator uint64) PoolBuilder
+	WithRewardAccountKey(keyHash []byte) PoolBuilder
+	WithOwners(owners ...[]byte) PoolBuilder
+	WithRelays(relays ...lcommon.PoolRelay) PoolBuilder
+	WithMetadata(url string, hash []byte) PoolBuilder
+	Build() (*lcommon.PoolRegistrationCertificate, error)
+}
+
+// MockPool holds the state for building a pool registration certificate
+type MockPool struct {
+	operator        lcommon.PoolKeyHash
+	vrfKeyHash      lcommon.VrfKeyHash
+	vrfKeyHashErr   error // tracks VRF key hash validation error
+	pledge          uint64
+	cost            uint64
+	margin          cbor.Rat
+	marginDenomZero bool // tracks if denominator was set to zero
+	rewardAccount   lcommon.AddrKeyHash
+	poolOwners      []lcommon.AddrKeyHash
+	relays          []lcommon.PoolRelay
+	poolMetadata    *lcommon.PoolMetadata
+	metadataHashErr error // tracks metadata hash validation error
+}
+
+// NewPoolBuilder creates a new MockPool builder
+func NewPoolBuilder() *MockPool {
+	return &MockPool{
+		margin: cbor.Rat{Rat: big.NewRat(0, 1)},
+	}
+}
+
+// WithOperator sets the pool operator key hash
+func (p *MockPool) WithOperator(keyHash []byte) PoolBuilder {
+	p.operator = lcommon.NewBlake2b224(keyHash)
+	return p
+}
+
+// WithVrfKeyHash sets the VRF key hash
+// If hash length is not exactly 32 bytes, Build() will return an error
+func (p *MockPool) WithVrfKeyHash(hash []byte) PoolBuilder {
+	if len(hash) != len(p.vrfKeyHash) {
+		p.vrfKeyHashErr = fmt.Errorf(
+			"VRF key hash must be exactly %d bytes, got %d",
+			len(p.vrfKeyHash),
+			len(hash),
+		)
+		return p
+	}
+	// Clear any previous error when valid hash is provided
+	p.vrfKeyHashErr = nil
+	copy(p.vrfKeyHash[:], hash)
+	return p
+}
+
+// WithPledge sets the pool pledge amount in lovelace
+func (p *MockPool) WithPledge(lovelace uint64) PoolBuilder {
+	p.pledge = lovelace
+	return p
+}
+
+// WithCost sets the pool fixed cost in lovelace
+func (p *MockPool) WithCost(lovelace uint64) PoolBuilder {
+	p.cost = lovelace
+	return p
+}
+
+// WithMargin sets the pool margin as a ratio (numerator/denominator)
+// If denominator is zero, Build() will return an error
+func (p *MockPool) WithMargin(numerator, denominator uint64) PoolBuilder {
+	if denominator == 0 {
+		p.marginDenomZero = true
+		return p
+	}
+	// Clear any previous error flag when valid denominator is provided
+	p.marginDenomZero = false
+	// #nosec G115 - margin values are expected to be small rational numbers
+	p.margin = cbor.Rat{Rat: big.NewRat(int64(numerator), int64(denominator))}
+	return p
+}
+
+// WithRewardAccountKey sets the pool reward account key hash
+// The keyHash should be a Blake2b224 hash (28 bytes)
+func (p *MockPool) WithRewardAccountKey(keyHash []byte) PoolBuilder {
+	p.rewardAccount = lcommon.NewBlake2b224(keyHash)
+	return p
+}
+
+// WithOwners sets the pool owners
+func (p *MockPool) WithOwners(owners ...[]byte) PoolBuilder {
+	p.poolOwners = make([]lcommon.AddrKeyHash, len(owners))
+	for i, owner := range owners {
+		p.poolOwners[i] = lcommon.NewBlake2b224(owner)
+	}
+	return p
+}
+
+// WithRelays sets the pool relays
+func (p *MockPool) WithRelays(relays ...lcommon.PoolRelay) PoolBuilder {
+	p.relays = relays
+	return p
+}
+
+// WithMetadata sets the pool metadata URL and hash
+// If hash length is not exactly 32 bytes, Build() will return an error
+func (p *MockPool) WithMetadata(url string, hash []byte) PoolBuilder {
+	var metadataHash lcommon.PoolMetadataHash
+	if len(hash) != len(metadataHash) {
+		p.metadataHashErr = fmt.Errorf(
+			"pool metadata hash must be exactly %d bytes, got %d",
+			len(metadataHash),
+			len(hash),
+		)
+		return p
+	}
+	// Clear any previous error when valid hash is provided
+	p.metadataHashErr = nil
+	copy(metadataHash[:], hash)
+	p.poolMetadata = &lcommon.PoolMetadata{
+		Url:  url,
+		Hash: metadataHash,
+	}
+	return p
+}
+
+// Build constructs a PoolRegistrationCertificate from the builder state
+func (p *MockPool) Build() (*lcommon.PoolRegistrationCertificate, error) {
+	// Return any stored validation errors
+	if p.vrfKeyHashErr != nil {
+		return nil, p.vrfKeyHashErr
+	}
+	if p.metadataHashErr != nil {
+		return nil, p.metadataHashErr
+	}
+	// Validate margin denominator was not zero
+	if p.marginDenomZero {
+		return nil, errors.New("pool margin denominator cannot be zero")
+	}
+
+	cert := &lcommon.PoolRegistrationCertificate{
+		CertType:      3, // Pool registration certificate type
+		Operator:      p.operator,
+		VrfKeyHash:    p.vrfKeyHash,
+		Pledge:        p.pledge,
+		Cost:          p.cost,
+		Margin:        p.margin,
+		RewardAccount: p.rewardAccount,
+		PoolOwners:    p.poolOwners,
+		Relays:        p.relays,
+		PoolMetadata:  p.poolMetadata,
+	}
+	return cert, nil
+}

--- a/ledger/pparams.go
+++ b/ledger/pparams.go
@@ -1,0 +1,351 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// Helper function to create a cbor.Rat from numerator and denominator
+func newRat(num, denom int64) *cbor.Rat {
+	return &cbor.Rat{Rat: big.NewRat(num, denom)}
+}
+
+// MockByronProtocolParams represents mock Byron protocol parameters.
+// Note: Byron doesn't have a formal ProtocolParameters struct in gouroboros,
+// but these values represent typical Byron-era parameters.
+type MockByronProtocolParams struct {
+	ScriptVersion     uint16
+	SlotDuration      uint64 // milliseconds
+	MaxBlockSize      uint64
+	MaxHeaderSize     uint64
+	MaxTxSize         uint64
+	MaxProposalSize   uint64
+	MpcThd            uint64
+	HeavyDelThd       uint64
+	UpdateVoteThd     uint64
+	UpdateProposalThd uint64
+	UpdateImplicit    uint64
+	SoftForkRule      [3]uint64 // [initThd, minThd, thdDecrement]
+	TxFeePolicy       [2]uint64 // [summand, multiplier] - fee = summand + multiplier * txSize
+	UnlockStakeEpoch  uint64
+}
+
+// NewMockByronProtocolParams returns mock Byron protocol parameters
+// with typical mainnet values
+func NewMockByronProtocolParams() MockByronProtocolParams {
+	return MockByronProtocolParams{
+		ScriptVersion:     0,
+		SlotDuration:      20000, // 20 seconds
+		MaxBlockSize:      2000000,
+		MaxHeaderSize:     2000000,
+		MaxTxSize:         8192,
+		MaxProposalSize:   700,
+		MpcThd:            20000000000000, // 2% of total stake
+		HeavyDelThd:       300000000000,   // 0.03% of total stake
+		UpdateVoteThd:     1000000000000,  // 0.1% of total stake
+		UpdateProposalThd: 100000000000,   // 0.01% of total stake
+		UpdateImplicit:    10000,          // slots
+		SoftForkRule: [3]uint64{
+			900000000000000,
+			600000000000000,
+			50000000000000,
+		},
+		TxFeePolicy:      [2]uint64{155381, 44}, // fee = 155381 + 44 * txSize
+		UnlockStakeEpoch: 18446744073709551615,  // max uint64 (never)
+	}
+}
+
+// NewMockShelleyProtocolParams returns mock Shelley protocol parameters
+// with typical mainnet values at Shelley launch
+func NewMockShelleyProtocolParams() shelley.ShelleyProtocolParameters {
+	return shelley.ShelleyProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,         // 2 ADA
+		PoolDeposit:        500000000,       // 500 ADA
+		MaxEpoch:           18,              // pool retirement max epochs
+		NOpt:               150,             // desired number of pools
+		A0:                 newRat(3, 10),   // pool influence factor 0.3
+		Rho:                newRat(3, 1000), // monetary expansion 0.003
+		Tau:                newRat(2, 10),   // treasury cut 0.2
+		Decentralization: newRat(
+			1,
+			1,
+		), // d=1 means fully federated (Shelley launch)
+		ExtraEntropy:  lcommon.Nonce{}, // neutral nonce
+		ProtocolMajor: 2,
+		ProtocolMinor: 0,
+		MinUtxoValue:  1000000, // 1 ADA minimum UTxO
+	}
+}
+
+// NewMockAllegraProtocolParams returns mock Allegra protocol parameters
+// Allegra uses the same parameter structure as Shelley
+func NewMockAllegraProtocolParams() shelley.ShelleyProtocolParameters {
+	params := NewMockShelleyProtocolParams()
+	params.ProtocolMajor = 3
+	params.ProtocolMinor = 0
+	return params
+}
+
+// NewMockMaryProtocolParams returns mock Mary protocol parameters
+// with typical mainnet values
+func NewMockMaryProtocolParams() mary.MaryProtocolParameters {
+	return mary.MaryProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,   // 2 ADA
+		PoolDeposit:        500000000, // 500 ADA
+		MaxEpoch:           18,
+		NOpt:               500,             // increased from Shelley
+		A0:                 newRat(3, 10),   // 0.3
+		Rho:                newRat(3, 1000), // 0.003
+		Tau:                newRat(2, 10),   // 0.2
+		Decentralization:   newRat(0, 1),    // fully decentralized (d=0)
+		ExtraEntropy:       lcommon.Nonce{},
+		ProtocolMajor:      4,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000000,   // 1 ADA
+		MinPoolCost:        340000000, // 340 ADA minimum pool cost
+	}
+}
+
+// NewMockAlonzoProtocolParams returns mock Alonzo protocol parameters
+// with typical mainnet values including Plutus support
+func NewMockAlonzoProtocolParams() alonzo.AlonzoProtocolParameters {
+	return alonzo.AlonzoProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   73728, // increased for smart contracts
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		Decentralization:   newRat(0, 1),
+		ExtraEntropy:       lcommon.Nonce{},
+		ProtocolMajor:      5,
+		ProtocolMinor:      0,
+		MinUtxoValue:       0, // deprecated, use AdaPerUtxoByte
+		MinPoolCost:        340000000,
+		AdaPerUtxoByte:     4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(), // PlutusV1
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),    // 0.0577 lovelace per memory unit
+			StepPrice: newRat(721, 10000000), // 0.0000721 lovelace per step
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 10000000,    // 10M memory units
+			Steps:  10000000000, // 10B CPU steps
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 50000000,    // 50M memory units
+			Steps:  40000000000, // 40B CPU steps
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150, // 150% collateral required
+		MaxCollateralInputs:  3,
+	}
+}
+
+// NewMockBabbageProtocolParams returns mock Babbage protocol parameters
+// with typical mainnet values including reference scripts
+func NewMockBabbageProtocolParams() babbage.BabbageProtocolParameters {
+	return babbage.BabbageProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   90112, // increased from Alonzo
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		ProtocolMajor:      7,
+		ProtocolMinor:      0,
+		MinPoolCost:        170000000, // reduced to 170 ADA
+		AdaPerUtxoByte:     4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(),
+			1: mockPlutusV2CostModel(),
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),
+			StepPrice: newRat(721, 10000000),
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 14000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+	}
+}
+
+// NewMockConwayProtocolParams returns mock Conway protocol parameters
+// with typical mainnet values including governance parameters
+func NewMockConwayProtocolParams() conway.ConwayProtocolParameters {
+	return conway.ConwayProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   90112,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 9,
+			Minor: 0,
+		},
+		MinPoolCost:    170000000,
+		AdaPerUtxoByte: 4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(),
+			1: mockPlutusV2CostModel(),
+			2: mockPlutusV3CostModel(),
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),
+			StepPrice: newRat(721, 10000000),
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 14000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+		// Conway governance parameters
+		PoolVotingThresholds: conway.PoolVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(51, 100)}, // 51%
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(51, 100)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(51, 100)},
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(51, 100)},
+			PpSecurityGroup:       cbor.Rat{Rat: big.NewRat(51, 100)},
+		},
+		DRepVotingThresholds: conway.DRepVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(67, 100)}, // 67%
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(67, 100)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(60, 100)}, // 60%
+			UpdateToConstitution:  cbor.Rat{Rat: big.NewRat(75, 100)}, // 75%
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(60, 100)},
+			PpNetworkGroup:        cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpEconomicGroup:       cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpTechnicalGroup:      cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpGovGroup:            cbor.Rat{Rat: big.NewRat(75, 100)},
+			TreasuryWithdrawal:    cbor.Rat{Rat: big.NewRat(67, 100)},
+		},
+		MinCommitteeSize:           7,
+		CommitteeTermLimit:         146,          // ~2 years in epochs
+		GovActionValidityPeriod:    6,            // epochs
+		GovActionDeposit:           100000000000, // 100,000 ADA
+		DRepDeposit:                500000000,    // 500 ADA
+		DRepInactivityPeriod:       20,           // epochs
+		MinFeeRefScriptCostPerByte: newRat(15, 1),
+	}
+}
+
+// mockPlutusV1CostModel returns a mock Plutus V1 cost model (166 parameters)
+func mockPlutusV1CostModel() []int64 {
+	// These are representative values, not actual mainnet values
+	// PlutusV1 has 166 parameters
+	costModel := make([]int64, 166)
+
+	// Set some representative values for common operations
+	// Integer operations
+	costModel[0] = 205665 // addInteger-cpu-arguments-intercept
+	costModel[1] = 812    // addInteger-cpu-arguments-slope
+	costModel[2] = 1      // addInteger-memory-arguments-intercept
+	costModel[3] = 1      // addInteger-memory-arguments-slope
+
+	// Fill remaining with reasonable defaults
+	for i := 4; i < 166; i++ {
+		costModel[i] = 1000 + int64(i*100)
+	}
+
+	return costModel
+}
+
+// mockPlutusV2CostModel returns a mock Plutus V2 cost model (175 parameters)
+func mockPlutusV2CostModel() []int64 {
+	// PlutusV2 has 175 parameters (166 from V1 + 9 new)
+	costModel := make([]int64, 175)
+
+	// Copy V1 model as base
+	v1Model := mockPlutusV1CostModel()
+	copy(costModel, v1Model)
+
+	// Add V2 specific parameters
+	for i := 166; i < 175; i++ {
+		costModel[i] = 2000 + int64(i*50)
+	}
+
+	return costModel
+}
+
+// mockPlutusV3CostModel returns a mock Plutus V3 cost model (223 parameters)
+func mockPlutusV3CostModel() []int64 {
+	// PlutusV3 has 223 parameters
+	costModel := make([]int64, 223)
+
+	// Copy V2 model as base
+	v2Model := mockPlutusV2CostModel()
+	copy(costModel, v2Model)
+
+	// Add V3 specific parameters
+	for i := 175; i < 223; i++ {
+		costModel[i] = 3000 + int64(i*50)
+	}
+
+	return costModel
+}

--- a/ledger/rewards.go
+++ b/ledger/rewards.go
@@ -1,0 +1,276 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// AdaPotsBuilder defines an interface for building mock AdaPots
+type AdaPotsBuilder interface {
+	WithReserves(lovelace uint64) AdaPotsBuilder
+	WithTreasury(lovelace uint64) AdaPotsBuilder
+	WithRewards(lovelace uint64) AdaPotsBuilder
+	Build() (*lcommon.AdaPots, error)
+}
+
+// MockAdaPots holds the state for building AdaPots
+type MockAdaPots struct {
+	reserves uint64
+	treasury uint64
+	rewards  uint64
+}
+
+// NewAdaPotsBuilder creates a new MockAdaPots builder
+func NewAdaPotsBuilder() *MockAdaPots {
+	return &MockAdaPots{}
+}
+
+// WithReserves sets the reserves pot
+func (m *MockAdaPots) WithReserves(lovelace uint64) AdaPotsBuilder {
+	m.reserves = lovelace
+	return m
+}
+
+// WithTreasury sets the treasury pot
+func (m *MockAdaPots) WithTreasury(lovelace uint64) AdaPotsBuilder {
+	m.treasury = lovelace
+	return m
+}
+
+// WithRewards sets the rewards pot
+func (m *MockAdaPots) WithRewards(lovelace uint64) AdaPotsBuilder {
+	m.rewards = lovelace
+	return m
+}
+
+// Build constructs an AdaPots from the builder state
+func (m *MockAdaPots) Build() (*lcommon.AdaPots, error) {
+	pots := &lcommon.AdaPots{
+		Reserves: m.reserves,
+		Treasury: m.treasury,
+		Rewards:  m.rewards,
+	}
+	return pots, nil
+}
+
+// RewardSnapshotBuilder defines an interface for building mock RewardSnapshots
+type RewardSnapshotBuilder interface {
+	WithTotalActiveStake(stake uint64) RewardSnapshotBuilder
+	WithPoolStake(pool lcommon.PoolKeyHash, stake uint64) RewardSnapshotBuilder
+	WithDelegatorStake(delegator []byte, stake uint64) RewardSnapshotBuilder
+	WithDelegatorStakeForPool(
+		pool lcommon.PoolKeyHash,
+		delegator []byte,
+		stake uint64,
+	) RewardSnapshotBuilder
+	WithPoolParams(
+		pool lcommon.PoolKeyHash,
+		cert *lcommon.PoolRegistrationCertificate,
+	) RewardSnapshotBuilder
+	WithPoolBlocks(pool lcommon.PoolKeyHash, blocks uint64) RewardSnapshotBuilder
+	Build() (*lcommon.RewardSnapshot, error)
+}
+
+// MockRewardSnapshot holds the state for building a RewardSnapshot
+type MockRewardSnapshot struct {
+	totalActiveStake uint64
+	poolStake        map[lcommon.PoolKeyHash]uint64
+	delegatorStake   map[lcommon.PoolKeyHash]map[lcommon.AddrKeyHash]uint64
+	poolParams       map[lcommon.PoolKeyHash]*lcommon.PoolRegistrationCertificate
+	poolBlocks       map[lcommon.PoolKeyHash]uint32
+	// Track which pool a delegator belongs to for delegator stake
+	delegatorPools    map[lcommon.AddrKeyHash]lcommon.PoolKeyHash
+	poolBlocksErr     error // tracks if pool blocks exceeded uint32
+	delegatorStakeErr error // tracks if delegator stake was called with no pools
+}
+
+// NewRewardSnapshotBuilder creates a new MockRewardSnapshot builder
+func NewRewardSnapshotBuilder() *MockRewardSnapshot {
+	return &MockRewardSnapshot{
+		poolStake: make(map[lcommon.PoolKeyHash]uint64),
+		delegatorStake: make(
+			map[lcommon.PoolKeyHash]map[lcommon.AddrKeyHash]uint64,
+		),
+		poolParams: make(
+			map[lcommon.PoolKeyHash]*lcommon.PoolRegistrationCertificate,
+		),
+		poolBlocks:     make(map[lcommon.PoolKeyHash]uint32),
+		delegatorPools: make(map[lcommon.AddrKeyHash]lcommon.PoolKeyHash),
+	}
+}
+
+// WithTotalActiveStake sets the total active stake in the system
+func (m *MockRewardSnapshot) WithTotalActiveStake(
+	stake uint64,
+) RewardSnapshotBuilder {
+	m.totalActiveStake = stake
+	return m
+}
+
+// WithPoolStake sets the stake for a specific pool
+func (m *MockRewardSnapshot) WithPoolStake(
+	pool lcommon.PoolKeyHash,
+	stake uint64,
+) RewardSnapshotBuilder {
+	m.poolStake[pool] = stake
+	// Clear any previous delegatorStakeErr since pools now exist
+	m.delegatorStakeErr = nil
+	return m
+}
+
+// WithDelegatorStake sets the stake for a delegator
+// This selects the lexicographically smallest pool key from the existing pool
+// stake map for deterministic behavior. For explicit pool selection, use
+// WithDelegatorStakeForPool instead. If no pools exist, Build() will return
+// an error.
+func (m *MockRewardSnapshot) WithDelegatorStake(
+	delegator []byte,
+	stake uint64,
+) RewardSnapshotBuilder {
+	// Fail-fast if no pools exist
+	if len(m.poolStake) == 0 {
+		m.delegatorStakeErr = errors.New(
+			"WithDelegatorStake called but no pools exist; call WithPoolStake first",
+		)
+		return m
+	}
+
+	delegatorKey := lcommon.NewBlake2b224(delegator)
+
+	// Collect pool keys and sort for deterministic selection
+	pools := make([]lcommon.PoolKeyHash, 0, len(m.poolStake))
+	for p := range m.poolStake {
+		pools = append(pools, p)
+	}
+	slices.SortFunc(pools, func(a, b lcommon.PoolKeyHash) int {
+		return bytes.Compare(a.Bytes(), b.Bytes())
+	})
+	// Select the lexicographically smallest pool
+	pool := pools[0]
+
+	if m.delegatorStake[pool] == nil {
+		m.delegatorStake[pool] = make(map[lcommon.AddrKeyHash]uint64)
+	}
+	m.delegatorStake[pool][delegatorKey] = stake
+	m.delegatorPools[delegatorKey] = pool
+	return m
+}
+
+// WithDelegatorStakeForPool sets the stake for a delegator associated with a specific pool
+func (m *MockRewardSnapshot) WithDelegatorStakeForPool(
+	pool lcommon.PoolKeyHash,
+	delegator []byte,
+	stake uint64,
+) RewardSnapshotBuilder {
+	delegatorKey := lcommon.NewBlake2b224(delegator)
+
+	if m.delegatorStake[pool] == nil {
+		m.delegatorStake[pool] = make(map[lcommon.AddrKeyHash]uint64)
+	}
+	m.delegatorStake[pool][delegatorKey] = stake
+	m.delegatorPools[delegatorKey] = pool
+	return m
+}
+
+// WithPoolParams sets the pool parameters for a specific pool
+func (m *MockRewardSnapshot) WithPoolParams(
+	pool lcommon.PoolKeyHash,
+	cert *lcommon.PoolRegistrationCertificate,
+) RewardSnapshotBuilder {
+	m.poolParams[pool] = cert
+	return m
+}
+
+// WithPoolBlocks sets the number of blocks produced by a pool
+// If blocks exceeds uint32 max value, Build() will return an error
+func (m *MockRewardSnapshot) WithPoolBlocks(
+	pool lcommon.PoolKeyHash,
+	blocks uint64,
+) RewardSnapshotBuilder {
+	if blocks > math.MaxUint32 {
+		m.poolBlocksErr = fmt.Errorf(
+			"blocks %d exceeds maximum uint32 value",
+			blocks,
+		)
+		return m
+	}
+	m.poolBlocks[pool] = uint32(blocks)
+	return m
+}
+
+// Build constructs a RewardSnapshot from the builder state
+func (m *MockRewardSnapshot) Build() (*lcommon.RewardSnapshot, error) {
+	// Check for validation errors
+	if m.poolBlocksErr != nil {
+		return nil, m.poolBlocksErr
+	}
+	if m.delegatorStakeErr != nil {
+		return nil, m.delegatorStakeErr
+	}
+
+	// Calculate total blocks in uint64 to detect overflow
+	var totalBlocksSum uint64
+	for _, blocks := range m.poolBlocks {
+		totalBlocksSum += uint64(blocks)
+	}
+	if totalBlocksSum > math.MaxUint32 {
+		return nil, fmt.Errorf(
+			"total blocks %d exceeds maximum uint32 value",
+			totalBlocksSum,
+		)
+	}
+	totalBlocks := uint32(totalBlocksSum)
+
+	snapshot := &lcommon.RewardSnapshot{
+		TotalActiveStake:     m.totalActiveStake,
+		PoolStake:            m.poolStake,
+		DelegatorStake:       m.delegatorStake,
+		PoolParams:           m.poolParams,
+		StakeRegistrations:   make(map[lcommon.AddrKeyHash]bool),
+		PoolBlocks:           m.poolBlocks,
+		TotalBlocksInEpoch:   totalBlocks,
+		EarlyDeregistrations: make(map[lcommon.AddrKeyHash]uint64),
+		LateDeregistrations:  make(map[lcommon.AddrKeyHash]uint64),
+		RetiredPools: make(
+			map[lcommon.PoolKeyHash]lcommon.PoolRetirementInfo,
+		),
+		StakeKeyPoolAssociations: make(
+			map[lcommon.AddrKeyHash][]lcommon.PoolKeyHash,
+		),
+	}
+
+	// Mark all delegators as registered
+	for _, delegators := range m.delegatorStake {
+		for delegator := range delegators {
+			snapshot.StakeRegistrations[delegator] = true
+		}
+	}
+
+	// Populate stake key pool associations from delegator pools
+	for delegator, pool := range m.delegatorPools {
+		snapshot.StakeKeyPoolAssociations[delegator] = []lcommon.PoolKeyHash{
+			pool,
+		}
+	}
+
+	return snapshot, nil
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1,0 +1,436 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ErrNotFound is returned when a requested item is not found
+var ErrNotFound = errors.New("ledger: not found")
+
+// PlutusLanguage represents a Plutus language version
+type PlutusLanguage uint
+
+const (
+	PlutusV1 PlutusLanguage = 1
+	PlutusV2 PlutusLanguage = 2
+	PlutusV3 PlutusLanguage = 3
+)
+
+// CostModel represents a Plutus cost model
+type CostModel []int64
+
+// UtxoByIdFunc is a callback for UTxO lookups by transaction input
+type UtxoByIdFunc func(lcommon.TransactionInput) (lcommon.Utxo, error)
+
+// StakeRegistrationFunc is a callback for stake registration lookups
+type StakeRegistrationFunc func([]byte) ([]lcommon.StakeRegistrationCertificate, error)
+
+// SlotToTimeFunc is a callback for converting slots to time
+type SlotToTimeFunc func(uint64) (time.Time, error)
+
+// TimeToSlotFunc is a callback for converting time to slots
+type TimeToSlotFunc func(time.Time) (uint64, error)
+
+// PoolCurrentStateFunc is a callback for pool state lookups
+type PoolCurrentStateFunc func(lcommon.PoolKeyHash) (*lcommon.PoolRegistrationCertificate, *uint64, error)
+
+// CalculateRewardsFunc is a callback for reward calculation
+type CalculateRewardsFunc func(lcommon.AdaPots, lcommon.RewardSnapshot, lcommon.RewardParameters) (*lcommon.RewardCalculationResult, error)
+
+// GetRewardSnapshotFunc is a callback for reward snapshot lookups
+type GetRewardSnapshotFunc func(uint64) (lcommon.RewardSnapshot, error)
+
+// CommitteeMemberFunc is a callback for committee member lookups
+type CommitteeMemberFunc func(lcommon.Blake2b224) (*CommitteeMember, error)
+
+// DRepRegistrationFunc is a callback for DRep registration lookups
+type DRepRegistrationFunc func(lcommon.Blake2b224) (*lcommon.RegistrationDrepCertificate, error)
+
+// ConstitutionFunc is a callback for constitution lookups
+type ConstitutionFunc func() (*Constitution, error)
+
+// TreasuryValueFunc is a callback for treasury value lookups
+type TreasuryValueFunc func() (uint64, error)
+
+// CostModelsFunc is a callback for cost models lookups
+type CostModelsFunc func() map[PlutusLanguage]CostModel
+
+// MockLedgerState implements the ledger.LedgerState interface from gouroboros
+// using callback functions for customizable behavior
+type MockLedgerState struct {
+	// UtxoState callbacks
+	UtxoByIdCallback UtxoByIdFunc
+
+	// CertState callbacks
+	StakeRegistrationCallback StakeRegistrationFunc
+
+	// SlotState callbacks
+	SlotToTimeCallback SlotToTimeFunc
+	TimeToSlotCallback TimeToSlotFunc
+
+	// PoolState callbacks
+	PoolCurrentStateCallback PoolCurrentStateFunc
+
+	// RewardState callbacks
+	CalculateRewardsCallback  CalculateRewardsFunc
+	GetRewardSnapshotCallback GetRewardSnapshotFunc
+
+	// GovState callbacks (for future governance queries)
+	CommitteeMemberCallback  CommitteeMemberFunc
+	DRepRegistrationCallback DRepRegistrationFunc
+	ConstitutionCallback     ConstitutionFunc
+	TreasuryValueCallback    TreasuryValueFunc
+	CostModelsCallback       CostModelsFunc
+
+	// Static fields
+	networkId uint
+	adaPots   lcommon.AdaPots
+}
+
+// NetworkId returns the network identifier
+func (ls *MockLedgerState) NetworkId() uint {
+	return ls.networkId
+}
+
+// UtxoById looks up a UTxO by transaction input
+func (ls *MockLedgerState) UtxoById(
+	id lcommon.TransactionInput,
+) (lcommon.Utxo, error) {
+	if ls.UtxoByIdCallback != nil {
+		return ls.UtxoByIdCallback(id)
+	}
+	return lcommon.Utxo{}, ErrNotFound
+}
+
+// StakeRegistration looks up stake registrations by staking key
+func (ls *MockLedgerState) StakeRegistration(
+	stakingKey []byte,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	if ls.StakeRegistrationCallback != nil {
+		return ls.StakeRegistrationCallback(stakingKey)
+	}
+	return []lcommon.StakeRegistrationCertificate{}, nil
+}
+
+// SlotToTime converts a slot number to a time
+func (ls *MockLedgerState) SlotToTime(slot uint64) (time.Time, error) {
+	if ls.SlotToTimeCallback != nil {
+		return ls.SlotToTimeCallback(slot)
+	}
+	return time.Time{}, nil
+}
+
+// TimeToSlot converts a time to a slot number
+func (ls *MockLedgerState) TimeToSlot(t time.Time) (uint64, error) {
+	if ls.TimeToSlotCallback != nil {
+		return ls.TimeToSlotCallback(t)
+	}
+	return 0, nil
+}
+
+// PoolCurrentState returns the current state of a pool
+func (ls *MockLedgerState) PoolCurrentState(
+	poolKeyHash lcommon.PoolKeyHash,
+) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
+	if ls.PoolCurrentStateCallback != nil {
+		return ls.PoolCurrentStateCallback(poolKeyHash)
+	}
+	return nil, nil, nil
+}
+
+// CalculateRewards calculates rewards for the given epoch
+func (ls *MockLedgerState) CalculateRewards(
+	pots lcommon.AdaPots,
+	snapshot lcommon.RewardSnapshot,
+	params lcommon.RewardParameters,
+) (*lcommon.RewardCalculationResult, error) {
+	if ls.CalculateRewardsCallback != nil {
+		return ls.CalculateRewardsCallback(pots, snapshot, params)
+	}
+	return lcommon.CalculateRewards(pots, snapshot, params)
+}
+
+// GetAdaPots returns the current ADA pots
+func (ls *MockLedgerState) GetAdaPots() lcommon.AdaPots {
+	return ls.adaPots
+}
+
+// UpdateAdaPots updates the ADA pots
+func (ls *MockLedgerState) UpdateAdaPots(pots lcommon.AdaPots) error {
+	ls.adaPots = pots
+	return nil
+}
+
+// GetRewardSnapshot returns the stake snapshot for reward calculation
+func (ls *MockLedgerState) GetRewardSnapshot(
+	epoch uint64,
+) (lcommon.RewardSnapshot, error) {
+	if ls.GetRewardSnapshotCallback != nil {
+		return ls.GetRewardSnapshotCallback(epoch)
+	}
+	return lcommon.RewardSnapshot{}, nil
+}
+
+// CommitteeMember looks up a constitutional committee member by credential hash
+func (ls *MockLedgerState) CommitteeMember(
+	credHash lcommon.Blake2b224,
+) (*CommitteeMember, error) {
+	if ls.CommitteeMemberCallback != nil {
+		return ls.CommitteeMemberCallback(credHash)
+	}
+	return nil, ErrNotFound
+}
+
+// DRepRegistration looks up a DRep registration by credential hash
+func (ls *MockLedgerState) DRepRegistration(
+	credHash lcommon.Blake2b224,
+) (*lcommon.RegistrationDrepCertificate, error) {
+	if ls.DRepRegistrationCallback != nil {
+		return ls.DRepRegistrationCallback(credHash)
+	}
+	return nil, ErrNotFound
+}
+
+// Constitution returns the current constitution
+func (ls *MockLedgerState) Constitution() (*Constitution, error) {
+	if ls.ConstitutionCallback != nil {
+		return ls.ConstitutionCallback()
+	}
+	return nil, ErrNotFound
+}
+
+// TreasuryValue returns the current treasury value
+func (ls *MockLedgerState) TreasuryValue() (uint64, error) {
+	if ls.TreasuryValueCallback != nil {
+		return ls.TreasuryValueCallback()
+	}
+	return ls.adaPots.Treasury, nil
+}
+
+// CostModels returns the current cost models for Plutus scripts
+func (ls *MockLedgerState) CostModels() map[PlutusLanguage]CostModel {
+	if ls.CostModelsCallback != nil {
+		return ls.CostModelsCallback()
+	}
+	return make(map[PlutusLanguage]CostModel)
+}
+
+// LedgerStateBuilder provides a fluent API for setting up MockLedgerState
+type LedgerStateBuilder struct {
+	state *MockLedgerState
+}
+
+// NewLedgerStateBuilder creates a new LedgerStateBuilder
+func NewLedgerStateBuilder() *LedgerStateBuilder {
+	return &LedgerStateBuilder{
+		state: &MockLedgerState{},
+	}
+}
+
+// WithNetworkId sets the network ID
+func (b *LedgerStateBuilder) WithNetworkId(networkId uint) *LedgerStateBuilder {
+	b.state.networkId = networkId
+	return b
+}
+
+// WithAdaPots sets the ADA pots
+func (b *LedgerStateBuilder) WithAdaPots(
+	pots lcommon.AdaPots,
+) *LedgerStateBuilder {
+	b.state.adaPots = pots
+	return b
+}
+
+// WithUtxoById sets the UTxO lookup callback
+func (b *LedgerStateBuilder) WithUtxoById(fn UtxoByIdFunc) *LedgerStateBuilder {
+	b.state.UtxoByIdCallback = fn
+	return b
+}
+
+// WithStakeRegistration sets the stake registration lookup callback
+func (b *LedgerStateBuilder) WithStakeRegistration(
+	fn StakeRegistrationFunc,
+) *LedgerStateBuilder {
+	b.state.StakeRegistrationCallback = fn
+	return b
+}
+
+// WithSlotToTime sets the slot to time conversion callback
+func (b *LedgerStateBuilder) WithSlotToTime(
+	fn SlotToTimeFunc,
+) *LedgerStateBuilder {
+	b.state.SlotToTimeCallback = fn
+	return b
+}
+
+// WithTimeToSlot sets the time to slot conversion callback
+func (b *LedgerStateBuilder) WithTimeToSlot(
+	fn TimeToSlotFunc,
+) *LedgerStateBuilder {
+	b.state.TimeToSlotCallback = fn
+	return b
+}
+
+// WithPoolCurrentState sets the pool current state callback
+func (b *LedgerStateBuilder) WithPoolCurrentState(
+	fn PoolCurrentStateFunc,
+) *LedgerStateBuilder {
+	b.state.PoolCurrentStateCallback = fn
+	return b
+}
+
+// WithCalculateRewards sets the calculate rewards callback
+func (b *LedgerStateBuilder) WithCalculateRewards(
+	fn CalculateRewardsFunc,
+) *LedgerStateBuilder {
+	b.state.CalculateRewardsCallback = fn
+	return b
+}
+
+// WithGetRewardSnapshot sets the get reward snapshot callback
+func (b *LedgerStateBuilder) WithGetRewardSnapshot(
+	fn GetRewardSnapshotFunc,
+) *LedgerStateBuilder {
+	b.state.GetRewardSnapshotCallback = fn
+	return b
+}
+
+// WithCommitteeMember sets the committee member lookup callback
+func (b *LedgerStateBuilder) WithCommitteeMember(
+	fn CommitteeMemberFunc,
+) *LedgerStateBuilder {
+	b.state.CommitteeMemberCallback = fn
+	return b
+}
+
+// WithDRepRegistration sets the DRep registration lookup callback
+func (b *LedgerStateBuilder) WithDRepRegistration(
+	fn DRepRegistrationFunc,
+) *LedgerStateBuilder {
+	b.state.DRepRegistrationCallback = fn
+	return b
+}
+
+// WithConstitution sets the constitution lookup callback
+func (b *LedgerStateBuilder) WithConstitution(
+	fn ConstitutionFunc,
+) *LedgerStateBuilder {
+	b.state.ConstitutionCallback = fn
+	return b
+}
+
+// WithTreasuryValue sets the treasury value lookup callback
+func (b *LedgerStateBuilder) WithTreasuryValue(
+	fn TreasuryValueFunc,
+) *LedgerStateBuilder {
+	b.state.TreasuryValueCallback = fn
+	return b
+}
+
+// WithCostModels sets the cost models lookup callback
+func (b *LedgerStateBuilder) WithCostModels(
+	fn CostModelsFunc,
+) *LedgerStateBuilder {
+	b.state.CostModelsCallback = fn
+	return b
+}
+
+// WithUtxos configures the mock with a static set of UTxOs for lookup
+func (b *LedgerStateBuilder) WithUtxos(
+	utxos []lcommon.Utxo,
+) *LedgerStateBuilder {
+	b.state.UtxoByIdCallback = func(id lcommon.TransactionInput) (lcommon.Utxo, error) {
+		// Guard against nil input
+		if id == nil {
+			return lcommon.Utxo{}, ErrNotFound
+		}
+		inputId := id.Id()
+		if inputId == (lcommon.Blake2b256{}) {
+			return lcommon.Utxo{}, ErrNotFound
+		}
+
+		for _, utxo := range utxos {
+			// Guard against nil utxo.Id
+			if utxo.Id == nil {
+				continue
+			}
+			utxoId := utxo.Id.Id()
+
+			// Compare index and ID using bytes.Equal
+			if id.Index() != utxo.Id.Index() {
+				continue
+			}
+			if !bytes.Equal(inputId.Bytes(), utxoId.Bytes()) {
+				continue
+			}
+			return utxo, nil
+		}
+		return lcommon.Utxo{}, ErrNotFound
+	}
+	return b
+}
+
+// WithPools configures the mock with a static set of pool registrations
+func (b *LedgerStateBuilder) WithPools(
+	pools []*lcommon.PoolRegistrationCertificate,
+) *LedgerStateBuilder {
+	b.state.PoolCurrentStateCallback = func(poolKeyHash lcommon.PoolKeyHash) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
+		for _, pool := range pools {
+			// Skip nil pool entries
+			if pool == nil {
+				continue
+			}
+			// Compare pool operator hash directly with the lookup key using bytes.Equal
+			// (both are already Blake2b224 hashes, no need to hash again)
+			if bytes.Equal(pool.Operator.Bytes(), poolKeyHash.Bytes()) {
+				return pool, nil, nil
+			}
+		}
+		return nil, nil, nil
+	}
+	return b
+}
+
+// WithStakeRegistrations configures the mock with a static set of stake registrations
+func (b *LedgerStateBuilder) WithStakeRegistrations(
+	certs []lcommon.StakeRegistrationCertificate,
+) *LedgerStateBuilder {
+	b.state.StakeRegistrationCallback = func(stakingKey []byte) ([]lcommon.StakeRegistrationCertificate, error) {
+		var result []lcommon.StakeRegistrationCertificate
+		for _, cert := range certs {
+			// Compare credential directly using bytes.Equal
+			// (it's already a Blake2b224 hash, no need to hash again)
+			if bytes.Equal(
+				cert.StakeCredential.Credential.Bytes(),
+				stakingKey,
+			) {
+				result = append(result, cert)
+			}
+		}
+		return result, nil
+	}
+	return b
+}
+
+// Build constructs the MockLedgerState
+func (b *LedgerStateBuilder) Build() *MockLedgerState {
+	return b.state
+}

--- a/ledger/transaction.go
+++ b/ledger/transaction.go
@@ -1,0 +1,893 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// TransactionBuilder defines an interface for building mock transactions
+type TransactionBuilder interface {
+	WithId(txId []byte) TransactionBuilder
+	WithInputs(inputs ...lcommon.TransactionInput) TransactionBuilder
+	WithOutputs(outputs ...lcommon.TransactionOutput) TransactionBuilder
+	WithFee(fee uint64) TransactionBuilder
+	WithTTL(ttl uint64) TransactionBuilder
+	WithMetadata(metadata []byte) TransactionBuilder
+	WithValid(valid bool) TransactionBuilder
+	Build() (lcommon.Transaction, error)
+}
+
+// TransactionInputBuilder defines an interface for building mock transaction inputs
+type TransactionInputBuilder interface {
+	WithTxId(txId []byte) TransactionInputBuilder
+	WithIndex(idx uint32) TransactionInputBuilder
+	Build() (lcommon.TransactionInput, error)
+}
+
+// TransactionOutputBuilder defines an interface for building mock transaction outputs
+type TransactionOutputBuilder interface {
+	WithAddress(addr string) TransactionOutputBuilder
+	WithLovelace(amount uint64) TransactionOutputBuilder
+	WithAssets(assets ...Asset) TransactionOutputBuilder
+	WithDatum(datum []byte) TransactionOutputBuilder
+	WithDatumHash(hash []byte) TransactionOutputBuilder
+	Build() (lcommon.TransactionOutput, error)
+}
+
+// MockTransaction implements lcommon.Transaction interface
+type MockTransaction struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	txId        lcommon.Blake2b256
+	inputs      []lcommon.TransactionInput
+	outputs     []lcommon.TransactionOutput
+	fee         uint64
+	ttl         uint64
+	metadata    lcommon.TransactionMetadatum
+	metadataErr error // Stores metadata decoding error for deferred reporting
+	valid       bool
+	txType      int
+	witnesses   *MockTransactionWitnessSet
+	leiosHash   lcommon.Blake2b256
+	refInputs   []lcommon.TransactionInput
+	collateral  []lcommon.TransactionInput
+	collReturn  lcommon.TransactionOutput
+	totalColl   uint64
+	certs       []lcommon.Certificate
+	wdrls       map[*lcommon.Address]uint64
+	auxHash     *lcommon.Blake2b256
+	reqSigners  []lcommon.Blake2b224
+	mint        *lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	scriptHash  *lcommon.Blake2b256
+	votingProc  lcommon.VotingProcedures
+	proposals   []lcommon.ProposalProcedure
+	treasury    int64
+	donation    uint64
+	ppUpdEpoch  uint64
+	ppUpdates   map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate
+	validStart  uint64
+}
+
+// NewTransactionBuilder creates a new MockTransaction builder
+func NewTransactionBuilder() *MockTransaction {
+	return &MockTransaction{
+		valid:     true,
+		witnesses: NewMockTransactionWitnessSet(),
+	}
+}
+
+// WithId sets the transaction ID
+func (t *MockTransaction) WithId(txId []byte) TransactionBuilder {
+	t.txId = lcommon.NewBlake2b256(txId)
+	return t
+}
+
+// WithInputs sets the transaction inputs
+func (t *MockTransaction) WithInputs(
+	inputs ...lcommon.TransactionInput,
+) TransactionBuilder {
+	t.inputs = append(t.inputs, inputs...)
+	return t
+}
+
+// WithOutputs sets the transaction outputs
+func (t *MockTransaction) WithOutputs(
+	outputs ...lcommon.TransactionOutput,
+) TransactionBuilder {
+	t.outputs = append(t.outputs, outputs...)
+	return t
+}
+
+// WithFee sets the transaction fee
+func (t *MockTransaction) WithFee(fee uint64) TransactionBuilder {
+	t.fee = fee
+	return t
+}
+
+// WithTTL sets the transaction time-to-live
+func (t *MockTransaction) WithTTL(ttl uint64) TransactionBuilder {
+	t.ttl = ttl
+	return t
+}
+
+// WithMetadata sets the transaction metadata from raw bytes
+func (t *MockTransaction) WithMetadata(metadata []byte) TransactionBuilder {
+	if metadata != nil {
+		decoded, err := lcommon.DecodeAuxiliaryDataToMetadata(metadata)
+		if err != nil {
+			// Store the error for reporting in Build()
+			t.metadataErr = fmt.Errorf("invalid metadata CBOR: %w", err)
+		} else {
+			t.metadata = decoded
+			t.metadataErr = nil
+		}
+	}
+	return t
+}
+
+// WithValid sets the transaction validity flag
+func (t *MockTransaction) WithValid(valid bool) TransactionBuilder {
+	t.valid = valid
+	return t
+}
+
+// Build constructs a Transaction from the builder state
+func (t *MockTransaction) Build() (lcommon.Transaction, error) {
+	// Return any stored parsing errors
+	if t.metadataErr != nil {
+		return nil, t.metadataErr
+	}
+	if len(t.inputs) == 0 {
+		return nil, errors.New("transaction must have at least one input")
+	}
+	if len(t.outputs) == 0 {
+		return nil, errors.New("transaction must have at least one output")
+	}
+	return t, nil
+}
+
+// Type returns the transaction type identifier
+func (t *MockTransaction) Type() int {
+	return t.txType
+}
+
+// Cbor returns the CBOR-encoded transaction
+func (t *MockTransaction) Cbor() []byte {
+	return t.DecodeStoreCbor.Cbor()
+}
+
+// Hash returns the transaction hash (ID)
+func (t *MockTransaction) Hash() lcommon.Blake2b256 {
+	return t.txId
+}
+
+// LeiosHash returns the Leios hash of the transaction
+func (t *MockTransaction) LeiosHash() lcommon.Blake2b256 {
+	return t.leiosHash
+}
+
+// Metadata returns the transaction metadata
+func (t *MockTransaction) Metadata() lcommon.TransactionMetadatum {
+	return t.metadata
+}
+
+// AuxiliaryData returns the transaction auxiliary data
+func (t *MockTransaction) AuxiliaryData() lcommon.AuxiliaryData {
+	return nil
+}
+
+// IsValid returns whether the transaction is valid
+func (t *MockTransaction) IsValid() bool {
+	return t.valid
+}
+
+// Consumed returns the transaction inputs that are consumed
+func (t *MockTransaction) Consumed() []lcommon.TransactionInput {
+	return t.inputs
+}
+
+// Produced returns the UTxOs produced by this transaction
+func (t *MockTransaction) Produced() []lcommon.Utxo {
+	utxos := make([]lcommon.Utxo, 0, len(t.outputs))
+	for idx, output := range t.outputs {
+		input := &MockTransactionInput{
+			txId: t.txId,
+			// #nosec G115 - transaction output index is bounded by protocol limits
+			index: uint32(idx),
+		}
+		utxos = append(utxos, lcommon.Utxo{
+			Id:     input,
+			Output: output,
+		})
+	}
+	return utxos
+}
+
+// Witnesses returns the transaction witness set
+func (t *MockTransaction) Witnesses() lcommon.TransactionWitnessSet {
+	return t.witnesses
+}
+
+// Fee returns the transaction fee as *big.Int
+func (t *MockTransaction) Fee() *big.Int {
+	return new(big.Int).SetUint64(t.fee)
+}
+
+// Id returns the transaction ID
+func (t *MockTransaction) Id() lcommon.Blake2b256 {
+	return t.txId
+}
+
+// Inputs returns the transaction inputs
+func (t *MockTransaction) Inputs() []lcommon.TransactionInput {
+	return t.inputs
+}
+
+// Outputs returns the transaction outputs
+func (t *MockTransaction) Outputs() []lcommon.TransactionOutput {
+	return t.outputs
+}
+
+// TTL returns the transaction time-to-live
+func (t *MockTransaction) TTL() uint64 {
+	return t.ttl
+}
+
+// ProtocolParameterUpdates returns protocol parameter updates (if any)
+func (t *MockTransaction) ProtocolParameterUpdates() (uint64, map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate) {
+	return t.ppUpdEpoch, t.ppUpdates
+}
+
+// ValidityIntervalStart returns the validity interval start slot
+func (t *MockTransaction) ValidityIntervalStart() uint64 {
+	return t.validStart
+}
+
+// ReferenceInputs returns the reference inputs
+func (t *MockTransaction) ReferenceInputs() []lcommon.TransactionInput {
+	return t.refInputs
+}
+
+// Collateral returns the collateral inputs
+func (t *MockTransaction) Collateral() []lcommon.TransactionInput {
+	return t.collateral
+}
+
+// CollateralReturn returns the collateral return output
+func (t *MockTransaction) CollateralReturn() lcommon.TransactionOutput {
+	return t.collReturn
+}
+
+// TotalCollateral returns the total collateral amount as *big.Int
+func (t *MockTransaction) TotalCollateral() *big.Int {
+	return new(big.Int).SetUint64(t.totalColl)
+}
+
+// Certificates returns the certificates in the transaction
+func (t *MockTransaction) Certificates() []lcommon.Certificate {
+	return t.certs
+}
+
+// Withdrawals returns the stake withdrawals in the transaction as map[*lcommon.Address]*big.Int
+func (t *MockTransaction) Withdrawals() map[*lcommon.Address]*big.Int {
+	if t.wdrls == nil {
+		return nil
+	}
+	result := make(map[*lcommon.Address]*big.Int, len(t.wdrls))
+	for addr, amount := range t.wdrls {
+		result[addr] = new(big.Int).SetUint64(amount)
+	}
+	return result
+}
+
+// AuxDataHash returns the auxiliary data hash
+func (t *MockTransaction) AuxDataHash() *lcommon.Blake2b256 {
+	return t.auxHash
+}
+
+// RequiredSigners returns the required signers for the transaction
+func (t *MockTransaction) RequiredSigners() []lcommon.Blake2b224 {
+	return t.reqSigners
+}
+
+// AssetMint returns the native asset minting/burning in the transaction
+func (t *MockTransaction) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return t.mint
+}
+
+// ScriptDataHash returns the script data hash
+func (t *MockTransaction) ScriptDataHash() *lcommon.Blake2b256 {
+	return t.scriptHash
+}
+
+// VotingProcedures returns the voting procedures in the transaction
+func (t *MockTransaction) VotingProcedures() lcommon.VotingProcedures {
+	return t.votingProc
+}
+
+// ProposalProcedures returns the governance proposals in the transaction
+func (t *MockTransaction) ProposalProcedures() []lcommon.ProposalProcedure {
+	return t.proposals
+}
+
+// CurrentTreasuryValue returns the current treasury value as *big.Int
+func (t *MockTransaction) CurrentTreasuryValue() *big.Int {
+	return big.NewInt(t.treasury)
+}
+
+// Donation returns the donation amount as *big.Int
+func (t *MockTransaction) Donation() *big.Int {
+	return new(big.Int).SetUint64(t.donation)
+}
+
+// Utxorpc returns the UTxO RPC representation of the transaction
+func (t *MockTransaction) Utxorpc() (*utxorpc.Tx, error) {
+	tx := &utxorpc.Tx{
+		Hash: t.txId.Bytes(),
+		Fee:  lcommon.ToUtxorpcBigInt(t.fee),
+	}
+
+	for _, input := range t.inputs {
+		utxorpcInput, err := input.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		tx.Inputs = append(tx.Inputs, utxorpcInput)
+	}
+
+	for _, output := range t.outputs {
+		utxorpcOutput, err := output.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		tx.Outputs = append(tx.Outputs, utxorpcOutput)
+	}
+
+	return tx, nil
+}
+
+// MockTransactionInputBuilder holds the state for building a transaction input
+type MockTransactionInputBuilder struct {
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
+// NewTransactionInputBuilder creates a new transaction input builder
+func NewTransactionInputBuilder() *MockTransactionInputBuilder {
+	return &MockTransactionInputBuilder{}
+}
+
+// WithTxId sets the transaction ID for the input
+func (b *MockTransactionInputBuilder) WithTxId(
+	txId []byte,
+) TransactionInputBuilder {
+	b.txId = lcommon.NewBlake2b256(txId)
+	return b
+}
+
+// WithIndex sets the output index for the input
+func (b *MockTransactionInputBuilder) WithIndex(
+	idx uint32,
+) TransactionInputBuilder {
+	b.index = idx
+	return b
+}
+
+// Build constructs a TransactionInput from the builder state
+func (b *MockTransactionInputBuilder) Build() (lcommon.TransactionInput, error) {
+	if b.txId == (lcommon.Blake2b256{}) {
+		return nil, errors.New("transaction ID is required")
+	}
+	return &MockTransactionInput{
+		txId:  b.txId,
+		index: b.index,
+	}, nil
+}
+
+// MockTransactionOutputBuilder holds the state for building a transaction output
+type MockTransactionOutputBuilder struct {
+	address   lcommon.Address
+	amount    uint64
+	assets    *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum     *lcommon.Datum
+	datumHash *lcommon.Blake2b256
+	addrErr   error // Stores address parsing error for deferred reporting
+	datumErr  error // Stores datum decoding error for deferred reporting
+}
+
+// NewTransactionOutputBuilder creates a new transaction output builder
+func NewTransactionOutputBuilder() *MockTransactionOutputBuilder {
+	return &MockTransactionOutputBuilder{}
+}
+
+// WithAddress sets the address for the output
+func (b *MockTransactionOutputBuilder) WithAddress(
+	addr string,
+) TransactionOutputBuilder {
+	parsedAddr, err := lcommon.NewAddress(addr)
+	if err != nil {
+		// Store the error for reporting in Build()
+		b.address = lcommon.Address{}
+		b.addrErr = fmt.Errorf("invalid address %q: %w", addr, err)
+	} else {
+		b.address = parsedAddr
+		b.addrErr = nil
+	}
+	return b
+}
+
+// WithLovelace sets the ADA amount in lovelace for the output
+func (b *MockTransactionOutputBuilder) WithLovelace(
+	amount uint64,
+) TransactionOutputBuilder {
+	b.amount = amount
+	return b
+}
+
+// WithAssets sets the native assets for the output
+func (b *MockTransactionOutputBuilder) WithAssets(
+	assets ...Asset,
+) TransactionOutputBuilder {
+	b.assets = buildMultiAsset(assets)
+	return b
+}
+
+// WithDatum sets the inline datum for the output
+func (b *MockTransactionOutputBuilder) WithDatum(
+	datum []byte,
+) TransactionOutputBuilder {
+	if datum != nil {
+		d := lcommon.Datum{}
+		if _, err := cbor.Decode(datum, &d); err != nil {
+			// Store the error for reporting in Build()
+			b.datumErr = fmt.Errorf("invalid datum CBOR: %w", err)
+		} else {
+			b.datum = &d
+			b.datumErr = nil
+		}
+	}
+	return b
+}
+
+// WithDatumHash sets the datum hash for the output
+func (b *MockTransactionOutputBuilder) WithDatumHash(
+	hash []byte,
+) TransactionOutputBuilder {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		b.datumHash = &h
+	}
+	return b
+}
+
+// Build constructs a TransactionOutput from the builder state
+func (b *MockTransactionOutputBuilder) Build() (lcommon.TransactionOutput, error) {
+	// Return any stored parsing errors
+	if b.addrErr != nil {
+		return nil, b.addrErr
+	}
+	if b.datumErr != nil {
+		return nil, b.datumErr
+	}
+	if b.address.String() == "" {
+		return nil, errors.New("address is required")
+	}
+	return &MockTransactionOutput{
+		address:   b.address,
+		amount:    b.amount,
+		assets:    b.assets,
+		datum:     b.datum,
+		datumHash: b.datumHash,
+	}, nil
+}
+
+// MockTransactionWitnessSet implements lcommon.TransactionWitnessSet
+type MockTransactionWitnessSet struct {
+	vkeys        []lcommon.VkeyWitness
+	native       []lcommon.NativeScript
+	bootstrap    []lcommon.BootstrapWitness
+	plutusData   []lcommon.Datum
+	plutusV1     []lcommon.PlutusV1Script
+	plutusV2     []lcommon.PlutusV2Script
+	plutusV3     []lcommon.PlutusV3Script
+	redeemerData lcommon.TransactionWitnessRedeemers
+}
+
+// NewMockTransactionWitnessSet creates a new empty witness set
+func NewMockTransactionWitnessSet() *MockTransactionWitnessSet {
+	return &MockTransactionWitnessSet{}
+}
+
+// Vkey returns the VKey witnesses
+func (w *MockTransactionWitnessSet) Vkey() []lcommon.VkeyWitness {
+	return w.vkeys
+}
+
+// NativeScripts returns the native scripts
+func (w *MockTransactionWitnessSet) NativeScripts() []lcommon.NativeScript {
+	return w.native
+}
+
+// Bootstrap returns the bootstrap witnesses
+func (w *MockTransactionWitnessSet) Bootstrap() []lcommon.BootstrapWitness {
+	return w.bootstrap
+}
+
+// PlutusData returns the Plutus data
+func (w *MockTransactionWitnessSet) PlutusData() []lcommon.Datum {
+	return w.plutusData
+}
+
+// PlutusV1Scripts returns the Plutus V1 scripts
+func (w *MockTransactionWitnessSet) PlutusV1Scripts() []lcommon.PlutusV1Script {
+	return w.plutusV1
+}
+
+// PlutusV2Scripts returns the Plutus V2 scripts
+func (w *MockTransactionWitnessSet) PlutusV2Scripts() []lcommon.PlutusV2Script {
+	return w.plutusV2
+}
+
+// PlutusV3Scripts returns the Plutus V3 scripts
+func (w *MockTransactionWitnessSet) PlutusV3Scripts() []lcommon.PlutusV3Script {
+	return w.plutusV3
+}
+
+// Redeemers returns the transaction redeemers
+func (w *MockTransactionWitnessSet) Redeemers() lcommon.TransactionWitnessRedeemers {
+	return w.redeemerData
+}
+
+// Additional builder methods for MockTransaction to support advanced features
+
+// WithType sets the transaction type
+func (t *MockTransaction) WithType(txType int) *MockTransaction {
+	t.txType = txType
+	return t
+}
+
+// WithLeiosHash sets the Leios hash
+func (t *MockTransaction) WithLeiosHash(hash []byte) *MockTransaction {
+	t.leiosHash = lcommon.NewBlake2b256(hash)
+	return t
+}
+
+// WithReferenceInputs sets the reference inputs
+func (t *MockTransaction) WithReferenceInputs(
+	inputs ...lcommon.TransactionInput,
+) *MockTransaction {
+	t.refInputs = append(t.refInputs, inputs...)
+	return t
+}
+
+// WithCollateral sets the collateral inputs
+func (t *MockTransaction) WithCollateral(
+	inputs ...lcommon.TransactionInput,
+) *MockTransaction {
+	t.collateral = append(t.collateral, inputs...)
+	return t
+}
+
+// WithCollateralReturn sets the collateral return output
+func (t *MockTransaction) WithCollateralReturn(
+	output lcommon.TransactionOutput,
+) *MockTransaction {
+	t.collReturn = output
+	return t
+}
+
+// WithTotalCollateral sets the total collateral amount
+func (t *MockTransaction) WithTotalCollateral(amount uint64) *MockTransaction {
+	t.totalColl = amount
+	return t
+}
+
+// WithCertificates sets the certificates
+func (t *MockTransaction) WithCertificates(
+	certs ...lcommon.Certificate,
+) *MockTransaction {
+	t.certs = append(t.certs, certs...)
+	return t
+}
+
+// WithWithdrawals sets the stake withdrawals
+func (t *MockTransaction) WithWithdrawals(
+	wdrls map[*lcommon.Address]uint64,
+) *MockTransaction {
+	t.wdrls = wdrls
+	return t
+}
+
+// WithAuxDataHash sets the auxiliary data hash
+func (t *MockTransaction) WithAuxDataHash(hash []byte) *MockTransaction {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		t.auxHash = &h
+	}
+	return t
+}
+
+// WithRequiredSigners sets the required signers
+func (t *MockTransaction) WithRequiredSigners(
+	signers ...lcommon.Blake2b224,
+) *MockTransaction {
+	t.reqSigners = append(t.reqSigners, signers...)
+	return t
+}
+
+// WithMint sets the asset minting/burning
+func (t *MockTransaction) WithMint(
+	mint *lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
+) *MockTransaction {
+	t.mint = mint
+	return t
+}
+
+// WithScriptDataHash sets the script data hash
+func (t *MockTransaction) WithScriptDataHash(hash []byte) *MockTransaction {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		t.scriptHash = &h
+	}
+	return t
+}
+
+// WithVotingProcedures sets the voting procedures
+func (t *MockTransaction) WithVotingProcedures(
+	procs lcommon.VotingProcedures,
+) *MockTransaction {
+	t.votingProc = procs
+	return t
+}
+
+// WithProposalProcedures sets the governance proposals
+func (t *MockTransaction) WithProposalProcedures(
+	proposals ...lcommon.ProposalProcedure,
+) *MockTransaction {
+	t.proposals = append(t.proposals, proposals...)
+	return t
+}
+
+// WithTreasuryValue sets the current treasury value
+func (t *MockTransaction) WithTreasuryValue(value int64) *MockTransaction {
+	t.treasury = value
+	return t
+}
+
+// WithDonation sets the donation amount
+func (t *MockTransaction) WithDonation(amount uint64) *MockTransaction {
+	t.donation = amount
+	return t
+}
+
+// WithValidityIntervalStart sets the validity interval start slot
+func (t *MockTransaction) WithValidityIntervalStart(
+	slot uint64,
+) *MockTransaction {
+	t.validStart = slot
+	return t
+}
+
+// WithWitnesses sets the witness set
+func (t *MockTransaction) WithWitnesses(
+	witnesses *MockTransactionWitnessSet,
+) *MockTransaction {
+	t.witnesses = witnesses
+	return t
+}
+
+// Witness set builder methods
+
+// WithVkeyWitnesses adds VKey witnesses to the witness set
+func (w *MockTransactionWitnessSet) WithVkeyWitnesses(
+	vkeys ...lcommon.VkeyWitness,
+) *MockTransactionWitnessSet {
+	w.vkeys = append(w.vkeys, vkeys...)
+	return w
+}
+
+// WithNativeScripts adds native scripts to the witness set
+func (w *MockTransactionWitnessSet) WithNativeScripts(
+	scripts ...lcommon.NativeScript,
+) *MockTransactionWitnessSet {
+	w.native = append(w.native, scripts...)
+	return w
+}
+
+// WithBootstrapWitnesses adds bootstrap witnesses to the witness set
+func (w *MockTransactionWitnessSet) WithBootstrapWitnesses(
+	witnesses ...lcommon.BootstrapWitness,
+) *MockTransactionWitnessSet {
+	w.bootstrap = append(w.bootstrap, witnesses...)
+	return w
+}
+
+// WithPlutusData adds Plutus data to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusData(
+	datum ...lcommon.Datum,
+) *MockTransactionWitnessSet {
+	w.plutusData = append(w.plutusData, datum...)
+	return w
+}
+
+// WithPlutusV1Scripts adds Plutus V1 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV1Scripts(
+	scripts ...lcommon.PlutusV1Script,
+) *MockTransactionWitnessSet {
+	w.plutusV1 = append(w.plutusV1, scripts...)
+	return w
+}
+
+// WithPlutusV2Scripts adds Plutus V2 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV2Scripts(
+	scripts ...lcommon.PlutusV2Script,
+) *MockTransactionWitnessSet {
+	w.plutusV2 = append(w.plutusV2, scripts...)
+	return w
+}
+
+// WithPlutusV3Scripts adds Plutus V3 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV3Scripts(
+	scripts ...lcommon.PlutusV3Script,
+) *MockTransactionWitnessSet {
+	w.plutusV3 = append(w.plutusV3, scripts...)
+	return w
+}
+
+// WithRedeemers sets the redeemers for the witness set
+func (w *MockTransactionWitnessSet) WithRedeemers(
+	redeemers lcommon.TransactionWitnessRedeemers,
+) *MockTransactionWitnessSet {
+	w.redeemerData = redeemers
+	return w
+}
+
+// Ensure MockTransactionOutput implements the Cbor() method required by lcommon.TransactionOutput
+// The existing MockTransactionOutput in utxo.go already has most methods, but we need Cbor()
+
+// MockTransactionOutputWithCbor wraps MockTransactionOutput to add CBOR support
+type MockTransactionOutputWithCbor struct {
+	*MockTransactionOutput
+	cborData []byte
+}
+
+// Cbor returns the CBOR-encoded output
+func (o *MockTransactionOutputWithCbor) Cbor() []byte {
+	return o.cborData
+}
+
+// NewTransactionOutputFromUtxo creates a transaction output builder from an existing MockTransactionOutput.
+// Returns nil if output is nil.
+func NewTransactionOutputFromUtxo(
+	output *MockTransactionOutput,
+) *MockTransactionOutputBuilder {
+	if output == nil {
+		return nil
+	}
+	return &MockTransactionOutputBuilder{
+		address:   output.address,
+		amount:    output.amount,
+		assets:    output.assets,
+		datum:     output.datum,
+		datumHash: output.datumHash,
+	}
+}
+
+// Helper function to create a simple transaction for testing
+func NewSimpleTransaction(
+	txId []byte,
+	inputs []lcommon.TransactionInput,
+	outputs []lcommon.TransactionOutput,
+	fee uint64,
+) (*MockTransaction, error) {
+	tx := NewTransactionBuilder().
+		WithId(txId).
+		WithFee(fee)
+
+	for _, input := range inputs {
+		tx.WithInputs(input)
+	}
+	for _, output := range outputs {
+		tx.WithOutputs(output)
+	}
+
+	result, err := tx.Build()
+	if err != nil {
+		return nil, err
+	}
+	mockTx, ok := result.(*MockTransaction)
+	if !ok {
+		return nil, errors.New("unexpected transaction type")
+	}
+	return mockTx, nil
+}
+
+// Helper function to create a simple transaction input
+func NewSimpleTransactionInput(
+	txId []byte,
+	index uint32,
+) (*MockTransactionInput, error) {
+	input, err := NewTransactionInputBuilder().
+		WithTxId(txId).
+		WithIndex(index).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	mockInput, ok := input.(*MockTransactionInput)
+	if !ok {
+		return nil, errors.New("unexpected transaction input type")
+	}
+	return mockInput, nil
+}
+
+// Helper function to create a simple transaction output
+func NewSimpleTransactionOutput(
+	address string,
+	lovelace uint64,
+) (*MockTransactionOutput, error) {
+	output, err := NewTransactionOutputBuilder().
+		WithAddress(address).
+		WithLovelace(lovelace).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	mockOutput, ok := output.(*MockTransactionOutput)
+	if !ok {
+		return nil, errors.New("unexpected transaction output type")
+	}
+	return mockOutput, nil
+}
+
+// String returns a string representation of the transaction
+func (t *MockTransaction) String() string {
+	return fmt.Sprintf(
+		"Transaction{id=%s, inputs=%d, outputs=%d, fee=%d}",
+		t.txId.String(),
+		len(t.inputs),
+		len(t.outputs),
+		t.fee,
+	)
+}
+
+// ToPlutusData converts the transaction to Plutus data representation
+func (t *MockTransaction) ToPlutusData() data.PlutusData {
+	// Build inputs list
+	inputsList := make([]data.PlutusData, len(t.inputs))
+	for i, input := range t.inputs {
+		inputsList[i] = input.ToPlutusData()
+	}
+
+	// Build outputs list
+	outputsList := make([]data.PlutusData, len(t.outputs))
+	for i, output := range t.outputs {
+		outputsList[i] = output.ToPlutusData()
+	}
+
+	return data.NewConstr(0,
+		data.NewList(inputsList...),
+		data.NewList(outputsList...),
+		data.NewInteger(new(big.Int).SetUint64(t.fee)),
+	)
+}

--- a/ledger/utxo.go
+++ b/ledger/utxo.go
@@ -1,0 +1,409 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// Asset represents a native asset with policy ID, asset name, and amount
+type Asset struct {
+	PolicyId  []byte
+	AssetName []byte
+	Amount    uint64
+}
+
+// buildMultiAsset constructs a MultiAsset from a slice of Asset.
+// Returns nil if assets is empty.
+func buildMultiAsset(
+	assets []Asset,
+) *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	if len(assets) == 0 {
+		return nil
+	}
+	assetData := make(
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput,
+	)
+	for _, asset := range assets {
+		policyId := lcommon.NewBlake2b224(asset.PolicyId)
+		if _, ok := assetData[policyId]; !ok {
+			assetData[policyId] = make(
+				map[cbor.ByteString]lcommon.MultiAssetTypeOutput,
+			)
+		}
+		assetData[policyId][cbor.NewByteString(asset.AssetName)] = new(
+			big.Int,
+		).SetUint64(asset.Amount)
+	}
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](assetData)
+	return &multiAsset
+}
+
+// UtxoBuilder defines an interface for building mock UTxOs
+type UtxoBuilder interface {
+	WithTxId(txId []byte) UtxoBuilder
+	WithIndex(idx uint32) UtxoBuilder
+	WithAddress(addr string) UtxoBuilder
+	WithLovelace(amount uint64) UtxoBuilder
+	WithAssets(assets ...Asset) UtxoBuilder
+	WithDatum(datum []byte) UtxoBuilder
+	WithDatumHash(hash []byte) UtxoBuilder
+	WithScriptRef(script []byte) UtxoBuilder
+	Build() (lcommon.Utxo, error)
+}
+
+// MockUtxo holds the state for building a UTxO
+type MockUtxo struct {
+	txId         lcommon.Blake2b256
+	index        uint32
+	address      lcommon.Address
+	lovelace     uint64
+	assets       *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum        *lcommon.Datum
+	datumHash    *lcommon.Blake2b256
+	scriptRef    lcommon.Script
+	addrErr      error // Stores address parsing error for deferred reporting
+	datumErr     error // Stores datum CBOR decode error for deferred reporting
+	scriptRefErr error // Stores script ref CBOR decode error for deferred reporting
+}
+
+// NewUtxoBuilder creates a new MockUtxo builder
+func NewUtxoBuilder() *MockUtxo {
+	return &MockUtxo{}
+}
+
+// WithTxId sets the transaction ID for the UTxO
+func (u *MockUtxo) WithTxId(txId []byte) UtxoBuilder {
+	u.txId = lcommon.NewBlake2b256(txId)
+	return u
+}
+
+// WithIndex sets the output index for the UTxO
+func (u *MockUtxo) WithIndex(idx uint32) UtxoBuilder {
+	u.index = idx
+	return u
+}
+
+// WithAddress sets the address for the UTxO
+func (u *MockUtxo) WithAddress(addr string) UtxoBuilder {
+	parsedAddr, err := lcommon.NewAddress(addr)
+	if err != nil {
+		// Store the error for reporting in Build()
+		u.address = lcommon.Address{}
+		u.addrErr = fmt.Errorf("invalid address %q: %w", addr, err)
+	} else {
+		u.address = parsedAddr
+		u.addrErr = nil
+	}
+	return u
+}
+
+// WithLovelace sets the ADA amount in lovelace for the UTxO
+func (u *MockUtxo) WithLovelace(amount uint64) UtxoBuilder {
+	u.lovelace = amount
+	return u
+}
+
+// WithAssets sets the native assets for the UTxO
+func (u *MockUtxo) WithAssets(assets ...Asset) UtxoBuilder {
+	u.assets = buildMultiAsset(assets)
+	return u
+}
+
+// WithDatum sets the inline datum for the UTxO
+func (u *MockUtxo) WithDatum(datum []byte) UtxoBuilder {
+	if datum != nil {
+		d := lcommon.Datum{}
+		if _, err := cbor.Decode(datum, &d); err != nil {
+			u.datumErr = fmt.Errorf("failed to decode datum CBOR: %w", err)
+		} else {
+			u.datum = &d
+			u.datumErr = nil
+		}
+	}
+	return u
+}
+
+// WithDatumHash sets the datum hash for the UTxO
+func (u *MockUtxo) WithDatumHash(hash []byte) UtxoBuilder {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		u.datumHash = &h
+	}
+	return u
+}
+
+// WithScriptRef sets the script reference for the UTxO
+func (u *MockUtxo) WithScriptRef(script []byte) UtxoBuilder {
+	if script != nil {
+		// Try to decode as a script reference
+		var scriptRef lcommon.ScriptRef
+		if _, err := cbor.Decode(script, &scriptRef); err != nil {
+			u.scriptRefErr = fmt.Errorf(
+				"failed to decode script reference CBOR: %w",
+				err,
+			)
+		} else {
+			u.scriptRef = scriptRef.Script
+			u.scriptRefErr = nil
+		}
+	}
+	return u
+}
+
+// Build constructs a Utxo from the builder state
+func (u *MockUtxo) Build() (lcommon.Utxo, error) {
+	// Validate required fields
+	if u.txId == (lcommon.Blake2b256{}) {
+		return lcommon.Utxo{}, errors.New("transaction ID is required")
+	}
+	// Return any stored errors from deferred validation
+	if u.addrErr != nil {
+		return lcommon.Utxo{}, u.addrErr
+	}
+	if u.datumErr != nil {
+		return lcommon.Utxo{}, u.datumErr
+	}
+	if u.scriptRefErr != nil {
+		return lcommon.Utxo{}, u.scriptRefErr
+	}
+	// Validate address is not zero/invalid
+	if u.address.String() == "" {
+		return lcommon.Utxo{}, errors.New("address is required")
+	}
+
+	// Create the transaction input
+	input := &MockTransactionInput{
+		txId:  u.txId,
+		index: u.index,
+	}
+
+	// Create the transaction output
+	output := &MockTransactionOutput{
+		address:   u.address,
+		amount:    u.lovelace,
+		assets:    u.assets,
+		datum:     u.datum,
+		datumHash: u.datumHash,
+		scriptRef: u.scriptRef,
+	}
+
+	return lcommon.Utxo{
+		Id:     input,
+		Output: output,
+	}, nil
+}
+
+// MockTransactionInput implements lcommon.TransactionInput
+type MockTransactionInput struct {
+	cbor.StructAsArray
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
+// Id returns the transaction ID
+func (i *MockTransactionInput) Id() lcommon.Blake2b256 {
+	return i.txId
+}
+
+// Index returns the output index
+func (i *MockTransactionInput) Index() uint32 {
+	return i.index
+}
+
+// String returns a string representation of the input
+func (i *MockTransactionInput) String() string {
+	return fmt.Sprintf("%s#%d", i.txId.String(), i.index)
+}
+
+// Utxorpc returns the UTxO RPC representation
+func (i *MockTransactionInput) Utxorpc() (*utxorpc.TxInput, error) {
+	return &utxorpc.TxInput{
+		TxHash:      i.txId.Bytes(),
+		OutputIndex: i.index,
+	}, nil
+}
+
+// ToPlutusData converts the input to Plutus data
+func (i *MockTransactionInput) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0,
+		data.NewByteString(i.txId.Bytes()),
+		data.NewInteger(big.NewInt(int64(i.index))),
+	)
+}
+
+// MockTransactionOutput implements lcommon.TransactionOutput
+type MockTransactionOutput struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	address   lcommon.Address
+	amount    uint64
+	assets    *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum     *lcommon.Datum
+	datumHash *lcommon.Blake2b256
+	scriptRef lcommon.Script
+}
+
+// Address returns the output address
+func (o *MockTransactionOutput) Address() lcommon.Address {
+	return o.address
+}
+
+// Amount returns the lovelace amount as *big.Int
+func (o *MockTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.amount)
+}
+
+// Assets returns the native assets
+func (o *MockTransactionOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return o.assets
+}
+
+// Datum returns the inline datum
+func (o *MockTransactionOutput) Datum() *lcommon.Datum {
+	return o.datum
+}
+
+// DatumHash returns the datum hash
+func (o *MockTransactionOutput) DatumHash() *lcommon.Blake2b256 {
+	return o.datumHash
+}
+
+// ScriptRef returns the script reference
+func (o *MockTransactionOutput) ScriptRef() lcommon.Script {
+	return o.scriptRef
+}
+
+// Utxorpc returns the UTxO RPC representation
+func (o *MockTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
+	addrBytes, err := o.address.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	output := &utxorpc.TxOutput{
+		Address: addrBytes,
+		Coin:    lcommon.ToUtxorpcBigInt(o.amount),
+	}
+
+	// Add assets if present
+	if o.assets != nil {
+		var multiassets []*utxorpc.Multiasset
+		for _, policyId := range o.assets.Policies() {
+			var assets []*utxorpc.Asset
+			for _, assetName := range o.assets.Assets(policyId) {
+				amount := o.assets.Asset(policyId, assetName)
+				// Convert *big.Int to utxorpc BigInt
+				utxorpcAmount := &utxorpc.BigInt{
+					BigInt: &utxorpc.BigInt_BigUInt{
+						BigUInt: amount.Bytes(),
+					},
+				}
+				assets = append(assets, &utxorpc.Asset{
+					Name: assetName,
+					Quantity: &utxorpc.Asset_OutputCoin{
+						OutputCoin: utxorpcAmount,
+					},
+				})
+			}
+			multiassets = append(multiassets, &utxorpc.Multiasset{
+				PolicyId: policyId.Bytes(),
+				Assets:   assets,
+			})
+		}
+		output.Assets = multiassets
+	}
+
+	// Add datum if present (inline datum or datum hash)
+	if o.datum != nil {
+		output.Datum = &utxorpc.Datum{
+			Hash:         o.datum.Hash().Bytes(),
+			OriginalCbor: o.datum.Cbor(),
+		}
+	} else if o.datumHash != nil {
+		// Datum hash only (referenced datum)
+		output.Datum = &utxorpc.Datum{
+			Hash: o.datumHash.Bytes(),
+		}
+	}
+
+	// Add script reference if present
+	if o.scriptRef != nil {
+		// Use PlutusV2 as default since we don't have type info from the interface
+		output.Script = &utxorpc.Script{
+			Script: &utxorpc.Script_PlutusV2{
+				PlutusV2: o.scriptRef.RawScriptBytes(),
+			},
+		}
+	}
+
+	return output, nil
+}
+
+// ToPlutusData converts the output to Plutus data
+func (o *MockTransactionOutput) ToPlutusData() data.PlutusData {
+	// Build address data
+	addressPd := o.address.ToPlutusData()
+
+	// Build value data (lovelace + assets)
+	var valuePd data.PlutusData
+	if o.assets != nil {
+		valuePd = data.NewConstr(0,
+			data.NewInteger(new(big.Int).SetUint64(o.amount)),
+			o.assets.ToPlutusData(),
+		)
+	} else {
+		valuePd = data.NewInteger(new(big.Int).SetUint64(o.amount))
+	}
+
+	// Build datum option
+	var datumPd data.PlutusData
+	if o.datum != nil {
+		datumPd = data.NewConstr(2, o.datum.Data)
+	} else if o.datumHash != nil {
+		datumPd = data.NewConstr(1, data.NewByteString(o.datumHash.Bytes()))
+	} else {
+		datumPd = data.NewConstr(0)
+	}
+
+	// Build script ref option
+	var scriptRefPd data.PlutusData
+	if o.scriptRef != nil {
+		scriptRefPd = data.NewConstr(
+			0,
+			data.NewByteString(o.scriptRef.Hash().Bytes()),
+		)
+	} else {
+		scriptRefPd = data.NewConstr(1)
+	}
+
+	return data.NewConstr(0,
+		addressPd,
+		valuePd,
+		datumPd,
+		scriptRefPd,
+	)
+}
+
+// String returns a string representation of the output
+func (o *MockTransactionOutput) String() string {
+	return fmt.Sprintf("%s: %d lovelace", o.address.String(), o.amount)
+}

--- a/localstatequery/entries.go
+++ b/localstatequery/entries.go
@@ -1,0 +1,224 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntryAcquire expects an Acquire message from the client
+type ConversationEntryAcquire struct {
+	Point *pcommon.Point // Optional: expected point for validation (nil means accept any)
+}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryInput
+func (e ConversationEntryAcquire) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localstatequery.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localstatequery.MessageTypeAcquire,
+		MsgFromCborFunc: localstatequery.NewMsgFromCbor,
+	}
+	if e.Point != nil {
+		entry.Message = localstatequery.NewMsgAcquire(*e.Point)
+	}
+	return entry
+}
+
+// ConversationEntryAcquired sends an Acquired response to the client
+type ConversationEntryAcquired struct{}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryOutput
+func (e ConversationEntryAcquired) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localstatequery.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localstatequery.NewMsgAcquired(),
+		},
+	}
+}
+
+// ConversationEntryAcquireFailure sends an AcquireFailure response to the client
+type ConversationEntryAcquireFailure struct {
+	Failure uint8 // Failure reason: AcquireFailurePointTooOld or AcquireFailurePointNotOnChain
+}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryOutput
+func (e ConversationEntryAcquireFailure) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localstatequery.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localstatequery.NewMsgFailure(e.Failure),
+		},
+	}
+}
+
+// ConversationEntryReAcquire expects a ReAcquire message from the client
+type ConversationEntryReAcquire struct {
+	Point *pcommon.Point // Optional: expected point for validation (nil means accept any)
+}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryInput
+func (e ConversationEntryReAcquire) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localstatequery.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localstatequery.MessageTypeReacquire,
+		MsgFromCborFunc: localstatequery.NewMsgFromCbor,
+	}
+	if e.Point != nil {
+		entry.Message = localstatequery.NewMsgReAcquire(*e.Point)
+	}
+	return entry
+}
+
+// ConversationEntryQuery expects a Query message from the client
+type ConversationEntryQuery struct {
+	Query []byte // Optional: expected query CBOR for validation (nil means accept any)
+}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryInput
+func (e ConversationEntryQuery) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localstatequery.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localstatequery.MessageTypeQuery,
+		MsgFromCborFunc: localstatequery.NewMsgFromCbor,
+	}
+	if e.Query != nil {
+		entry.Message = localstatequery.NewMsgQuery(e.Query)
+	}
+	return entry
+}
+
+// ConversationEntryResult sends a query Result to the client
+type ConversationEntryResult struct {
+	Result []byte // Result CBOR data
+}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryOutput
+func (e ConversationEntryResult) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localstatequery.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localstatequery.NewMsgResult(e.Result),
+		},
+	}
+}
+
+// ConversationEntryRelease expects a Release message from the client
+type ConversationEntryRelease struct{}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryInput
+func (e ConversationEntryRelease) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localstatequery.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localstatequery.MessageTypeRelease,
+		MsgFromCborFunc: localstatequery.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate the protocol
+type ConversationEntryDone struct{}
+
+// ToEntry converts this LocalStateQuery entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localstatequery.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localstatequery.MessageTypeDone,
+		MsgFromCborFunc: localstatequery.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewAcquireEntry creates a ConversationEntryInput for expecting an Acquire message
+func NewAcquireEntry(
+	point *pcommon.Point,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryAcquire{Point: point}.ToEntry()
+}
+
+// NewAcquireEntryAny creates a ConversationEntryInput for expecting any Acquire message
+func NewAcquireEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryAcquire{}.ToEntry()
+}
+
+// NewAcquiredEntry creates a ConversationEntryOutput for sending an Acquired response
+func NewAcquiredEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryAcquired{}.ToEntry()
+}
+
+// NewAcquireFailureEntry creates a ConversationEntryOutput for sending an AcquireFailure response
+func NewAcquireFailureEntry(
+	failure uint8,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryAcquireFailure{Failure: failure}.ToEntry()
+}
+
+// NewAcquireFailurePointTooOldEntry creates a ConversationEntryOutput for PointTooOld failure
+func NewAcquireFailurePointTooOldEntry() ouroboros_mock.ConversationEntryOutput {
+	return NewAcquireFailureEntry(localstatequery.AcquireFailurePointTooOld)
+}
+
+// NewAcquireFailurePointNotOnChainEntry creates a ConversationEntryOutput for PointNotOnChain failure
+func NewAcquireFailurePointNotOnChainEntry() ouroboros_mock.ConversationEntryOutput {
+	return NewAcquireFailureEntry(localstatequery.AcquireFailurePointNotOnChain)
+}
+
+// NewReAcquireEntry creates a ConversationEntryInput for expecting a ReAcquire message
+func NewReAcquireEntry(
+	point *pcommon.Point,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReAcquire{Point: point}.ToEntry()
+}
+
+// NewReAcquireEntryAny creates a ConversationEntryInput for expecting any ReAcquire message
+func NewReAcquireEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReAcquire{}.ToEntry()
+}
+
+// NewQueryEntry creates a ConversationEntryInput for expecting a Query message
+func NewQueryEntry(query []byte) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryQuery{Query: query}.ToEntry()
+}
+
+// NewQueryEntryAny creates a ConversationEntryInput for expecting any Query message
+func NewQueryEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryQuery{}.ToEntry()
+}
+
+// NewResultEntry creates a ConversationEntryOutput for sending a Result response
+func NewResultEntry(result []byte) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryResult{Result: result}.ToEntry()
+}
+
+// NewReleaseEntry creates a ConversationEntryInput for expecting a Release message
+func NewReleaseEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryRelease{}.ToEntry()
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry()
+}

--- a/localstatequery/entries_test.go
+++ b/localstatequery/entries_test.go
@@ -1,0 +1,1404 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	lsq "github.com/blinklabs-io/ouroboros-mock/localstatequery"
+)
+
+// Test constants
+var (
+	testBlockHash = []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	testPoint     = pcommon.NewPoint(12345, testBlockHash)
+	testQueryCBOR = []byte{0x82, 0x00, 0x82, 0x02, 0x81, 0x00}
+	testResult    = []byte{0x06}
+)
+
+// TestConversationEntryAcquire tests the ConversationEntryAcquire type
+func TestConversationEntryAcquire(t *testing.T) {
+	t.Run("without point", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquire{}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeAcquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeAcquire,
+				result.MessageType,
+			)
+		}
+		if result.Message != nil {
+			t.Error("expected Message to be nil when Point is not set")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("with point", func(t *testing.T) {
+		point := testPoint
+		entry := lsq.ConversationEntryAcquire{Point: &point}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeAcquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeAcquire,
+				result.MessageType,
+			)
+		}
+		if result.Message == nil {
+			t.Error("expected Message to be set when Point is provided")
+		}
+	})
+}
+
+// TestConversationEntryAcquired tests the ConversationEntryAcquired type
+func TestConversationEntryAcquired(t *testing.T) {
+	entry := lsq.ConversationEntryAcquired{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != localstatequery.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			localstatequery.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if !result.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryAcquireFailure tests the ConversationEntryAcquireFailure type
+func TestConversationEntryAcquireFailure(t *testing.T) {
+	testCases := []struct {
+		name    string
+		failure uint8
+	}{
+		{"PointTooOld", localstatequery.AcquireFailurePointTooOld},
+		{"PointNotOnChain", localstatequery.AcquireFailurePointNotOnChain},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := lsq.ConversationEntryAcquireFailure{Failure: tc.failure}
+			result := entry.ToEntry()
+
+			if result.ProtocolId != localstatequery.ProtocolId {
+				t.Errorf(
+					"expected ProtocolId %d, got %d",
+					localstatequery.ProtocolId,
+					result.ProtocolId,
+				)
+			}
+			if !result.IsResponse {
+				t.Error("expected IsResponse to be true")
+			}
+			if len(result.Messages) != 1 {
+				t.Errorf("expected 1 message, got %d", len(result.Messages))
+			}
+		})
+	}
+}
+
+// TestConversationEntryReAcquire tests the ConversationEntryReAcquire type
+func TestConversationEntryReAcquire(t *testing.T) {
+	t.Run("without point", func(t *testing.T) {
+		entry := lsq.ConversationEntryReAcquire{}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeReacquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeReacquire,
+				result.MessageType,
+			)
+		}
+		if result.Message != nil {
+			t.Error("expected Message to be nil when Point is not set")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("with point", func(t *testing.T) {
+		point := testPoint
+		entry := lsq.ConversationEntryReAcquire{Point: &point}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeReacquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeReacquire,
+				result.MessageType,
+			)
+		}
+		if result.Message == nil {
+			t.Error("expected Message to be set when Point is provided")
+		}
+	})
+}
+
+// TestConversationEntryQuery tests the ConversationEntryQuery type
+func TestConversationEntryQuery(t *testing.T) {
+	t.Run("without query", func(t *testing.T) {
+		entry := lsq.ConversationEntryQuery{}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeQuery {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeQuery,
+				result.MessageType,
+			)
+		}
+		if result.Message != nil {
+			t.Error("expected Message to be nil when Query is not set")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("with query", func(t *testing.T) {
+		entry := lsq.ConversationEntryQuery{Query: testQueryCBOR}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if result.MessageType != localstatequery.MessageTypeQuery {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeQuery,
+				result.MessageType,
+			)
+		}
+		if result.Message == nil {
+			t.Error("expected Message to be set when Query is provided")
+		}
+	})
+}
+
+// TestConversationEntryResult tests the ConversationEntryResult type
+func TestConversationEntryResult(t *testing.T) {
+	entry := lsq.ConversationEntryResult{Result: testResult}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != localstatequery.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			localstatequery.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if !result.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryRelease tests the ConversationEntryRelease type
+func TestConversationEntryRelease(t *testing.T) {
+	entry := lsq.ConversationEntryRelease{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != localstatequery.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			localstatequery.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse {
+		t.Error("expected IsResponse to be false")
+	}
+	if result.MessageType != localstatequery.MessageTypeRelease {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			localstatequery.MessageTypeRelease,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryDone tests the ConversationEntryDone type
+func TestConversationEntryDone(t *testing.T) {
+	entry := lsq.ConversationEntryDone{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != localstatequery.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			localstatequery.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse {
+		t.Error("expected IsResponse to be false for Done message")
+	}
+	if result.MessageType != localstatequery.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			localstatequery.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestHelperFunctions tests all helper functions for creating entries
+func TestHelperFunctions(t *testing.T) {
+	t.Run("NewAcquireEntry", func(t *testing.T) {
+		point := testPoint
+		entry := lsq.NewAcquireEntry(&point)
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeAcquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeAcquire,
+				entry.MessageType,
+			)
+		}
+		if entry.Message == nil {
+			t.Error("expected Message to be set")
+		}
+	})
+
+	t.Run("NewAcquireEntryAny", func(t *testing.T) {
+		entry := lsq.NewAcquireEntryAny()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeAcquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeAcquire,
+				entry.MessageType,
+			)
+		}
+		if entry.Message != nil {
+			t.Error("expected Message to be nil for 'any' entry")
+		}
+	})
+
+	t.Run("NewAcquiredEntry", func(t *testing.T) {
+		entry := lsq.NewAcquiredEntry()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if !entry.IsResponse {
+			t.Error("expected IsResponse to be true")
+		}
+		if len(entry.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(entry.Messages))
+		}
+	})
+
+	t.Run("NewAcquireFailureEntry", func(t *testing.T) {
+		entry := lsq.NewAcquireFailureEntry(
+			localstatequery.AcquireFailurePointTooOld,
+		)
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if !entry.IsResponse {
+			t.Error("expected IsResponse to be true")
+		}
+		if len(entry.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(entry.Messages))
+		}
+	})
+
+	t.Run("NewAcquireFailurePointTooOldEntry", func(t *testing.T) {
+		entry := lsq.NewAcquireFailurePointTooOldEntry()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if !entry.IsResponse {
+			t.Error("expected IsResponse to be true")
+		}
+		if len(entry.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(entry.Messages))
+		}
+	})
+
+	t.Run("NewAcquireFailurePointNotOnChainEntry", func(t *testing.T) {
+		entry := lsq.NewAcquireFailurePointNotOnChainEntry()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if !entry.IsResponse {
+			t.Error("expected IsResponse to be true")
+		}
+		if len(entry.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(entry.Messages))
+		}
+	})
+
+	t.Run("NewReAcquireEntry", func(t *testing.T) {
+		point := testPoint
+		entry := lsq.NewReAcquireEntry(&point)
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeReacquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeReacquire,
+				entry.MessageType,
+			)
+		}
+		if entry.Message == nil {
+			t.Error("expected Message to be set")
+		}
+	})
+
+	t.Run("NewReAcquireEntryAny", func(t *testing.T) {
+		entry := lsq.NewReAcquireEntryAny()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeReacquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeReacquire,
+				entry.MessageType,
+			)
+		}
+		if entry.Message != nil {
+			t.Error("expected Message to be nil for 'any' entry")
+		}
+	})
+
+	t.Run("NewQueryEntry", func(t *testing.T) {
+		entry := lsq.NewQueryEntry(testQueryCBOR)
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeQuery {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeQuery,
+				entry.MessageType,
+			)
+		}
+		if entry.Message == nil {
+			t.Error("expected Message to be set")
+		}
+	})
+
+	t.Run("NewQueryEntryAny", func(t *testing.T) {
+		entry := lsq.NewQueryEntryAny()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeQuery {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeQuery,
+				entry.MessageType,
+			)
+		}
+		if entry.Message != nil {
+			t.Error("expected Message to be nil for 'any' entry")
+		}
+	})
+
+	t.Run("NewResultEntry", func(t *testing.T) {
+		entry := lsq.NewResultEntry(testResult)
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if !entry.IsResponse {
+			t.Error("expected IsResponse to be true")
+		}
+		if len(entry.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(entry.Messages))
+		}
+	})
+
+	t.Run("NewReleaseEntry", func(t *testing.T) {
+		entry := lsq.NewReleaseEntry()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false")
+		}
+		if entry.MessageType != localstatequery.MessageTypeRelease {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeRelease,
+				entry.MessageType,
+			)
+		}
+	})
+
+	t.Run("NewDoneEntry", func(t *testing.T) {
+		entry := lsq.NewDoneEntry()
+
+		if entry.ProtocolId != localstatequery.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				localstatequery.ProtocolId,
+				entry.ProtocolId,
+			)
+		}
+		if entry.IsResponse {
+			t.Error("expected IsResponse to be false for Done message")
+		}
+		if entry.MessageType != localstatequery.MessageTypeDone {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeDone,
+				entry.MessageType,
+			)
+		}
+		if entry.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+}
+
+// TestQueryBuilders tests the query builder functions
+func TestQueryBuilders(t *testing.T) {
+	t.Run("NewCurrentEraQuery", func(t *testing.T) {
+		query, err := lsq.NewCurrentEraQuery()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+
+	t.Run("NewEpochNoQuery", func(t *testing.T) {
+		query, err := lsq.NewEpochNoQuery(6) // Conway era
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+
+	t.Run("NewSystemStartQuery", func(t *testing.T) {
+		query, err := lsq.NewSystemStartQuery()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+
+	t.Run("NewChainPointQuery", func(t *testing.T) {
+		query, err := lsq.NewChainPointQuery()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+
+	t.Run("NewProtocolParamsQuery", func(t *testing.T) {
+		query, err := lsq.NewProtocolParamsQuery(6) // Conway era
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+
+	t.Run("NewStakeDistributionQuery", func(t *testing.T) {
+		query, err := lsq.NewStakeDistributionQuery(6) // Conway era
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(query) == 0 {
+			t.Error("expected non-empty query")
+		}
+	})
+}
+
+// TestResultBuilders tests the result builder functions
+func TestResultBuilders(t *testing.T) {
+	t.Run("NewCurrentEraResult", func(t *testing.T) {
+		result, err := lsq.NewCurrentEraResult(6)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewEpochNoResult", func(t *testing.T) {
+		result, err := lsq.NewEpochNoResult(500)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewSystemStartResult", func(t *testing.T) {
+		startTime := time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC)
+		result, err := lsq.NewSystemStartResult(startTime)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewChainPointResult with origin", func(t *testing.T) {
+		originPoint := pcommon.NewPoint(0, nil)
+		result, err := lsq.NewChainPointResult(originPoint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewChainPointResult with point", func(t *testing.T) {
+		result, err := lsq.NewChainPointResult(testPoint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewProtocolParamsResult", func(t *testing.T) {
+		params := lsq.ProtocolParamsResult{
+			MinFeeA:            44,
+			MinFeeB:            155381,
+			MaxBlockBodySize:   90112,
+			MaxTxSize:          16384,
+			MaxBlockHeaderSize: 1100,
+			KeyDeposit:         2000000,
+			PoolDeposit:        500000000,
+			EMax:               18,
+			NOpt:               500,
+			ProtocolMajorVer:   9,
+			ProtocolMinorVer:   0,
+			MinPoolCost:        170000000,
+			CoinsPerUTxOByte:   4310,
+		}
+		result, err := lsq.NewProtocolParamsResult(params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewUTxOByAddressResult empty", func(t *testing.T) {
+		result, err := lsq.NewUTxOByAddressResult(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewUTxOByAddressResult with utxos", func(t *testing.T) {
+		utxos := []lsq.UTxOResult{
+			{
+				TxHash:      testBlockHash,
+				OutputIndex: 0,
+				Address:     lsq.MockAddress,
+				Amount:      10000000,
+				Assets:      nil,
+			},
+		}
+		result, err := lsq.NewUTxOByAddressResult(utxos)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewUTxOByAddressResult with assets", func(t *testing.T) {
+		utxos := []lsq.UTxOResult{
+			{
+				TxHash:      testBlockHash,
+				OutputIndex: 0,
+				Address:     lsq.MockAddress,
+				Amount:      10000000,
+				Assets: map[string]map[string]uint64{
+					"policy1": {
+						"asset1": 100,
+					},
+				},
+			},
+		}
+		result, err := lsq.NewUTxOByAddressResult(utxos)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewStakeDistributionResult empty", func(t *testing.T) {
+		result, err := lsq.NewStakeDistributionResult(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewStakeDistributionResult with entries", func(t *testing.T) {
+		distribution := []lsq.StakeDistributionEntry{
+			{
+				PoolId:        lsq.MockPoolId,
+				StakeFraction: [2]uint64{1, 100},
+				VrfKeyHash:    lsq.MockVrfKeyHash,
+			},
+		}
+		result, err := lsq.NewStakeDistributionResult(distribution)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+
+	t.Run("NewEmptyResult", func(t *testing.T) {
+		result, err := lsq.NewEmptyResult()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) == 0 {
+			t.Error("expected non-empty result")
+		}
+	})
+}
+
+// TestQueryTypeConstants tests that query type constants are exported correctly
+func TestQueryTypeConstants(t *testing.T) {
+	// Verify constants match the underlying gouroboros values
+	if lsq.QueryTypeBlock != localstatequery.QueryTypeBlock {
+		t.Errorf(
+			"QueryTypeBlock mismatch: expected %d, got %d",
+			localstatequery.QueryTypeBlock,
+			lsq.QueryTypeBlock,
+		)
+	}
+	if lsq.QueryTypeSystemStart != localstatequery.QueryTypeSystemStart {
+		t.Errorf(
+			"QueryTypeSystemStart mismatch: expected %d, got %d",
+			localstatequery.QueryTypeSystemStart,
+			lsq.QueryTypeSystemStart,
+		)
+	}
+	if lsq.QueryTypeChainPoint != localstatequery.QueryTypeChainPoint {
+		t.Errorf(
+			"QueryTypeChainPoint mismatch: expected %d, got %d",
+			localstatequery.QueryTypeChainPoint,
+			lsq.QueryTypeChainPoint,
+		)
+	}
+	if lsq.QueryTypeShelley != localstatequery.QueryTypeShelley {
+		t.Errorf(
+			"QueryTypeShelley mismatch: expected %d, got %d",
+			localstatequery.QueryTypeShelley,
+			lsq.QueryTypeShelley,
+		)
+	}
+	if lsq.QueryTypeHardFork != localstatequery.QueryTypeHardFork {
+		t.Errorf(
+			"QueryTypeHardFork mismatch: expected %d, got %d",
+			localstatequery.QueryTypeHardFork,
+			lsq.QueryTypeHardFork,
+		)
+	}
+	if lsq.QueryTypeHardForkCurrentEra != localstatequery.QueryTypeHardForkCurrentEra {
+		t.Errorf(
+			"QueryTypeHardForkCurrentEra mismatch: expected %d, got %d",
+			localstatequery.QueryTypeHardForkCurrentEra,
+			lsq.QueryTypeHardForkCurrentEra,
+		)
+	}
+	if lsq.QueryTypeShelleyEpochNo != localstatequery.QueryTypeShelleyEpochNo {
+		t.Errorf(
+			"QueryTypeShelleyEpochNo mismatch: expected %d, got %d",
+			localstatequery.QueryTypeShelleyEpochNo,
+			lsq.QueryTypeShelleyEpochNo,
+		)
+	}
+	if lsq.QueryTypeShelleyCurrentProtocolParams != localstatequery.QueryTypeShelleyCurrentProtocolParams {
+		t.Errorf(
+			"QueryTypeShelleyCurrentProtocolParams mismatch: expected %d, got %d",
+			localstatequery.QueryTypeShelleyCurrentProtocolParams,
+			lsq.QueryTypeShelleyCurrentProtocolParams,
+		)
+	}
+	if lsq.QueryTypeShelleyStakeDistribution != localstatequery.QueryTypeShelleyStakeDistribution {
+		t.Errorf(
+			"QueryTypeShelleyStakeDistribution mismatch: expected %d, got %d",
+			localstatequery.QueryTypeShelleyStakeDistribution,
+			lsq.QueryTypeShelleyStakeDistribution,
+		)
+	}
+	if lsq.QueryTypeShelleyUtxoByAddress != localstatequery.QueryTypeShelleyUtxoByAddress {
+		t.Errorf(
+			"QueryTypeShelleyUtxoByAddress mismatch: expected %d, got %d",
+			localstatequery.QueryTypeShelleyUtxoByAddress,
+			lsq.QueryTypeShelleyUtxoByAddress,
+		)
+	}
+}
+
+// TestMockConstants tests the mock constants and fixtures
+func TestMockConstants(t *testing.T) {
+	t.Run("MockCurrentEra", func(t *testing.T) {
+		if lsq.MockCurrentEra != 6 {
+			t.Errorf(
+				"expected MockCurrentEra to be 6 (Conway), got %d",
+				lsq.MockCurrentEra,
+			)
+		}
+	})
+
+	t.Run("MockEpochNo", func(t *testing.T) {
+		if lsq.MockEpochNo != 500 {
+			t.Errorf("expected MockEpochNo to be 500, got %d", lsq.MockEpochNo)
+		}
+	})
+
+	t.Run("MockSystemStartTime", func(t *testing.T) {
+		expected := time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC)
+		if !lsq.MockSystemStartTime.Equal(expected) {
+			t.Errorf(
+				"expected MockSystemStartTime to be %v, got %v",
+				expected,
+				lsq.MockSystemStartTime,
+			)
+		}
+	})
+
+	t.Run("MockBlockHash", func(t *testing.T) {
+		if len(lsq.MockBlockHash) != 32 {
+			t.Errorf(
+				"expected MockBlockHash to be 32 bytes, got %d",
+				len(lsq.MockBlockHash),
+			)
+		}
+	})
+
+	t.Run("MockPoint", func(t *testing.T) {
+		if lsq.MockPoint.Slot != 100000 {
+			t.Errorf(
+				"expected MockPoint.Slot to be 100000, got %d",
+				lsq.MockPoint.Slot,
+			)
+		}
+		if !bytes.Equal(lsq.MockPoint.Hash, lsq.MockBlockHash) {
+			t.Error("expected MockPoint.Hash to equal MockBlockHash")
+		}
+	})
+
+	t.Run("MockTxHash", func(t *testing.T) {
+		if len(lsq.MockTxHash) != 32 {
+			t.Errorf(
+				"expected MockTxHash to be 32 bytes, got %d",
+				len(lsq.MockTxHash),
+			)
+		}
+	})
+
+	t.Run("MockAddress", func(t *testing.T) {
+		if len(lsq.MockAddress) == 0 {
+			t.Error("expected MockAddress to be non-empty")
+		}
+	})
+
+	t.Run("MockPoolId", func(t *testing.T) {
+		if len(lsq.MockPoolId) != 28 {
+			t.Errorf(
+				"expected MockPoolId to be 28 bytes, got %d",
+				len(lsq.MockPoolId),
+			)
+		}
+	})
+
+	t.Run("MockVrfKeyHash", func(t *testing.T) {
+		if len(lsq.MockVrfKeyHash) != 32 {
+			t.Errorf(
+				"expected MockVrfKeyHash to be 32 bytes, got %d",
+				len(lsq.MockVrfKeyHash),
+			)
+		}
+	})
+}
+
+// TestFixtureConversations tests that fixture conversations are valid slices
+func TestFixtureConversations(t *testing.T) {
+	t.Run("ConversationQueryCurrentEra", func(t *testing.T) {
+		if len(lsq.ConversationQueryCurrentEra) == 0 {
+			t.Error("expected ConversationQueryCurrentEra to be non-empty")
+		}
+		// Verify it has expected structure: handshake + acquire + acquired + query + result + release
+		if len(lsq.ConversationQueryCurrentEra) < 7 {
+			t.Errorf(
+				"expected ConversationQueryCurrentEra to have at least 7 entries, got %d",
+				len(lsq.ConversationQueryCurrentEra),
+			)
+		}
+	})
+
+	t.Run("ConversationQueryProtocolParams", func(t *testing.T) {
+		if len(lsq.ConversationQueryProtocolParams) == 0 {
+			t.Error("expected ConversationQueryProtocolParams to be non-empty")
+		}
+		if len(lsq.ConversationQueryProtocolParams) < 7 {
+			t.Errorf(
+				"expected ConversationQueryProtocolParams to have at least 7 entries, got %d",
+				len(lsq.ConversationQueryProtocolParams),
+			)
+		}
+	})
+
+	t.Run("ConversationQueryUTxOByAddress", func(t *testing.T) {
+		if len(lsq.ConversationQueryUTxOByAddress) == 0 {
+			t.Error("expected ConversationQueryUTxOByAddress to be non-empty")
+		}
+		if len(lsq.ConversationQueryUTxOByAddress) < 7 {
+			t.Errorf(
+				"expected ConversationQueryUTxOByAddress to have at least 7 entries, got %d",
+				len(lsq.ConversationQueryUTxOByAddress),
+			)
+		}
+	})
+
+	t.Run("ConversationQueryMultiple", func(t *testing.T) {
+		if len(lsq.ConversationQueryMultiple) == 0 {
+			t.Error("expected ConversationQueryMultiple to be non-empty")
+		}
+		// Should have: handshake(2) + acquire(1) + acquired(1) + 4*(query+result) + release(1) = 13
+		if len(lsq.ConversationQueryMultiple) < 13 {
+			t.Errorf(
+				"expected ConversationQueryMultiple to have at least 13 entries, got %d",
+				len(lsq.ConversationQueryMultiple),
+			)
+		}
+	})
+
+	t.Run("ConversationQuerySystemStart", func(t *testing.T) {
+		if len(lsq.ConversationQuerySystemStart) == 0 {
+			t.Error("expected ConversationQuerySystemStart to be non-empty")
+		}
+		if len(lsq.ConversationQuerySystemStart) < 7 {
+			t.Errorf(
+				"expected ConversationQuerySystemStart to have at least 7 entries, got %d",
+				len(lsq.ConversationQuerySystemStart),
+			)
+		}
+	})
+
+	t.Run("ConversationQueryAcquireFailure", func(t *testing.T) {
+		if len(lsq.ConversationQueryAcquireFailure) == 0 {
+			t.Error("expected ConversationQueryAcquireFailure to be non-empty")
+		}
+		// Should have: handshake(2) + acquire(1) + failure(1) = 4
+		if len(lsq.ConversationQueryAcquireFailure) < 4 {
+			t.Errorf(
+				"expected ConversationQueryAcquireFailure to have at least 4 entries, got %d",
+				len(lsq.ConversationQueryAcquireFailure),
+			)
+		}
+	})
+
+	t.Run("ConversationQueryWithReacquire", func(t *testing.T) {
+		if len(lsq.ConversationQueryWithReacquire) == 0 {
+			t.Error("expected ConversationQueryWithReacquire to be non-empty")
+		}
+		// Should have: handshake(2) + acquire(1) + acquired(1) + query+result(2) + reacquire(1) + acquired(1) + query+result(2) + release(1) = 11
+		if len(lsq.ConversationQueryWithReacquire) < 11 {
+			t.Errorf(
+				"expected ConversationQueryWithReacquire to have at least 11 entries, got %d",
+				len(lsq.ConversationQueryWithReacquire),
+			)
+		}
+	})
+}
+
+// TestInputEntriesHaveMsgFromCborFunc verifies that all input entries have MsgFromCborFunc set
+func TestInputEntriesHaveMsgFromCborFunc(t *testing.T) {
+	t.Run("ConversationEntryAcquire", func(t *testing.T) {
+		result := lsq.ConversationEntryAcquire{}.ToEntry()
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ConversationEntryReAcquire", func(t *testing.T) {
+		result := lsq.ConversationEntryReAcquire{}.ToEntry()
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ConversationEntryQuery", func(t *testing.T) {
+		result := lsq.ConversationEntryQuery{}.ToEntry()
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ConversationEntryRelease", func(t *testing.T) {
+		result := lsq.ConversationEntryRelease{}.ToEntry()
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+}
+
+// TestOutputEntriesHaveMessages verifies that all output entries have at least one message
+func TestOutputEntriesHaveMessages(t *testing.T) {
+	t.Run("ConversationEntryAcquired", func(t *testing.T) {
+		result := lsq.ConversationEntryAcquired{}.ToEntry()
+		if len(result.Messages) == 0 {
+			t.Error("expected at least one message")
+		}
+	})
+
+	t.Run("ConversationEntryAcquireFailure", func(t *testing.T) {
+		result := lsq.ConversationEntryAcquireFailure{Failure: 0}.ToEntry()
+		if len(result.Messages) == 0 {
+			t.Error("expected at least one message")
+		}
+	})
+
+	t.Run("ConversationEntryResult", func(t *testing.T) {
+		result := lsq.ConversationEntryResult{Result: []byte{0x00}}.ToEntry()
+		if len(result.Messages) == 0 {
+			t.Error("expected at least one message")
+		}
+	})
+
+	t.Run("ConversationEntryDone", func(t *testing.T) {
+		result := lsq.ConversationEntryDone{}.ToEntry()
+		if result.MessageType != localstatequery.MessageTypeDone {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeDone,
+				result.MessageType,
+			)
+		}
+	})
+}
+
+// TestProtocolIdConsistency verifies all entries use the correct protocol ID
+func TestProtocolIdConsistency(t *testing.T) {
+	expectedProtocolId := localstatequery.ProtocolId
+
+	t.Run("Acquire", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquire{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("ReAcquire", func(t *testing.T) {
+		entry := lsq.ConversationEntryReAcquire{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		entry := lsq.ConversationEntryQuery{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("Release", func(t *testing.T) {
+		entry := lsq.ConversationEntryRelease{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("Acquired", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquired{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("AcquireFailure", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquireFailure{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("Result", func(t *testing.T) {
+		entry := lsq.ConversationEntryResult{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+
+	t.Run("Done", func(t *testing.T) {
+		entry := lsq.ConversationEntryDone{}
+		result := entry.ToEntry()
+		if result.ProtocolId != expectedProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				expectedProtocolId,
+				result.ProtocolId,
+			)
+		}
+	})
+}
+
+// TestIsResponseValues verifies correct IsResponse values for all entry types
+func TestIsResponseValues(t *testing.T) {
+	t.Run("Acquire should have IsResponse=false", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquire{}
+		result := entry.ToEntry()
+		if result.IsResponse {
+			t.Error("ConversationEntryAcquire should have IsResponse=false")
+		}
+	})
+
+	t.Run("ReAcquire should have IsResponse=false", func(t *testing.T) {
+		entry := lsq.ConversationEntryReAcquire{}
+		result := entry.ToEntry()
+		if result.IsResponse {
+			t.Error("ConversationEntryReAcquire should have IsResponse=false")
+		}
+	})
+
+	t.Run("Query should have IsResponse=false", func(t *testing.T) {
+		entry := lsq.ConversationEntryQuery{}
+		result := entry.ToEntry()
+		if result.IsResponse {
+			t.Error("ConversationEntryQuery should have IsResponse=false")
+		}
+	})
+
+	t.Run("Release should have IsResponse=false", func(t *testing.T) {
+		entry := lsq.ConversationEntryRelease{}
+		result := entry.ToEntry()
+		if result.IsResponse {
+			t.Error("ConversationEntryRelease should have IsResponse=false")
+		}
+	})
+
+	t.Run("Acquired should have IsResponse=true", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquired{}
+		result := entry.ToEntry()
+		if !result.IsResponse {
+			t.Error("ConversationEntryAcquired should have IsResponse=true")
+		}
+	})
+
+	t.Run("AcquireFailure should have IsResponse=true", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquireFailure{}
+		result := entry.ToEntry()
+		if !result.IsResponse {
+			t.Error(
+				"ConversationEntryAcquireFailure should have IsResponse=true",
+			)
+		}
+	})
+
+	t.Run("Result should have IsResponse=true", func(t *testing.T) {
+		entry := lsq.ConversationEntryResult{}
+		result := entry.ToEntry()
+		if !result.IsResponse {
+			t.Error("ConversationEntryResult should have IsResponse=true")
+		}
+	})
+
+	t.Run("Done should have IsResponse=false", func(t *testing.T) {
+		entry := lsq.ConversationEntryDone{}
+		result := entry.ToEntry()
+		if result.IsResponse {
+			t.Error(
+				"ConversationEntryDone should have IsResponse=false (client-initiated)",
+			)
+		}
+	})
+}
+
+// TestMessageTypeValues verifies correct message types for input entries
+func TestMessageTypeValues(t *testing.T) {
+	t.Run("Acquire", func(t *testing.T) {
+		entry := lsq.ConversationEntryAcquire{}
+		result := entry.ToEntry()
+		if result.MessageType != localstatequery.MessageTypeAcquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeAcquire,
+				result.MessageType,
+			)
+		}
+	})
+
+	t.Run("ReAcquire", func(t *testing.T) {
+		entry := lsq.ConversationEntryReAcquire{}
+		result := entry.ToEntry()
+		if result.MessageType != localstatequery.MessageTypeReacquire {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeReacquire,
+				result.MessageType,
+			)
+		}
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		entry := lsq.ConversationEntryQuery{}
+		result := entry.ToEntry()
+		if result.MessageType != localstatequery.MessageTypeQuery {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeQuery,
+				result.MessageType,
+			)
+		}
+	})
+
+	t.Run("Release", func(t *testing.T) {
+		entry := lsq.ConversationEntryRelease{}
+		result := entry.ToEntry()
+		if result.MessageType != localstatequery.MessageTypeRelease {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				localstatequery.MessageTypeRelease,
+				result.MessageType,
+			)
+		}
+	})
+}

--- a/localstatequery/fixtures.go
+++ b/localstatequery/fixtures.go
@@ -1,0 +1,335 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"time"
+
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for LocalStateQuery testing
+
+// MockCurrentEra is the default mock era (Conway = 6)
+const MockCurrentEra uint = 6
+
+// MockEpochNo is a sample epoch number for testing
+const MockEpochNo uint64 = 500
+
+// MockSystemStartTime is the blockchain origin time (Byron mainnet start: September 23, 2017)
+// Note: This is the chain's SystemStart, not when any particular era started
+var MockSystemStartTime = time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC)
+
+// MockBlockHash is a sample block hash for testing
+var MockBlockHash = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// MockPoint is a sample chain point for testing
+var MockPoint = pcommon.NewPoint(100000, MockBlockHash)
+
+// MockTxHash is a sample transaction hash for UTxO testing
+var MockTxHash = []byte{
+	0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+	0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+	0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+	0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+}
+
+// MockAddress is a sample Shelley address bytes for testing
+var MockAddress = []byte{
+	0x01, // Shelley payment address type
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x01, 0x02, 0x03, 0x04,
+	0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+	0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+	0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+}
+
+// MockPoolId is a sample pool ID for testing
+var MockPoolId = []byte{
+	0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90,
+	0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90,
+	0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90,
+	0xab, 0xcd, 0xef, 0x12,
+}
+
+// MockVrfKeyHash is a sample VRF key hash for testing
+var MockVrfKeyHash = []byte{
+	0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+	0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+	0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+	0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+}
+
+// Helper function to build mock current era result CBOR
+func mockCurrentEraResult() []byte {
+	result, err := NewCurrentEraResult(MockCurrentEra)
+	if err != nil {
+		return []byte{0x06} // fallback: CBOR encoded 6
+	}
+	return result
+}
+
+// Helper function to build mock epoch number result CBOR
+func mockEpochNoResult() []byte {
+	result, err := NewEpochNoResult(MockEpochNo)
+	if err != nil {
+		return []byte{0x19, 0x01, 0xf4} // fallback: CBOR encoded 500
+	}
+	return result
+}
+
+// Helper function to build mock system start result CBOR
+func mockSystemStartResult() []byte {
+	result, err := NewSystemStartResult(MockSystemStartTime)
+	if err != nil {
+		// Fallback: minimal CBOR array
+		return []byte{0x83, 0x19, 0x07, 0xe1, 0x19, 0x01, 0x0a, 0x00}
+	}
+	return result
+}
+
+// Helper function to build mock chain point result CBOR
+func mockChainPointResult() []byte {
+	result, err := NewChainPointResult(MockPoint)
+	if err != nil {
+		return []byte{0x82, 0x00, 0x40} // fallback: minimal point
+	}
+	return result
+}
+
+// Helper function to build mock protocol params result CBOR
+func mockProtocolParamsResult() []byte {
+	params := ProtocolParamsResult{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   90112,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		EMax:               18,
+		NOpt:               500,
+		ProtocolMajorVer:   9,
+		ProtocolMinorVer:   0,
+		MinPoolCost:        170000000,
+		CoinsPerUTxOByte:   4310,
+	}
+	result, err := NewProtocolParamsResult(params)
+	if err != nil {
+		return []byte{0xa0} // fallback: empty map
+	}
+	return result
+}
+
+// Helper function to build mock UTxO result CBOR
+func mockUtxoResult() []byte {
+	utxos := []UTxOResult{
+		{
+			TxHash:      MockTxHash,
+			OutputIndex: 0,
+			Address:     MockAddress,
+			Amount:      10000000, // 10 ADA
+			Assets:      nil,
+		},
+		{
+			TxHash:      MockTxHash,
+			OutputIndex: 1,
+			Address:     MockAddress,
+			Amount:      5000000, // 5 ADA
+			Assets:      nil,
+		},
+	}
+	result, err := NewUTxOByAddressResult(utxos)
+	if err != nil {
+		return []byte{0xa0} // fallback: empty map
+	}
+	return result
+}
+
+// Pre-defined conversations for common LocalStateQuery scenarios
+
+// ConversationQueryCurrentEra is a pre-defined conversation for querying the current era:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (current era)
+// - Result (era number)
+// - Release
+var ConversationQueryCurrentEra = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at volatile tip
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query current era
+	NewQueryEntryAny(),
+	NewResultEntry(mockCurrentEraResult()),
+	// Release
+	NewReleaseEntry(),
+}
+
+// ConversationQueryProtocolParams is a pre-defined conversation for querying protocol parameters:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (protocol parameters)
+// - Result (protocol parameters)
+// - Release
+var ConversationQueryProtocolParams = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at volatile tip
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query protocol parameters
+	NewQueryEntryAny(),
+	NewResultEntry(mockProtocolParamsResult()),
+	// Release
+	NewReleaseEntry(),
+}
+
+// ConversationQueryUTxOByAddress is a pre-defined conversation for querying UTxOs by address:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (UTxO by address)
+// - Result (UTxO set)
+// - Release
+var ConversationQueryUTxOByAddress = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at volatile tip
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query UTxO by address
+	NewQueryEntryAny(),
+	NewResultEntry(mockUtxoResult()),
+	// Release
+	NewReleaseEntry(),
+}
+
+// ConversationQueryMultiple is a pre-defined conversation for multiple queries in one session:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (current era) -> Result
+// - Query (epoch number) -> Result
+// - Query (protocol parameters) -> Result
+// - Query (chain point) -> Result
+// - Release
+var ConversationQueryMultiple = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at volatile tip
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query 1: current era
+	NewQueryEntryAny(),
+	NewResultEntry(mockCurrentEraResult()),
+	// Query 2: epoch number
+	NewQueryEntryAny(),
+	NewResultEntry(mockEpochNoResult()),
+	// Query 3: protocol parameters
+	NewQueryEntryAny(),
+	NewResultEntry(mockProtocolParamsResult()),
+	// Query 4: chain point
+	NewQueryEntryAny(),
+	NewResultEntry(mockChainPointResult()),
+	// Release
+	NewReleaseEntry(),
+}
+
+// ConversationQuerySystemStart is a pre-defined conversation for querying system start:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (system start)
+// - Result (system start time)
+// - Release
+var ConversationQuerySystemStart = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at volatile tip
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query system start
+	NewQueryEntryAny(),
+	NewResultEntry(mockSystemStartResult()),
+	// Release
+	NewReleaseEntry(),
+}
+
+// ConversationQueryAcquireFailure is a pre-defined conversation for acquire failure scenario:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (specific point)
+// - Failure (point not on chain)
+var ConversationQueryAcquireFailure = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire at specific point
+	NewAcquireEntryAny(),
+	// Failure - point not on chain
+	NewAcquireFailurePointNotOnChainEntry(),
+}
+
+// ConversationQueryWithReacquire is a pre-defined conversation with reacquire:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire (volatile tip)
+// - Acquired
+// - Query (current era) -> Result
+// - ReAcquire (volatile tip)
+// - Acquired
+// - Query (epoch number) -> Result
+// - Release
+var ConversationQueryWithReacquire = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// First acquire
+	NewAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query current era
+	NewQueryEntryAny(),
+	NewResultEntry(mockCurrentEraResult()),
+	// ReAcquire at volatile tip
+	NewReAcquireEntryAny(),
+	NewAcquiredEntry(),
+	// Query epoch number
+	NewQueryEntryAny(),
+	NewResultEntry(mockEpochNoResult()),
+	// Release
+	NewReleaseEntry(),
+}

--- a/localstatequery/queries.go
+++ b/localstatequery/queries.go
@@ -1,0 +1,339 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// Query type constants from gouroboros
+const (
+	QueryTypeBlock       = localstatequery.QueryTypeBlock
+	QueryTypeSystemStart = localstatequery.QueryTypeSystemStart
+	QueryTypeChainPoint  = localstatequery.QueryTypeChainPoint
+
+	QueryTypeShelley  = localstatequery.QueryTypeShelley
+	QueryTypeHardFork = localstatequery.QueryTypeHardFork
+
+	QueryTypeHardForkCurrentEra = localstatequery.QueryTypeHardForkCurrentEra
+
+	QueryTypeShelleyEpochNo                              = localstatequery.QueryTypeShelleyEpochNo
+	QueryTypeShelleyCurrentProtocolParams                = localstatequery.QueryTypeShelleyCurrentProtocolParams
+	QueryTypeShelleyStakeDistribution                    = localstatequery.QueryTypeShelleyStakeDistribution
+	QueryTypeShelleyUtxoByAddress                        = localstatequery.QueryTypeShelleyUtxoByAddress
+	QueryTypeShelleyFilteredDelegationsAndRewardAccounts = localstatequery.QueryTypeShelleyFilteredDelegationAndRewardAccounts
+)
+
+// Query builders for common query types
+
+// NewCurrentEraQuery builds a query for the current era
+func NewCurrentEraQuery() ([]byte, error) {
+	// Query structure: [QueryTypeBlock, [QueryTypeHardFork, [QueryTypeHardForkCurrentEra]]]
+	query := cbor.IndefLengthList{
+		QueryTypeBlock,
+		cbor.IndefLengthList{
+			QueryTypeHardFork,
+			cbor.IndefLengthList{
+				QueryTypeHardForkCurrentEra,
+			},
+		},
+	}
+	return cbor.Encode(query)
+}
+
+// NewEpochNoQuery builds a query for the current epoch number
+func NewEpochNoQuery(era int) ([]byte, error) {
+	// Query structure: [QueryTypeBlock, [QueryTypeShelley, era, [QueryTypeShelleyEpochNo]]]
+	query := cbor.IndefLengthList{
+		QueryTypeBlock,
+		cbor.IndefLengthList{
+			QueryTypeShelley,
+			era,
+			cbor.IndefLengthList{
+				QueryTypeShelleyEpochNo,
+			},
+		},
+	}
+	return cbor.Encode(query)
+}
+
+// NewSystemStartQuery builds a query for the system start time
+func NewSystemStartQuery() ([]byte, error) {
+	// Query structure: [QueryTypeSystemStart]
+	query := cbor.IndefLengthList{
+		QueryTypeSystemStart,
+	}
+	return cbor.Encode(query)
+}
+
+// NewChainPointQuery builds a query for the current chain point
+func NewChainPointQuery() ([]byte, error) {
+	// Query structure: [QueryTypeChainPoint]
+	query := cbor.IndefLengthList{
+		QueryTypeChainPoint,
+	}
+	return cbor.Encode(query)
+}
+
+// NewProtocolParamsQuery builds a query for the current protocol parameters
+func NewProtocolParamsQuery(era int) ([]byte, error) {
+	// Query structure: [QueryTypeBlock, [QueryTypeShelley, era, [QueryTypeShelleyCurrentProtocolParams]]]
+	query := cbor.IndefLengthList{
+		QueryTypeBlock,
+		cbor.IndefLengthList{
+			QueryTypeShelley,
+			era,
+			cbor.IndefLengthList{
+				QueryTypeShelleyCurrentProtocolParams,
+			},
+		},
+	}
+	return cbor.Encode(query)
+}
+
+// NewUTxOByAddressQuery builds a query for UTxOs by address
+func NewUTxOByAddressQuery(
+	era int,
+	addresses []lcommon.Address,
+) ([]byte, error) {
+	// Convert addresses to byte arrays
+	addrBytes := make([][]byte, len(addresses))
+	for i, addr := range addresses {
+		bytes, err := addr.Bytes()
+		if err != nil {
+			return nil, err
+		}
+		addrBytes[i] = bytes
+	}
+
+	// Query structure: [QueryTypeBlock, [QueryTypeShelley, era, [QueryTypeShelleyUtxoByAddress, [addresses...]]]]
+	query := cbor.IndefLengthList{
+		QueryTypeBlock,
+		cbor.IndefLengthList{
+			QueryTypeShelley,
+			era,
+			cbor.IndefLengthList{
+				QueryTypeShelleyUtxoByAddress,
+				addrBytes,
+			},
+		},
+	}
+	return cbor.Encode(query)
+}
+
+// NewStakeDistributionQuery builds a query for stake distribution
+func NewStakeDistributionQuery(era int) ([]byte, error) {
+	// Query structure: [QueryTypeBlock, [QueryTypeShelley, era, [QueryTypeShelleyStakeDistribution]]]
+	query := cbor.IndefLengthList{
+		QueryTypeBlock,
+		cbor.IndefLengthList{
+			QueryTypeShelley,
+			era,
+			cbor.IndefLengthList{
+				QueryTypeShelleyStakeDistribution,
+			},
+		},
+	}
+	return cbor.Encode(query)
+}
+
+// Result builders for common query results
+
+// NewCurrentEraResult builds a result for the current era query
+func NewCurrentEraResult(era uint) ([]byte, error) {
+	return cbor.Encode(era)
+}
+
+// NewEpochNoResult builds a result for the epoch number query
+func NewEpochNoResult(epochNo uint64) ([]byte, error) {
+	return cbor.Encode(epochNo)
+}
+
+// NewSystemStartResult builds a result for the system start query
+func NewSystemStartResult(startTime time.Time) ([]byte, error) {
+	// System start is encoded as [year, dayOfYear, picoseconds]
+	year := startTime.Year()
+	dayOfYear := startTime.YearDay()
+	// Calculate picoseconds from midnight
+	midnight := time.Date(
+		startTime.Year(),
+		startTime.Month(),
+		startTime.Day(),
+		0,
+		0,
+		0,
+		0,
+		startTime.Location(),
+	)
+	// #nosec G115 - nanoseconds since midnight are always positive and within uint64 range
+	picoseconds := uint64(startTime.Sub(midnight).Nanoseconds()) * 1000
+
+	result := cbor.IndefLengthList{
+		year,
+		dayOfYear,
+		picoseconds,
+	}
+	return cbor.Encode(result)
+}
+
+// NewChainPointResult builds a result for the chain point query
+func NewChainPointResult(point pcommon.Point) ([]byte, error) {
+	if point.Slot == 0 && len(point.Hash) == 0 {
+		// Origin point
+		return cbor.Encode(cbor.IndefLengthList{})
+	}
+	result := cbor.IndefLengthList{
+		point.Slot,
+		point.Hash,
+	}
+	return cbor.Encode(result)
+}
+
+// ProtocolParamsResult holds simplified protocol parameters for building results
+type ProtocolParamsResult struct {
+	MinFeeA            uint64
+	MinFeeB            uint64
+	MaxBlockBodySize   uint64
+	MaxTxSize          uint64
+	MaxBlockHeaderSize uint64
+	KeyDeposit         uint64
+	PoolDeposit        uint64
+	EMax               uint64
+	NOpt               uint64
+	ProtocolMajorVer   uint64
+	ProtocolMinorVer   uint64
+	MinPoolCost        uint64
+	CoinsPerUTxOByte   uint64
+}
+
+// NewProtocolParamsResult builds a result for the protocol parameters query
+func NewProtocolParamsResult(params ProtocolParamsResult) ([]byte, error) {
+	// Protocol parameters are encoded as a map
+	// This is a simplified version - actual encoding depends on era
+	paramsMap := map[uint]any{
+		0:  params.MinFeeA,
+		1:  params.MinFeeB,
+		2:  params.MaxBlockBodySize,
+		3:  params.MaxTxSize,
+		4:  params.MaxBlockHeaderSize,
+		5:  params.KeyDeposit,
+		6:  params.PoolDeposit,
+		7:  params.EMax,
+		8:  params.NOpt,
+		14: params.ProtocolMajorVer,
+		15: params.ProtocolMinorVer,
+		16: params.MinPoolCost,
+		17: params.CoinsPerUTxOByte,
+	}
+	return cbor.Encode(paramsMap)
+}
+
+// UTxOResult represents a single UTxO for building results
+type UTxOResult struct {
+	TxHash      []byte
+	OutputIndex uint32
+	Address     []byte
+	Amount      uint64
+	Assets      map[string]map[string]uint64 // PolicyId -> AssetName -> Amount
+}
+
+// NewUTxOByAddressResult builds a result for the UTxO by address query
+func NewUTxOByAddressResult(utxos []UTxOResult) ([]byte, error) {
+	// UTxOs are encoded as a map from TxIn to TxOut
+	// TxIn: [txHash, outputIndex]
+	// TxOut: [address, value, ...]
+	//
+	// Implementation note: Per Cardano CDDL, TxIn should be a 2-element array
+	// key [txHash, outputIndex], not a byte string. However, Go maps don't
+	// support slice or array keys directly, so we pre-encode the TxIn array
+	// to CBOR bytes and use ByteString as the map key. This results in the
+	// TxIn being double-CBOR-encoded (once here, once in the final Encode).
+	// This produces non-standard CBOR but is acceptable for mock/test purposes
+	// where clients may not strictly validate the encoding format.
+	utxoMap := make(map[cbor.ByteString]any)
+
+	for _, utxo := range utxos {
+		// Create TxIn as CBOR bytes
+		txIn := cbor.IndefLengthList{utxo.TxHash, utxo.OutputIndex}
+		txInBytes, err := cbor.Encode(txIn)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create TxOut value
+		var value any
+		if len(utxo.Assets) > 0 {
+			// Multi-asset value: [lovelace, {policyId: {assetName: amount}}]
+			assetsMap := make(map[cbor.ByteString]map[cbor.ByteString]uint64)
+			for policyId, assets := range utxo.Assets {
+				policyKey := cbor.NewByteString([]byte(policyId))
+				assetsMap[policyKey] = make(map[cbor.ByteString]uint64)
+				for assetName, amount := range assets {
+					assetKey := cbor.NewByteString([]byte(assetName))
+					assetsMap[policyKey][assetKey] = amount
+				}
+			}
+			value = cbor.IndefLengthList{utxo.Amount, assetsMap}
+		} else {
+			// Simple lovelace value
+			value = utxo.Amount
+		}
+
+		// Create TxOut
+		txOut := cbor.IndefLengthList{utxo.Address, value}
+
+		utxoMap[cbor.NewByteString(txInBytes)] = txOut
+	}
+
+	return cbor.Encode(utxoMap)
+}
+
+// StakeDistributionEntry represents a single stake pool's distribution
+type StakeDistributionEntry struct {
+	PoolId        []byte
+	StakeFraction [2]uint64 // [numerator, denominator]
+	VrfKeyHash    []byte
+}
+
+// NewStakeDistributionResult builds a result for the stake distribution query
+func NewStakeDistributionResult(
+	distribution []StakeDistributionEntry,
+) ([]byte, error) {
+	// Stake distribution is encoded as a map from pool key hash to [rational, vrf key hash]
+	distMap := make(map[cbor.ByteString]any)
+
+	for _, entry := range distribution {
+		poolKey := cbor.NewByteString(entry.PoolId)
+		distMap[poolKey] = cbor.IndefLengthList{
+			cbor.IndefLengthList{
+				entry.StakeFraction[0],
+				entry.StakeFraction[1],
+			},
+			entry.VrfKeyHash,
+		}
+	}
+
+	return cbor.Encode(distMap)
+}
+
+// NewEmptyResult builds an empty result (used for queries that return nothing)
+func NewEmptyResult() ([]byte, error) {
+	return cbor.Encode(nil)
+}

--- a/localtxmonitor/entries.go
+++ b/localtxmonitor/entries.go
@@ -1,0 +1,270 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxmonitor
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntryAcquire expects an Acquire message from the client
+type ConversationEntryAcquire struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryAcquire) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeAcquire,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryAcquired sends an Acquired response with slot to the client
+type ConversationEntryAcquired struct {
+	SlotNo uint64 // The slot number at which the mempool snapshot was taken
+}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryOutput
+func (e ConversationEntryAcquired) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxmonitor.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxmonitor.NewMsgAcquired(e.SlotNo),
+		},
+	}
+}
+
+// ConversationEntryAwaitAcquire expects an Acquire message from the client
+// when re-acquiring after a Release. This is semantically "await acquire" -
+// waiting for mempool changes before acquiring a new snapshot. Uses the same
+// MessageTypeAcquire as the initial Acquire.
+type ConversationEntryAwaitAcquire struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryAwaitAcquire) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeAcquire,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryHasTx expects a HasTx query from the client
+type ConversationEntryHasTx struct {
+	TxId []byte // Optional: expected transaction ID for validation (nil means accept any)
+}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryHasTx) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeHasTx,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+	if e.TxId != nil {
+		entry.Message = localtxmonitor.NewMsgHasTx(e.TxId)
+	}
+	return entry
+}
+
+// ConversationEntryHasTxResult sends a HasTx result to the client
+type ConversationEntryHasTxResult struct {
+	Result bool // Whether the transaction exists in the mempool
+}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryOutput
+func (e ConversationEntryHasTxResult) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxmonitor.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxmonitor.NewMsgReplyHasTx(e.Result),
+		},
+	}
+}
+
+// ConversationEntryNextTx expects a NextTx message from the client
+type ConversationEntryNextTx struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryNextTx) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeNextTx,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryNextTxResult sends a NextTx result with optional transaction to the client
+type ConversationEntryNextTxResult struct {
+	EraId uint8  // Era ID of the transaction (only used if Tx is not nil)
+	Tx    []byte // Transaction CBOR data (nil means no more transactions)
+}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryOutput
+func (e ConversationEntryNextTxResult) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxmonitor.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxmonitor.NewMsgReplyNextTx(e.EraId, e.Tx),
+		},
+	}
+}
+
+// ConversationEntryGetSizes expects a GetSizes message from the client
+type ConversationEntryGetSizes struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryGetSizes) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeGetSizes,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntrySizes sends a Sizes response to the client
+type ConversationEntrySizes struct {
+	Capacity    uint32 // Mempool capacity in bytes
+	Size        uint32 // Current mempool size in bytes
+	NumberOfTxs uint32 // Number of transactions in the mempool
+}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryOutput
+func (e ConversationEntrySizes) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxmonitor.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxmonitor.NewMsgReplyGetSizes(
+				e.Capacity,
+				e.Size,
+				e.NumberOfTxs,
+			),
+		},
+	}
+}
+
+// ConversationEntryRelease expects a Release message from the client
+type ConversationEntryRelease struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryRelease) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeRelease,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate
+// the protocol.
+type ConversationEntryDone struct{}
+
+// ToEntry converts this LocalTxMonitor entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxmonitor.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxmonitor.MessageTypeDone,
+		MsgFromCborFunc: localtxmonitor.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewAcquireEntry creates a ConversationEntryInput for expecting an Acquire message
+func NewAcquireEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryAcquire{}.ToEntry()
+}
+
+// NewAcquiredEntry creates a ConversationEntryOutput for sending an Acquired response
+func NewAcquiredEntry(slotNo uint64) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryAcquired{SlotNo: slotNo}.ToEntry()
+}
+
+// NewAwaitAcquireEntry creates a ConversationEntryInput for expecting an
+// Acquire message after a Release (re-acquire).
+func NewAwaitAcquireEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryAwaitAcquire{}.ToEntry()
+}
+
+// NewHasTxEntry creates a ConversationEntryInput for expecting a HasTx query
+func NewHasTxEntry(txId []byte) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryHasTx{TxId: txId}.ToEntry()
+}
+
+// NewHasTxEntryAny creates a ConversationEntryInput for expecting any HasTx query
+func NewHasTxEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryHasTx{}.ToEntry()
+}
+
+// NewHasTxResultEntry creates a ConversationEntryOutput for sending a HasTx result
+func NewHasTxResultEntry(result bool) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryHasTxResult{Result: result}.ToEntry()
+}
+
+// NewNextTxEntry creates a ConversationEntryInput for expecting a NextTx message
+func NewNextTxEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryNextTx{}.ToEntry()
+}
+
+// NewNextTxResultEntry creates a ConversationEntryOutput for sending a NextTx result with transaction
+func NewNextTxResultEntry(
+	eraId uint8,
+	tx []byte,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryNextTxResult{EraId: eraId, Tx: tx}.ToEntry()
+}
+
+// NewNextTxResultEmptyEntry creates a ConversationEntryOutput for sending an empty NextTx result
+func NewNextTxResultEmptyEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryNextTxResult{}.ToEntry()
+}
+
+// NewGetSizesEntry creates a ConversationEntryInput for expecting a GetSizes message
+func NewGetSizesEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryGetSizes{}.ToEntry()
+}
+
+// NewSizesEntry creates a ConversationEntryOutput for sending a Sizes response
+func NewSizesEntry(
+	capacity, size, numberOfTxs uint32,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntrySizes{
+		Capacity:    capacity,
+		Size:        size,
+		NumberOfTxs: numberOfTxs,
+	}.ToEntry()
+}
+
+// NewReleaseEntry creates a ConversationEntryInput for expecting a Release message
+func NewReleaseEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryRelease{}.ToEntry()
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry()
+}

--- a/localtxmonitor/entries_test.go
+++ b/localtxmonitor/entries_test.go
@@ -1,0 +1,727 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxmonitor_test
+
+import (
+	"testing"
+
+	gouroboros_localtxmonitor "github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
+	"github.com/blinklabs-io/ouroboros-mock/localtxmonitor"
+)
+
+// TestConversationEntryAcquire tests the ConversationEntryAcquire entry type
+func TestConversationEntryAcquire(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryAcquire{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeAcquire {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeAcquire,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryAcquired tests the ConversationEntryAcquired entry type
+func TestConversationEntryAcquired(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryAcquired{
+		SlotNo: localtxmonitor.MockSlotNo,
+	}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryAwaitAcquire tests the ConversationEntryAwaitAcquire entry type
+func TestConversationEntryAwaitAcquire(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryAwaitAcquire{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	// AwaitAcquire expects client to send Acquire message
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	// AwaitAcquire uses same MessageTypeAcquire as regular Acquire
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeAcquire {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeAcquire,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryHasTx tests the ConversationEntryHasTx entry type
+func TestConversationEntryHasTx(t *testing.T) {
+	t.Run("ToEntry with TxId", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryHasTx{
+			TxId: localtxmonitor.MockTxId,
+		}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxmonitor.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != false {
+			t.Errorf("expected IsResponse to be false, got true")
+		}
+		if result.MessageType != gouroboros_localtxmonitor.MessageTypeHasTx {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				gouroboros_localtxmonitor.MessageTypeHasTx,
+				result.MessageType,
+			)
+		}
+		if result.Message == nil {
+			t.Error("expected Message to be set when TxId is provided")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ToEntry without TxId", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryHasTx{}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxmonitor.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.Message != nil {
+			t.Error("expected Message to be nil when TxId is not provided")
+		}
+	})
+}
+
+// TestConversationEntryHasTxResult tests the ConversationEntryHasTxResult entry type
+func TestConversationEntryHasTxResult(t *testing.T) {
+	t.Run("Result true", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryHasTxResult{Result: true}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxmonitor.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+	})
+
+	t.Run("Result false", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryHasTxResult{Result: false}
+		result := entry.ToEntry()
+
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+	})
+}
+
+// TestConversationEntryNextTx tests the ConversationEntryNextTx entry type
+func TestConversationEntryNextTx(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryNextTx{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeNextTx {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeNextTx,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryNextTxResult tests the ConversationEntryNextTxResult entry type
+func TestConversationEntryNextTxResult(t *testing.T) {
+	t.Run("with transaction", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryNextTxResult{
+			EraId: localtxmonitor.MockEraIdConway,
+			Tx:    localtxmonitor.MockTxCbor,
+		}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxmonitor.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		entry := localtxmonitor.ConversationEntryNextTxResult{}
+		result := entry.ToEntry()
+
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+	})
+}
+
+// TestConversationEntryGetSizes tests the ConversationEntryGetSizes entry type
+func TestConversationEntryGetSizes(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryGetSizes{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeGetSizes {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeGetSizes,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntrySizes tests the ConversationEntrySizes entry type
+func TestConversationEntrySizes(t *testing.T) {
+	entry := localtxmonitor.ConversationEntrySizes{
+		Capacity:    localtxmonitor.MockMempoolCapacity,
+		Size:        localtxmonitor.MockMempoolSize,
+		NumberOfTxs: localtxmonitor.MockMempoolTxCount,
+	}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryRelease tests the ConversationEntryRelease entry type
+func TestConversationEntryRelease(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryRelease{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeRelease {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeRelease,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryDone tests the ConversationEntryDone entry type
+func TestConversationEntryDone(t *testing.T) {
+	entry := localtxmonitor.ConversationEntryDone{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	// Done is sent by the client, not as a response
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewAcquireEntry tests the NewAcquireEntry helper function
+func TestNewAcquireEntry(t *testing.T) {
+	result := localtxmonitor.NewAcquireEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeAcquire {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeAcquire,
+			result.MessageType,
+		)
+	}
+}
+
+// TestNewAcquiredEntry tests the NewAcquiredEntry helper function
+func TestNewAcquiredEntry(t *testing.T) {
+	result := localtxmonitor.NewAcquiredEntry(localtxmonitor.MockSlotNo)
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewAwaitAcquireEntry tests the NewAwaitAcquireEntry helper function
+func TestNewAwaitAcquireEntry(t *testing.T) {
+	result := localtxmonitor.NewAwaitAcquireEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	// AwaitAcquire uses same MessageTypeAcquire as regular Acquire
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeAcquire {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeAcquire,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewHasTxEntry tests the NewHasTxEntry helper function
+func TestNewHasTxEntry(t *testing.T) {
+	result := localtxmonitor.NewHasTxEntry(localtxmonitor.MockTxId)
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeHasTx {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeHasTx,
+			result.MessageType,
+		)
+	}
+	if result.Message == nil {
+		t.Error("expected Message to be set")
+	}
+}
+
+// TestNewHasTxEntryAny tests the NewHasTxEntryAny helper function
+func TestNewHasTxEntryAny(t *testing.T) {
+	result := localtxmonitor.NewHasTxEntryAny()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.Message != nil {
+		t.Error("expected Message to be nil for 'any' entry")
+	}
+}
+
+// TestNewHasTxResultEntry tests the NewHasTxResultEntry helper function
+func TestNewHasTxResultEntry(t *testing.T) {
+	t.Run("result true", func(t *testing.T) {
+		result := localtxmonitor.NewHasTxResultEntry(true)
+
+		if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxmonitor.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+	})
+
+	t.Run("result false", func(t *testing.T) {
+		result := localtxmonitor.NewHasTxResultEntry(false)
+
+		if result.IsResponse != true {
+			t.Errorf("expected IsResponse to be true, got false")
+		}
+	})
+}
+
+// TestNewNextTxEntry tests the NewNextTxEntry helper function
+func TestNewNextTxEntry(t *testing.T) {
+	result := localtxmonitor.NewNextTxEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeNextTx {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeNextTx,
+			result.MessageType,
+		)
+	}
+}
+
+// TestNewNextTxResultEntry tests the NewNextTxResultEntry helper function
+func TestNewNextTxResultEntry(t *testing.T) {
+	result := localtxmonitor.NewNextTxResultEntry(
+		localtxmonitor.MockEraIdConway,
+		localtxmonitor.MockTxCbor,
+	)
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewNextTxResultEmptyEntry tests the NewNextTxResultEmptyEntry helper function
+func TestNewNextTxResultEmptyEntry(t *testing.T) {
+	result := localtxmonitor.NewNextTxResultEmptyEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewGetSizesEntry tests the NewGetSizesEntry helper function
+func TestNewGetSizesEntry(t *testing.T) {
+	result := localtxmonitor.NewGetSizesEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeGetSizes {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeGetSizes,
+			result.MessageType,
+		)
+	}
+}
+
+// TestNewSizesEntry tests the NewSizesEntry helper function
+func TestNewSizesEntry(t *testing.T) {
+	result := localtxmonitor.NewSizesEntry(
+		localtxmonitor.MockMempoolCapacity,
+		localtxmonitor.MockMempoolSize,
+		localtxmonitor.MockMempoolTxCount,
+	)
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewReleaseEntry tests the NewReleaseEntry helper function
+func TestNewReleaseEntry(t *testing.T) {
+	result := localtxmonitor.NewReleaseEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeRelease {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeRelease,
+			result.MessageType,
+		)
+	}
+}
+
+// TestNewDoneEntry tests the NewDoneEntry helper function
+func TestNewDoneEntry(t *testing.T) {
+	result := localtxmonitor.NewDoneEntry()
+
+	if result.ProtocolId != gouroboros_localtxmonitor.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxmonitor.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	// Done is sent by client, not a response
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxmonitor.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxmonitor.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestMockConstants tests that the mock constants are defined correctly
+func TestMockConstants(t *testing.T) {
+	if localtxmonitor.MockSlotNo != 100000 {
+		t.Errorf(
+			"expected MockSlotNo to be 100000, got %d",
+			localtxmonitor.MockSlotNo,
+		)
+	}
+	if localtxmonitor.MockEraIdConway != 6 {
+		t.Errorf(
+			"expected MockEraIdConway to be 6, got %d",
+			localtxmonitor.MockEraIdConway,
+		)
+	}
+	if localtxmonitor.MockMempoolCapacity != 178176 {
+		t.Errorf(
+			"expected MockMempoolCapacity to be 178176, got %d",
+			localtxmonitor.MockMempoolCapacity,
+		)
+	}
+	if localtxmonitor.MockMempoolSize != 4096 {
+		t.Errorf(
+			"expected MockMempoolSize to be 4096, got %d",
+			localtxmonitor.MockMempoolSize,
+		)
+	}
+	if localtxmonitor.MockMempoolTxCount != 1 {
+		t.Errorf(
+			"expected MockMempoolTxCount to be 1, got %d",
+			localtxmonitor.MockMempoolTxCount,
+		)
+	}
+	if len(localtxmonitor.MockTxId) != 32 {
+		t.Errorf(
+			"expected MockTxId to have 32 bytes, got %d",
+			len(localtxmonitor.MockTxId),
+		)
+	}
+	if len(localtxmonitor.MockTxId2) != 32 {
+		t.Errorf(
+			"expected MockTxId2 to have 32 bytes, got %d",
+			len(localtxmonitor.MockTxId2),
+		)
+	}
+	if len(localtxmonitor.MockTxCbor) == 0 {
+		t.Error("expected MockTxCbor to be non-empty")
+	}
+	if len(localtxmonitor.MockTxCbor2) == 0 {
+		t.Error("expected MockTxCbor2 to be non-empty")
+	}
+}
+
+// TestConversationFixtures tests that the pre-defined conversation fixtures are valid
+func TestConversationFixtures(t *testing.T) {
+	t.Run("ConversationLocalTxMonitorBasic", func(t *testing.T) {
+		if len(localtxmonitor.ConversationLocalTxMonitorBasic) != 13 {
+			t.Errorf(
+				"expected 13 entries, got %d",
+				len(localtxmonitor.ConversationLocalTxMonitorBasic),
+			)
+		}
+	})
+
+	t.Run("ConversationLocalTxMonitorEmpty", func(t *testing.T) {
+		if len(localtxmonitor.ConversationLocalTxMonitorEmpty) != 9 {
+			t.Errorf(
+				"expected 9 entries, got %d",
+				len(localtxmonitor.ConversationLocalTxMonitorEmpty),
+			)
+		}
+	})
+}

--- a/localtxmonitor/fixtures.go
+++ b/localtxmonitor/fixtures.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxmonitor
+
+import (
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for LocalTxMonitor testing
+
+// MockSlotNo is a sample slot number for testing
+const MockSlotNo uint64 = 100000
+
+// MockEraIdConway is the era ID for Conway era transactions
+const MockEraIdConway uint8 = 6
+
+// MockMempoolCapacity is a sample mempool capacity in bytes
+const MockMempoolCapacity uint32 = 178176
+
+// MockMempoolSize is a sample mempool size in bytes
+const MockMempoolSize uint32 = 4096
+
+// MockMempoolTxCount is a sample number of transactions in mempool
+// Note: ConversationLocalTxMonitorBasic returns 1 transaction before returning empty
+const MockMempoolTxCount uint32 = 1
+
+// MockTxId is a sample transaction ID for testing
+var MockTxId = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// MockTxId2 is a second sample transaction ID for testing
+var MockTxId2 = []byte{
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+	0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+	0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+	0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
+}
+
+// MockTxCbor is sample transaction CBOR data for testing
+var MockTxCbor = []byte{
+	0x84, // Array of 4 (transaction structure)
+	0xa0, // Empty map (transaction body)
+	0xa0, // Empty map (transaction witness set)
+	0xf5, // True (is valid)
+	0xf6, // Null (auxiliary data)
+}
+
+// MockTxCbor2 is a second sample transaction CBOR data for testing
+var MockTxCbor2 = []byte{
+	0x84,             // Array of 4 (transaction structure)
+	0xa1, 0x00, 0x80, // Map with inputs (empty array)
+	0xa0, // Empty map (transaction witness set)
+	0xf5, // True (is valid)
+	0xf6, // Null (auxiliary data)
+}
+
+// Pre-defined conversations for common LocalTxMonitor scenarios
+
+// ConversationLocalTxMonitorBasic is a pre-defined conversation for basic mempool query:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire
+// - Acquired (with slot)
+// - GetSizes
+// - Sizes (mempool stats)
+// - HasTx (check for transaction)
+// - HasTx result (true)
+// - NextTx
+// - NextTx result (transaction)
+// - NextTx
+// - NextTx result (empty - no more transactions)
+// - Release
+var ConversationLocalTxMonitorBasic = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire mempool snapshot
+	NewAcquireEntry(),
+	NewAcquiredEntry(MockSlotNo),
+	// Query mempool sizes
+	NewGetSizesEntry(),
+	NewSizesEntry(MockMempoolCapacity, MockMempoolSize, MockMempoolTxCount),
+	// Check if specific transaction exists
+	NewHasTxEntryAny(),
+	NewHasTxResultEntry(true),
+	// Get first transaction
+	NewNextTxEntry(),
+	NewNextTxResultEntry(MockEraIdConway, MockTxCbor),
+	// Get second transaction (none remaining)
+	NewNextTxEntry(),
+	NewNextTxResultEmptyEntry(),
+	// Release snapshot
+	NewReleaseEntry(),
+}
+
+// ConversationLocalTxMonitorEmpty is a pre-defined conversation for empty mempool:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - Acquire
+// - Acquired (with slot)
+// - GetSizes
+// - Sizes (empty mempool)
+// - NextTx
+// - NextTx result (empty)
+// - Release
+var ConversationLocalTxMonitorEmpty = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Acquire mempool snapshot
+	NewAcquireEntry(),
+	NewAcquiredEntry(MockSlotNo),
+	// Query mempool sizes (empty)
+	NewGetSizesEntry(),
+	NewSizesEntry(MockMempoolCapacity, 0, 0),
+	// Try to get next transaction (none available)
+	NewNextTxEntry(),
+	NewNextTxResultEmptyEntry(),
+	// Release snapshot
+	NewReleaseEntry(),
+}

--- a/localtxsubmission/entries.go
+++ b/localtxsubmission/entries.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxsubmission
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntrySubmitTx expects a SubmitTx message from the client
+type ConversationEntrySubmitTx struct {
+	// EraId is the era ID for transaction validation. Only used when TxCbor
+	// is also provided. When TxCbor is nil, all messages are accepted
+	// regardless of EraId.
+	EraId uint16
+	// TxCbor is the expected transaction CBOR for validation. If nil, any
+	// SubmitTx message is accepted. If provided, the received message must
+	// match both EraId and TxCbor exactly.
+	TxCbor []byte
+}
+
+// ToEntry converts this LocalTxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntrySubmitTx) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxsubmission.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxsubmission.MessageTypeSubmitTx,
+		MsgFromCborFunc: localtxsubmission.NewMsgFromCbor,
+	}
+	if e.TxCbor != nil {
+		entry.Message = localtxsubmission.NewMsgSubmitTx(e.EraId, e.TxCbor)
+	}
+	return entry
+}
+
+// ConversationEntryAcceptTx sends an AcceptTx response to the client
+type ConversationEntryAcceptTx struct{}
+
+// ToEntry converts this LocalTxSubmission entry to a generic ConversationEntryOutput
+func (e ConversationEntryAcceptTx) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxsubmission.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxsubmission.NewMsgAcceptTx(),
+		},
+	}
+}
+
+// ConversationEntryRejectTx sends a RejectTx response with a rejection reason to the client
+type ConversationEntryRejectTx struct {
+	ReasonCbor []byte // CBOR-encoded rejection reason
+}
+
+// ToEntry converts this LocalTxSubmission entry to a generic ConversationEntryOutput
+func (e ConversationEntryRejectTx) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localtxsubmission.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localtxsubmission.NewMsgRejectTx(e.ReasonCbor),
+		},
+	}
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate the protocol
+type ConversationEntryDone struct{}
+
+// ToEntry converts this LocalTxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      localtxsubmission.ProtocolId,
+		IsResponse:      false,
+		MessageType:     localtxsubmission.MessageTypeDone,
+		MsgFromCborFunc: localtxsubmission.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewSubmitTxEntry creates a ConversationEntryInput for expecting a SubmitTx message
+// with specific era ID and transaction CBOR validation
+func NewSubmitTxEntry(
+	eraId uint16,
+	txCbor []byte,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntrySubmitTx{EraId: eraId, TxCbor: txCbor}.ToEntry()
+}
+
+// NewSubmitTxEntryAny creates a ConversationEntryInput for expecting any SubmitTx message
+func NewSubmitTxEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntrySubmitTx{}.ToEntry()
+}
+
+// NewAcceptTxEntry creates a ConversationEntryOutput for sending an AcceptTx response
+func NewAcceptTxEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryAcceptTx{}.ToEntry()
+}
+
+// NewRejectTxEntry creates a ConversationEntryOutput for sending a RejectTx response
+func NewRejectTxEntry(
+	reasonCbor []byte,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryRejectTx{ReasonCbor: reasonCbor}.ToEntry()
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry()
+}

--- a/localtxsubmission/entries_test.go
+++ b/localtxsubmission/entries_test.go
@@ -1,0 +1,339 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxsubmission_test
+
+import (
+	"testing"
+
+	gouroboros_localtxsubmission "github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+	"github.com/blinklabs-io/ouroboros-mock/localtxsubmission"
+)
+
+// TestConversationEntrySubmitTx tests the ConversationEntrySubmitTx entry type
+func TestConversationEntrySubmitTx(t *testing.T) {
+	t.Run("ToEntry with TxCbor", func(t *testing.T) {
+		entry := localtxsubmission.ConversationEntrySubmitTx{
+			EraId:  localtxsubmission.MockEraIdConway,
+			TxCbor: localtxsubmission.MockTxCbor,
+		}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxsubmission.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != false {
+			t.Errorf("expected IsResponse to be false, got true")
+		}
+		if result.MessageType != gouroboros_localtxsubmission.MessageTypeSubmitTx {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				gouroboros_localtxsubmission.MessageTypeSubmitTx,
+				result.MessageType,
+			)
+		}
+		if result.Message == nil {
+			t.Error("expected Message to be set when TxCbor is provided")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ToEntry without TxCbor", func(t *testing.T) {
+		entry := localtxsubmission.ConversationEntrySubmitTx{}
+		result := entry.ToEntry()
+
+		if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				gouroboros_localtxsubmission.ProtocolId,
+				result.ProtocolId,
+			)
+		}
+		if result.IsResponse != false {
+			t.Errorf("expected IsResponse to be false, got true")
+		}
+		if result.MessageType != gouroboros_localtxsubmission.MessageTypeSubmitTx {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				gouroboros_localtxsubmission.MessageTypeSubmitTx,
+				result.MessageType,
+			)
+		}
+		if result.Message != nil {
+			t.Error("expected Message to be nil when TxCbor is not provided")
+		}
+		if result.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+}
+
+// TestConversationEntryAcceptTx tests the ConversationEntryAcceptTx entry type
+func TestConversationEntryAcceptTx(t *testing.T) {
+	entry := localtxsubmission.ConversationEntryAcceptTx{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryRejectTx tests the ConversationEntryRejectTx entry type
+func TestConversationEntryRejectTx(t *testing.T) {
+	entry := localtxsubmission.ConversationEntryRejectTx{
+		ReasonCbor: localtxsubmission.MockRejectReasonCbor,
+	}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestConversationEntryDone tests the ConversationEntryDone entry type
+func TestConversationEntryDone(t *testing.T) {
+	entry := localtxsubmission.ConversationEntryDone{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	// Done is sent by the client, not as a response
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxsubmission.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxsubmission.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewSubmitTxEntry tests the NewSubmitTxEntry helper function
+func TestNewSubmitTxEntry(t *testing.T) {
+	result := localtxsubmission.NewSubmitTxEntry(
+		localtxsubmission.MockEraIdConway,
+		localtxsubmission.MockTxCbor,
+	)
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxsubmission.MessageTypeSubmitTx {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxsubmission.MessageTypeSubmitTx,
+			result.MessageType,
+		)
+	}
+	if result.Message == nil {
+		t.Error("expected Message to be set")
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewSubmitTxEntryAny tests the NewSubmitTxEntryAny helper function
+func TestNewSubmitTxEntryAny(t *testing.T) {
+	result := localtxsubmission.NewSubmitTxEntryAny()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxsubmission.MessageTypeSubmitTx {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxsubmission.MessageTypeSubmitTx,
+			result.MessageType,
+		)
+	}
+	if result.Message != nil {
+		t.Error("expected Message to be nil for 'any' entry")
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewAcceptTxEntry tests the NewAcceptTxEntry helper function
+func TestNewAcceptTxEntry(t *testing.T) {
+	result := localtxsubmission.NewAcceptTxEntry()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewRejectTxEntry tests the NewRejectTxEntry helper function
+func TestNewRejectTxEntry(t *testing.T) {
+	result := localtxsubmission.NewRejectTxEntry(
+		localtxsubmission.MockRejectReasonCbor,
+	)
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// TestNewDoneEntry tests the NewDoneEntry helper function
+func TestNewDoneEntry(t *testing.T) {
+	result := localtxsubmission.NewDoneEntry()
+
+	if result.ProtocolId != gouroboros_localtxsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			gouroboros_localtxsubmission.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	// Done is sent by client, not a response
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != gouroboros_localtxsubmission.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			gouroboros_localtxsubmission.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestMockConstants tests that the mock constants are defined correctly
+func TestMockConstants(t *testing.T) {
+	if localtxsubmission.MockEraIdConway != 6 {
+		t.Errorf(
+			"expected MockEraIdConway to be 6, got %d",
+			localtxsubmission.MockEraIdConway,
+		)
+	}
+	if localtxsubmission.MockEraIdBabbage != 5 {
+		t.Errorf(
+			"expected MockEraIdBabbage to be 5, got %d",
+			localtxsubmission.MockEraIdBabbage,
+		)
+	}
+	if len(localtxsubmission.MockTxCbor) == 0 {
+		t.Error("expected MockTxCbor to be non-empty")
+	}
+	if len(localtxsubmission.MockRejectReasonCbor) == 0 {
+		t.Error("expected MockRejectReasonCbor to be non-empty")
+	}
+	if len(localtxsubmission.MockRejectReasonInvalidScript) == 0 {
+		t.Error("expected MockRejectReasonInvalidScript to be non-empty")
+	}
+}
+
+// TestConversationFixtures tests that the pre-defined conversation fixtures are valid
+func TestConversationFixtures(t *testing.T) {
+	t.Run("ConversationLocalTxSubmissionAccept", func(t *testing.T) {
+		if len(localtxsubmission.ConversationLocalTxSubmissionAccept) != 4 {
+			t.Errorf(
+				"expected 4 entries, got %d",
+				len(localtxsubmission.ConversationLocalTxSubmissionAccept),
+			)
+		}
+	})
+
+	t.Run("ConversationLocalTxSubmissionReject", func(t *testing.T) {
+		if len(localtxsubmission.ConversationLocalTxSubmissionReject) != 4 {
+			t.Errorf(
+				"expected 4 entries, got %d",
+				len(localtxsubmission.ConversationLocalTxSubmissionReject),
+			)
+		}
+	})
+
+	t.Run("ConversationLocalTxSubmissionMultiple", func(t *testing.T) {
+		if len(localtxsubmission.ConversationLocalTxSubmissionMultiple) != 8 {
+			t.Errorf(
+				"expected 8 entries, got %d",
+				len(localtxsubmission.ConversationLocalTxSubmissionMultiple),
+			)
+		}
+	})
+}

--- a/localtxsubmission/fixtures.go
+++ b/localtxsubmission/fixtures.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxsubmission
+
+import (
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for LocalTxSubmission testing
+
+// MockEraIdConway is the Conway era ID
+const MockEraIdConway uint16 = 6
+
+// MockEraIdBabbage is the Babbage era ID
+const MockEraIdBabbage uint16 = 5
+
+// MockTxCbor is a minimal sample transaction CBOR for testing
+var MockTxCbor = []byte{
+	0x84, // array(4) - transaction structure
+	0xa0, // map(0) - empty transaction body
+	0xa0, // map(0) - empty witness set
+	0xf6, // null - no auxiliary data
+	0xf6, // null - no script validity
+}
+
+// MockRejectReasonCbor is a sample CBOR-encoded rejection reason for testing
+// This represents a generic transaction validation error
+var MockRejectReasonCbor = []byte{
+	0x82,       // array(2)
+	0x00,       // error code 0
+	0x78, 0x1a, // text string (26 bytes)
+	0x49, 0x6e, 0x73, 0x75, 0x66, 0x66, 0x69, 0x63, // "Insuffic"
+	0x69, 0x65, 0x6e, 0x74, 0x20, 0x66, 0x75, 0x6e, // "ient fun"
+	0x64, 0x73, 0x20, 0x66, 0x6f, 0x72, 0x20, 0x66, // "ds for f"
+	0x65, 0x65, // "ee"
+}
+
+// MockRejectReasonInvalidScript is a sample CBOR-encoded rejection reason for script validation failure
+var MockRejectReasonInvalidScript = []byte{
+	0x82,       // array(2)
+	0x01,       // error code 1
+	0x78, 0x18, // text string (24 bytes)
+	0x53, 0x63, 0x72, 0x69, 0x70, 0x74, 0x20, 0x76, // "Script v"
+	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, // "alidatio"
+	0x6e, 0x20, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64, // "n failed"
+}
+
+// Pre-defined conversations for common LocalTxSubmission scenarios
+
+// ConversationLocalTxSubmissionAccept is a pre-defined conversation for successful tx submission:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - SubmitTx (any transaction)
+// - AcceptTx
+var ConversationLocalTxSubmissionAccept = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Submit transaction
+	NewSubmitTxEntryAny(),
+	// Accept transaction
+	NewAcceptTxEntry(),
+}
+
+// ConversationLocalTxSubmissionReject is a pre-defined conversation for rejected tx submission:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - SubmitTx (any transaction)
+// - RejectTx with rejection reason
+var ConversationLocalTxSubmissionReject = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// Submit transaction
+	NewSubmitTxEntryAny(),
+	// Reject transaction with reason
+	NewRejectTxEntry(MockRejectReasonCbor),
+}
+
+// ConversationLocalTxSubmissionMultiple is a pre-defined conversation for multiple tx submissions:
+// - Handshake request (generic)
+// - Handshake NtC response
+// - SubmitTx -> AcceptTx (first tx accepted)
+// - SubmitTx -> RejectTx (second tx rejected)
+// - SubmitTx -> AcceptTx (third tx accepted)
+var ConversationLocalTxSubmissionMultiple = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+	// First transaction - accepted
+	NewSubmitTxEntryAny(),
+	NewAcceptTxEntry(),
+	// Second transaction - rejected
+	NewSubmitTxEntryAny(),
+	NewRejectTxEntry(MockRejectReasonCbor),
+	// Third transaction - accepted
+	NewSubmitTxEntryAny(),
+	NewAcceptTxEntry(),
+}

--- a/peersharing/entries.go
+++ b/peersharing/entries.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peersharing
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntryShareRequest expects a ShareRequest message from the client
+type ConversationEntryShareRequest struct {
+	Amount uint8 // Optional: expected number of peers requested (0 means accept any)
+}
+
+// ToEntry converts this PeerSharing entry to a generic ConversationEntryInput
+func (e ConversationEntryShareRequest) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      peersharing.ProtocolId,
+		IsResponse:      false,
+		MessageType:     peersharing.MessageTypeShareRequest,
+		MsgFromCborFunc: peersharing.NewMsgFromCbor,
+	}
+	if e.Amount > 0 {
+		entry.Message = peersharing.NewMsgShareRequest(e.Amount)
+	}
+	return entry
+}
+
+// ConversationEntrySharePeers sends a SharePeers response to the client
+type ConversationEntrySharePeers struct {
+	PeerAddresses []peersharing.PeerAddress // List of peer addresses to share
+}
+
+// ToEntry converts this PeerSharing entry to a generic ConversationEntryOutput
+func (e ConversationEntrySharePeers) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: peersharing.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			peersharing.NewMsgSharePeers(e.PeerAddresses),
+		},
+	}
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate the protocol
+type ConversationEntryDone struct{}
+
+// ToEntry converts this PeerSharing entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      peersharing.ProtocolId,
+		IsResponse:      false,
+		MessageType:     peersharing.MessageTypeDone,
+		MsgFromCborFunc: peersharing.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewShareRequestEntry creates a ConversationEntryInput for expecting a ShareRequest message
+func NewShareRequestEntry(amount uint8) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryShareRequest{Amount: amount}.ToEntry()
+}
+
+// NewShareRequestEntryAny creates a ConversationEntryInput for expecting any ShareRequest message
+func NewShareRequestEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryShareRequest{}.ToEntry()
+}
+
+// NewSharePeersEntry creates a ConversationEntryOutput for sending a SharePeers response
+func NewSharePeersEntry(
+	peerAddresses []peersharing.PeerAddress,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntrySharePeers{PeerAddresses: peerAddresses}.ToEntry()
+}
+
+// NewSharePeersEmptyEntry creates a ConversationEntryOutput for sending an empty SharePeers response
+func NewSharePeersEmptyEntry() ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntrySharePeers{
+		PeerAddresses: []peersharing.PeerAddress{},
+	}.ToEntry()
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry()
+}

--- a/peersharing/entries_test.go
+++ b/peersharing/entries_test.go
@@ -1,0 +1,504 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peersharing_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
+	ps "github.com/blinklabs-io/ouroboros-mock/peersharing"
+)
+
+// Test ConversationEntryShareRequest
+
+func TestConversationEntryShareRequest_ToEntry_WithAmount(t *testing.T) {
+	entry := ps.ConversationEntryShareRequest{Amount: 5}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != peersharing.MessageTypeShareRequest {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			peersharing.MessageTypeShareRequest,
+			result.MessageType,
+		)
+	}
+	if result.Message == nil {
+		t.Errorf("expected Message to be non-nil when Amount > 0")
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Errorf("expected MsgFromCborFunc to be non-nil")
+	}
+}
+
+func TestConversationEntryShareRequest_ToEntry_ZeroAmount(t *testing.T) {
+	entry := ps.ConversationEntryShareRequest{Amount: 0}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != peersharing.MessageTypeShareRequest {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			peersharing.MessageTypeShareRequest,
+			result.MessageType,
+		)
+	}
+	if result.Message != nil {
+		t.Errorf("expected Message to be nil when Amount is 0, got non-nil")
+	}
+}
+
+// Test ConversationEntrySharePeers
+
+func TestConversationEntrySharePeers_ToEntry_WithAddresses(t *testing.T) {
+	peerAddresses := []peersharing.PeerAddress{
+		{IP: net.ParseIP("192.168.1.1"), Port: 3001},
+		{IP: net.ParseIP("10.0.0.1"), Port: 3002},
+	}
+	entry := ps.ConversationEntrySharePeers{PeerAddresses: peerAddresses}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+func TestConversationEntrySharePeers_ToEntry_EmptyAddresses(t *testing.T) {
+	entry := ps.ConversationEntrySharePeers{
+		PeerAddresses: []peersharing.PeerAddress{},
+	}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+func TestConversationEntrySharePeers_ToEntry_NilAddresses(t *testing.T) {
+	entry := ps.ConversationEntrySharePeers{PeerAddresses: nil}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+// Test ConversationEntryDone
+
+func TestConversationEntryDone_ToEntry(t *testing.T) {
+	entry := ps.ConversationEntryDone{}
+	result := entry.ToEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf(
+			"expected IsResponse to be false (Done is sent by client), got true",
+		)
+	}
+	if result.MessageType != peersharing.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			peersharing.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// Test helper functions
+
+func TestNewShareRequestEntry(t *testing.T) {
+	testCases := []struct {
+		name   string
+		amount uint8
+	}{
+		{"amount 1", 1},
+		{"amount 5", 5},
+		{"amount 10", 10},
+		{"max amount", 255},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ps.NewShareRequestEntry(tc.amount)
+
+			if result.ProtocolId != peersharing.ProtocolId {
+				t.Errorf(
+					"expected ProtocolId %d, got %d",
+					peersharing.ProtocolId,
+					result.ProtocolId,
+				)
+			}
+			if result.IsResponse != false {
+				t.Errorf("expected IsResponse to be false, got true")
+			}
+			if result.MessageType != peersharing.MessageTypeShareRequest {
+				t.Errorf(
+					"expected MessageType %d, got %d",
+					peersharing.MessageTypeShareRequest,
+					result.MessageType,
+				)
+			}
+			if result.Message == nil {
+				t.Errorf("expected Message to be non-nil")
+			}
+		})
+	}
+}
+
+func TestNewShareRequestEntryAny(t *testing.T) {
+	result := ps.NewShareRequestEntryAny()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != peersharing.MessageTypeShareRequest {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			peersharing.MessageTypeShareRequest,
+			result.MessageType,
+		)
+	}
+	if result.Message != nil {
+		t.Errorf("expected Message to be nil for 'any' request, got non-nil")
+	}
+}
+
+func TestNewSharePeersEntry(t *testing.T) {
+	peerAddresses := []peersharing.PeerAddress{
+		{IP: net.ParseIP("192.168.1.100"), Port: 3001},
+		{IP: net.ParseIP("10.0.0.50"), Port: 3002},
+	}
+
+	result := ps.NewSharePeersEntry(peerAddresses)
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+func TestNewSharePeersEntry_SingleAddress(t *testing.T) {
+	peerAddresses := []peersharing.PeerAddress{
+		{IP: net.ParseIP("192.168.1.100"), Port: 3001},
+	}
+
+	result := ps.NewSharePeersEntry(peerAddresses)
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+func TestNewSharePeersEmptyEntry(t *testing.T) {
+	result := ps.NewSharePeersEmptyEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != true {
+		t.Errorf("expected IsResponse to be true, got false")
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}
+
+func TestNewDoneEntry(t *testing.T) {
+	result := ps.NewDoneEntry()
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if result.IsResponse != false {
+		t.Errorf("expected IsResponse to be false, got true")
+	}
+	if result.MessageType != peersharing.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			peersharing.MessageTypeDone,
+			result.MessageType,
+		)
+	}
+	if result.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// Test mock fixtures
+
+func TestMockPeerAddress1(t *testing.T) {
+	addr := ps.MockPeerAddress1
+
+	expectedIP := net.ParseIP("192.168.1.100")
+	if !addr.IP.Equal(expectedIP) {
+		t.Errorf("expected IP %v, got %v", expectedIP, addr.IP)
+	}
+	if addr.Port != 3001 {
+		t.Errorf("expected Port 3001, got %d", addr.Port)
+	}
+}
+
+func TestMockPeerAddress2(t *testing.T) {
+	addr := ps.MockPeerAddress2
+
+	expectedIP := net.ParseIP("10.0.0.50")
+	if !addr.IP.Equal(expectedIP) {
+		t.Errorf("expected IP %v, got %v", expectedIP, addr.IP)
+	}
+	if addr.Port != 3001 {
+		t.Errorf("expected Port 3001, got %d", addr.Port)
+	}
+}
+
+func TestMockPeerAddress3_IPv6(t *testing.T) {
+	addr := ps.MockPeerAddress3
+
+	expectedIP := net.ParseIP("2001:db8::1")
+	if !addr.IP.Equal(expectedIP) {
+		t.Errorf("expected IP %v, got %v", expectedIP, addr.IP)
+	}
+	if addr.Port != 3001 {
+		t.Errorf("expected Port 3001, got %d", addr.Port)
+	}
+}
+
+func TestMockPeerAddresses(t *testing.T) {
+	addrs := ps.MockPeerAddresses
+
+	if len(addrs) != 2 {
+		t.Errorf("expected 2 addresses, got %d", len(addrs))
+	}
+
+	// Verify it contains MockPeerAddress1 and MockPeerAddress2
+	if !addrs[0].IP.Equal(ps.MockPeerAddress1.IP) ||
+		addrs[0].Port != ps.MockPeerAddress1.Port {
+		t.Errorf("first address does not match MockPeerAddress1")
+	}
+	if !addrs[1].IP.Equal(ps.MockPeerAddress2.IP) ||
+		addrs[1].Port != ps.MockPeerAddress2.Port {
+		t.Errorf("second address does not match MockPeerAddress2")
+	}
+}
+
+func TestMockPeerAddressesWithIPv6(t *testing.T) {
+	addrs := ps.MockPeerAddressesWithIPv6
+
+	if len(addrs) != 3 {
+		t.Errorf("expected 3 addresses, got %d", len(addrs))
+	}
+
+	// Verify it contains all three mock addresses
+	if !addrs[0].IP.Equal(ps.MockPeerAddress1.IP) ||
+		addrs[0].Port != ps.MockPeerAddress1.Port {
+		t.Errorf("first address does not match MockPeerAddress1")
+	}
+	if !addrs[1].IP.Equal(ps.MockPeerAddress2.IP) ||
+		addrs[1].Port != ps.MockPeerAddress2.Port {
+		t.Errorf("second address does not match MockPeerAddress2")
+	}
+	if !addrs[2].IP.Equal(ps.MockPeerAddress3.IP) ||
+		addrs[2].Port != ps.MockPeerAddress3.Port {
+		t.Errorf("third address does not match MockPeerAddress3")
+	}
+}
+
+// Test conversation fixtures
+
+func TestConversationPeerSharingBasic(t *testing.T) {
+	conv := ps.ConversationPeerSharingBasic
+
+	if conv == nil {
+		t.Fatalf("ConversationPeerSharingBasic should not be nil")
+	}
+	if len(conv) != 4 {
+		t.Errorf("expected 4 entries, got %d", len(conv))
+	}
+}
+
+func TestConversationPeerSharingEmpty(t *testing.T) {
+	conv := ps.ConversationPeerSharingEmpty
+
+	if conv == nil {
+		t.Fatalf("ConversationPeerSharingEmpty should not be nil")
+	}
+	if len(conv) != 4 {
+		t.Errorf("expected 4 entries, got %d", len(conv))
+	}
+}
+
+func TestConversationPeerSharingMultiple(t *testing.T) {
+	conv := ps.ConversationPeerSharingMultiple
+
+	if conv == nil {
+		t.Fatalf("ConversationPeerSharingMultiple should not be nil")
+	}
+	if len(conv) != 7 {
+		t.Errorf("expected 7 entries, got %d", len(conv))
+	}
+}
+
+// Test that entries implement ConversationEntry interface (compile-time check)
+
+func TestConversationEntryInterface(t *testing.T) {
+	// This test verifies that the ToEntry() methods return types that can be
+	// used in conversation slices. The actual interface compliance is checked
+	// at compile time through the fixtures.
+
+	// ShareRequest entry
+	shareReqEntry := ps.NewShareRequestEntry(5)
+	if shareReqEntry.ProtocolId == 0 {
+		t.Error("ShareRequest entry should have non-zero ProtocolId")
+	}
+
+	// SharePeers entry
+	sharePeersEntry := ps.NewSharePeersEntry(ps.MockPeerAddresses)
+	if sharePeersEntry.ProtocolId == 0 {
+		t.Error("SharePeers entry should have non-zero ProtocolId")
+	}
+
+	// Done entry
+	doneEntry := ps.NewDoneEntry()
+	if doneEntry.ProtocolId == 0 {
+		t.Error("Done entry should have non-zero ProtocolId")
+	}
+}
+
+// Test edge cases
+
+func TestShareRequestEntry_ZeroAmount_ViaHelper(t *testing.T) {
+	result := ps.NewShareRequestEntry(0)
+
+	// According to the implementation, Amount > 0 sets Message, so 0 results in nil Message
+	// This matches the behavior of NewShareRequestEntryAny
+	if result.Message != nil {
+		t.Errorf("expected Message to be nil for amount 0, got non-nil")
+	}
+}
+
+func TestSharePeersEntry_ManyAddresses(t *testing.T) {
+	// Test with many peer addresses
+	var addresses []peersharing.PeerAddress
+	for i := range 100 {
+		addresses = append(addresses, peersharing.PeerAddress{
+			IP:   net.ParseIP("192.168.1.1"),
+			Port: uint16(3000 + i),
+		})
+	}
+
+	result := ps.NewSharePeersEntry(addresses)
+
+	if result.ProtocolId != peersharing.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			peersharing.ProtocolId,
+			result.ProtocolId,
+		)
+	}
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result.Messages))
+	}
+}

--- a/peersharing/fixtures.go
+++ b/peersharing/fixtures.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peersharing
+
+import (
+	"net"
+
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for PeerSharing testing
+
+// MockPeerAddress1 is a sample IPv4 peer address for testing
+var MockPeerAddress1 = peersharing.PeerAddress{
+	IP:   net.ParseIP("192.168.1.100"),
+	Port: 3001,
+}
+
+// MockPeerAddress2 is a second sample IPv4 peer address for testing
+var MockPeerAddress2 = peersharing.PeerAddress{
+	IP:   net.ParseIP("10.0.0.50"),
+	Port: 3001,
+}
+
+// MockPeerAddress3 is a sample IPv6 peer address for testing
+var MockPeerAddress3 = peersharing.PeerAddress{
+	IP:   net.ParseIP("2001:db8::1"),
+	Port: 3001,
+}
+
+// MockPeerAddresses is a sample list of peer addresses for testing
+var MockPeerAddresses = []peersharing.PeerAddress{
+	MockPeerAddress1,
+	MockPeerAddress2,
+}
+
+// MockPeerAddressesWithIPv6 is a sample list of peer addresses including IPv6 for testing
+var MockPeerAddressesWithIPv6 = []peersharing.PeerAddress{
+	MockPeerAddress1,
+	MockPeerAddress2,
+	MockPeerAddress3,
+}
+
+// Pre-defined conversations for common PeerSharing scenarios
+
+// ConversationPeerSharingBasic is a pre-defined conversation for basic peer sharing request/response:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - ShareRequest (request peers)
+// - SharePeers (return peer addresses)
+var ConversationPeerSharingBasic = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// Request peers
+	NewShareRequestEntryAny(),
+	// Return peer addresses
+	NewSharePeersEntry(MockPeerAddresses),
+}
+
+// ConversationPeerSharingEmpty is a pre-defined conversation for peer sharing with no peers available:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - ShareRequest (request peers)
+// - SharePeers (empty response)
+var ConversationPeerSharingEmpty = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// Request peers
+	NewShareRequestEntryAny(),
+	// Return empty peer list
+	NewSharePeersEmptyEntry(),
+}
+
+// ConversationPeerSharingMultiple is a pre-defined conversation for multiple peer sharing requests:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - ShareRequest (first request)
+// - SharePeers (return peers)
+// - ShareRequest (second request)
+// - SharePeers (return peers with IPv6)
+// - Done
+var ConversationPeerSharingMultiple = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// First peer request
+	NewShareRequestEntryAny(),
+	NewSharePeersEntry(MockPeerAddresses),
+	// Second peer request
+	NewShareRequestEntryAny(),
+	NewSharePeersEntry(MockPeerAddressesWithIPv6),
+	// Done
+	NewDoneEntry(),
+}

--- a/txsubmission/entries.go
+++ b/txsubmission/entries.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txsubmission
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// ConversationEntryInit expects an Init message from the client (client starts the protocol)
+type ConversationEntryInit struct{}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntryInit) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      txsubmission.ProtocolId,
+		IsResponse:      false,
+		MessageType:     txsubmission.MessageTypeInit,
+		MsgFromCborFunc: txsubmission.NewMsgFromCbor,
+	}
+}
+
+// ConversationEntryRequestTxIds sends a RequestTxIds message to the client
+type ConversationEntryRequestTxIds struct {
+	Blocking bool   // Whether to block until txs are available
+	Ack      uint16 // Number of txs to acknowledge
+	Req      uint16 // Number of txs to request
+}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryOutput
+func (e ConversationEntryRequestTxIds) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: txsubmission.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			txsubmission.NewMsgRequestTxIds(e.Blocking, e.Ack, e.Req),
+		},
+	}
+}
+
+// ConversationEntryReplyTxIds expects a ReplyTxIds message from the client
+type ConversationEntryReplyTxIds struct {
+	TxIds []txsubmission.TxIdAndSize // Optional: expected transaction IDs for validation (nil means accept any)
+}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntryReplyTxIds) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      txsubmission.ProtocolId,
+		IsResponse:      true,
+		MessageType:     txsubmission.MessageTypeReplyTxIds,
+		MsgFromCborFunc: txsubmission.NewMsgFromCbor,
+	}
+	if e.TxIds != nil {
+		entry.Message = txsubmission.NewMsgReplyTxIds(e.TxIds)
+	}
+	return entry
+}
+
+// ConversationEntryRequestTxs sends a RequestTxs message to the client
+type ConversationEntryRequestTxs struct {
+	TxIds []txsubmission.TxId // Transaction IDs to request
+}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryOutput
+func (e ConversationEntryRequestTxs) ToEntry() ouroboros_mock.ConversationEntryOutput {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: txsubmission.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			txsubmission.NewMsgRequestTxs(e.TxIds),
+		},
+	}
+}
+
+// ConversationEntryReplyTxs expects a ReplyTxs message from the client
+type ConversationEntryReplyTxs struct {
+	Txs []txsubmission.TxBody // Optional: expected transaction bodies for validation (nil means accept any)
+}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntryReplyTxs) ToEntry() ouroboros_mock.ConversationEntryInput {
+	entry := ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      txsubmission.ProtocolId,
+		IsResponse:      true,
+		MessageType:     txsubmission.MessageTypeReplyTxs,
+		MsgFromCborFunc: txsubmission.NewMsgFromCbor,
+	}
+	if e.Txs != nil {
+		entry.Message = txsubmission.NewMsgReplyTxs(e.Txs)
+	}
+	return entry
+}
+
+// ConversationEntryDone expects a Done message from the client to terminate the protocol
+type ConversationEntryDone struct{}
+
+// ToEntry converts this TxSubmission entry to a generic ConversationEntryInput
+func (e ConversationEntryDone) ToEntry() ouroboros_mock.ConversationEntryInput {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:      txsubmission.ProtocolId,
+		IsResponse:      false,
+		MessageType:     txsubmission.MessageTypeDone,
+		MsgFromCborFunc: txsubmission.NewMsgFromCbor,
+	}
+}
+
+// Helper functions for creating common conversation patterns
+
+// NewInitEntry creates a ConversationEntryInput for expecting an Init message
+func NewInitEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryInit{}.ToEntry()
+}
+
+// NewRequestTxIdsEntry creates a ConversationEntryOutput for sending a RequestTxIds message
+func NewRequestTxIdsEntry(
+	blocking bool,
+	ack, req uint16,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryRequestTxIds{
+		Blocking: blocking,
+		Ack:      ack,
+		Req:      req,
+	}.ToEntry()
+}
+
+// NewReplyTxIdsEntry creates a ConversationEntryInput for expecting a ReplyTxIds message
+func NewReplyTxIdsEntry(
+	txIds []txsubmission.TxIdAndSize,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReplyTxIds{
+		TxIds: txIds,
+	}.ToEntry()
+}
+
+// NewReplyTxIdsEntryAny creates a ConversationEntryInput for expecting any ReplyTxIds message
+func NewReplyTxIdsEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReplyTxIds{}.ToEntry()
+}
+
+// NewRequestTxsEntry creates a ConversationEntryOutput for sending a RequestTxs message
+func NewRequestTxsEntry(
+	txIds []txsubmission.TxId,
+) ouroboros_mock.ConversationEntryOutput {
+	return ConversationEntryRequestTxs{
+		TxIds: txIds,
+	}.ToEntry()
+}
+
+// NewReplyTxsEntry creates a ConversationEntryInput for expecting a ReplyTxs message
+func NewReplyTxsEntry(
+	txs []txsubmission.TxBody,
+) ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReplyTxs{
+		Txs: txs,
+	}.ToEntry()
+}
+
+// NewReplyTxsEntryAny creates a ConversationEntryInput for expecting any ReplyTxs message
+func NewReplyTxsEntryAny() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryReplyTxs{}.ToEntry()
+}
+
+// NewDoneEntry creates a ConversationEntryInput for expecting a Done message
+func NewDoneEntry() ouroboros_mock.ConversationEntryInput {
+	return ConversationEntryDone{}.ToEntry()
+}

--- a/txsubmission/entries_test.go
+++ b/txsubmission/entries_test.go
@@ -1,0 +1,991 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txsubmission_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	ts "github.com/blinklabs-io/ouroboros-mock/txsubmission"
+)
+
+// TestConversationEntryInitToEntry tests that ConversationEntryInit.ToEntry()
+// returns the correct ConversationEntryInput with proper protocol ID,
+// IsResponse flag, and message type.
+func TestConversationEntryInitToEntry(t *testing.T) {
+	entry := ts.ConversationEntryInit{}
+	input := entry.ToEntry()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if input.IsResponse {
+		t.Error("expected IsResponse to be false for Init entry")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeInit {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeInit,
+			input.MessageType,
+		)
+	}
+
+	if input.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestConversationEntryRequestTxIdsToEntry tests that
+// ConversationEntryRequestTxIds.ToEntry() returns the correct
+// ConversationEntryOutput with proper protocol ID and message.
+func TestConversationEntryRequestTxIdsToEntry(t *testing.T) {
+	entry := ts.ConversationEntryRequestTxIds{
+		Blocking: true,
+		Ack:      5,
+		Req:      10,
+	}
+	output := entry.ToEntry()
+
+	if output.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			output.ProtocolId,
+		)
+	}
+
+	if !output.IsResponse {
+		t.Error("expected IsResponse to be true for RequestTxIds entry")
+	}
+
+	if len(output.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(output.Messages))
+	}
+
+	if output.Messages[0].Type() != txsubmission.MessageTypeRequestTxIds {
+		t.Errorf(
+			"expected message type %d, got %d",
+			txsubmission.MessageTypeRequestTxIds,
+			output.Messages[0].Type(),
+		)
+	}
+
+	msg, ok := output.Messages[0].(*txsubmission.MsgRequestTxIds)
+	if !ok {
+		t.Fatalf(
+			"expected message type *MsgRequestTxIds, got %T",
+			output.Messages[0],
+		)
+	}
+
+	if !msg.Blocking {
+		t.Error("expected Blocking to be true")
+	}
+
+	if msg.Ack != 5 {
+		t.Errorf("expected Ack 5, got %d", msg.Ack)
+	}
+
+	if msg.Req != 10 {
+		t.Errorf("expected Req 10, got %d", msg.Req)
+	}
+}
+
+// TestConversationEntryReplyTxIdsToEntry tests that
+// ConversationEntryReplyTxIds.ToEntry() returns the correct
+// ConversationEntryInput with proper protocol ID and message type.
+func TestConversationEntryReplyTxIdsToEntry(t *testing.T) {
+	t.Run("with nil TxIds", func(t *testing.T) {
+		entry := ts.ConversationEntryReplyTxIds{}
+		input := entry.ToEntry()
+
+		if input.ProtocolId != txsubmission.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				txsubmission.ProtocolId,
+				input.ProtocolId,
+			)
+		}
+
+		if !input.IsResponse {
+			t.Error("expected IsResponse to be true for ReplyTxIds entry")
+		}
+
+		if input.MessageType != txsubmission.MessageTypeReplyTxIds {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				txsubmission.MessageTypeReplyTxIds,
+				input.MessageType,
+			)
+		}
+
+		if input.Message != nil {
+			t.Error("expected Message to be nil when TxIds is nil")
+		}
+	})
+
+	t.Run("with TxIds", func(t *testing.T) {
+		txIds := []txsubmission.TxIdAndSize{
+			ts.MockTxIdAndSize1,
+			ts.MockTxIdAndSize2,
+		}
+		entry := ts.ConversationEntryReplyTxIds{
+			TxIds: txIds,
+		}
+		input := entry.ToEntry()
+
+		if input.Message == nil {
+			t.Fatal("expected Message to be set when TxIds is provided")
+		}
+
+		msg, ok := input.Message.(*txsubmission.MsgReplyTxIds)
+		if !ok {
+			t.Fatalf(
+				"expected message type *MsgReplyTxIds, got %T",
+				input.Message,
+			)
+		}
+
+		if len(msg.TxIds) != 2 {
+			t.Errorf("expected 2 TxIds, got %d", len(msg.TxIds))
+		}
+	})
+}
+
+// TestConversationEntryRequestTxsToEntry tests that
+// ConversationEntryRequestTxs.ToEntry() returns the correct
+// ConversationEntryOutput with proper protocol ID and message.
+func TestConversationEntryRequestTxsToEntry(t *testing.T) {
+	txIds := []txsubmission.TxId{ts.MockTxId1, ts.MockTxId2}
+	entry := ts.ConversationEntryRequestTxs{
+		TxIds: txIds,
+	}
+	output := entry.ToEntry()
+
+	if output.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			output.ProtocolId,
+		)
+	}
+
+	if !output.IsResponse {
+		t.Error("expected IsResponse to be true for RequestTxs entry")
+	}
+
+	if len(output.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(output.Messages))
+	}
+
+	if output.Messages[0].Type() != txsubmission.MessageTypeRequestTxs {
+		t.Errorf(
+			"expected message type %d, got %d",
+			txsubmission.MessageTypeRequestTxs,
+			output.Messages[0].Type(),
+		)
+	}
+
+	msg, ok := output.Messages[0].(*txsubmission.MsgRequestTxs)
+	if !ok {
+		t.Fatalf("expected message type *MsgRequestTxs, got %T", output.Messages[0])
+	}
+
+	if len(msg.TxIds) != 2 {
+		t.Errorf("expected 2 TxIds, got %d", len(msg.TxIds))
+	}
+}
+
+// TestConversationEntryReplyTxsToEntry tests that
+// ConversationEntryReplyTxs.ToEntry() returns the correct
+// ConversationEntryInput with proper protocol ID and message type.
+func TestConversationEntryReplyTxsToEntry(t *testing.T) {
+	t.Run("with nil Txs", func(t *testing.T) {
+		entry := ts.ConversationEntryReplyTxs{}
+		input := entry.ToEntry()
+
+		if input.ProtocolId != txsubmission.ProtocolId {
+			t.Errorf(
+				"expected ProtocolId %d, got %d",
+				txsubmission.ProtocolId,
+				input.ProtocolId,
+			)
+		}
+
+		if !input.IsResponse {
+			t.Error("expected IsResponse to be true for ReplyTxs entry")
+		}
+
+		if input.MessageType != txsubmission.MessageTypeReplyTxs {
+			t.Errorf(
+				"expected MessageType %d, got %d",
+				txsubmission.MessageTypeReplyTxs,
+				input.MessageType,
+			)
+		}
+
+		if input.Message != nil {
+			t.Error("expected Message to be nil when Txs is nil")
+		}
+	})
+
+	t.Run("with Txs", func(t *testing.T) {
+		txs := []txsubmission.TxBody{ts.MockTx1, ts.MockTx2}
+		entry := ts.ConversationEntryReplyTxs{
+			Txs: txs,
+		}
+		input := entry.ToEntry()
+
+		if input.Message == nil {
+			t.Fatal("expected Message to be set when Txs is provided")
+		}
+
+		msg, ok := input.Message.(*txsubmission.MsgReplyTxs)
+		if !ok {
+			t.Fatalf("expected message type *MsgReplyTxs, got %T", input.Message)
+		}
+
+		if len(msg.Txs) != 2 {
+			t.Errorf("expected 2 Txs, got %d", len(msg.Txs))
+		}
+	})
+}
+
+// TestConversationEntryDoneToEntry tests that ConversationEntryDone.ToEntry()
+// returns the correct ConversationEntryInput with proper protocol ID,
+// IsResponse flag, and message type.
+func TestConversationEntryDoneToEntry(t *testing.T) {
+	entry := ts.ConversationEntryDone{}
+	input := entry.ToEntry()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if input.IsResponse {
+		t.Error("expected IsResponse to be false for Done entry")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeDone,
+			input.MessageType,
+		)
+	}
+
+	if input.MsgFromCborFunc == nil {
+		t.Error("expected MsgFromCborFunc to be set")
+	}
+}
+
+// TestNewInitEntry tests the NewInitEntry helper function.
+func TestNewInitEntry(t *testing.T) {
+	input := ts.NewInitEntry()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if input.IsResponse {
+		t.Error("expected IsResponse to be false")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeInit {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeInit,
+			input.MessageType,
+		)
+	}
+}
+
+// TestNewRequestTxIdsEntry tests the NewRequestTxIdsEntry helper function.
+func TestNewRequestTxIdsEntry(t *testing.T) {
+	output := ts.NewRequestTxIdsEntry(true, 5, 10)
+
+	if output.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			output.ProtocolId,
+		)
+	}
+
+	if !output.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if len(output.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(output.Messages))
+	}
+
+	msg, ok := output.Messages[0].(*txsubmission.MsgRequestTxIds)
+	if !ok {
+		t.Fatalf(
+			"expected message type *MsgRequestTxIds, got %T",
+			output.Messages[0],
+		)
+	}
+
+	if !msg.Blocking {
+		t.Error("expected Blocking to be true")
+	}
+
+	if msg.Ack != 5 {
+		t.Errorf("expected Ack 5, got %d", msg.Ack)
+	}
+
+	if msg.Req != 10 {
+		t.Errorf("expected Req 10, got %d", msg.Req)
+	}
+}
+
+// TestNewReplyTxIdsEntry tests the NewReplyTxIdsEntry helper function.
+func TestNewReplyTxIdsEntry(t *testing.T) {
+	txIds := []txsubmission.TxIdAndSize{
+		ts.MockTxIdAndSize1,
+		ts.MockTxIdAndSize2,
+		ts.MockTxIdAndSize3,
+	}
+	input := ts.NewReplyTxIdsEntry(txIds)
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if !input.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if input.Message == nil {
+		t.Fatal("expected Message to be set")
+	}
+
+	msg, ok := input.Message.(*txsubmission.MsgReplyTxIds)
+	if !ok {
+		t.Fatalf("expected message type *MsgReplyTxIds, got %T", input.Message)
+	}
+
+	if len(msg.TxIds) != 3 {
+		t.Errorf("expected 3 TxIds, got %d", len(msg.TxIds))
+	}
+}
+
+// TestNewReplyTxIdsEntryAny tests the NewReplyTxIdsEntryAny helper function.
+func TestNewReplyTxIdsEntryAny(t *testing.T) {
+	input := ts.NewReplyTxIdsEntryAny()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if !input.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeReplyTxIds {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeReplyTxIds,
+			input.MessageType,
+		)
+	}
+
+	if input.Message != nil {
+		t.Error("expected Message to be nil for 'any' entry")
+	}
+}
+
+// TestNewRequestTxsEntry tests the NewRequestTxsEntry helper function.
+func TestNewRequestTxsEntry(t *testing.T) {
+	txIds := []txsubmission.TxId{ts.MockTxId1, ts.MockTxId2}
+	output := ts.NewRequestTxsEntry(txIds)
+
+	if output.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			output.ProtocolId,
+		)
+	}
+
+	if !output.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if len(output.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(output.Messages))
+	}
+
+	msg, ok := output.Messages[0].(*txsubmission.MsgRequestTxs)
+	if !ok {
+		t.Fatalf("expected message type *MsgRequestTxs, got %T", output.Messages[0])
+	}
+
+	if len(msg.TxIds) != 2 {
+		t.Errorf("expected 2 TxIds, got %d", len(msg.TxIds))
+	}
+}
+
+// TestNewReplyTxsEntry tests the NewReplyTxsEntry helper function.
+func TestNewReplyTxsEntry(t *testing.T) {
+	txs := []txsubmission.TxBody{ts.MockTx1, ts.MockTx2, ts.MockTx3}
+	input := ts.NewReplyTxsEntry(txs)
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if !input.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if input.Message == nil {
+		t.Fatal("expected Message to be set")
+	}
+
+	msg, ok := input.Message.(*txsubmission.MsgReplyTxs)
+	if !ok {
+		t.Fatalf("expected message type *MsgReplyTxs, got %T", input.Message)
+	}
+
+	if len(msg.Txs) != 3 {
+		t.Errorf("expected 3 Txs, got %d", len(msg.Txs))
+	}
+}
+
+// TestNewReplyTxsEntryAny tests the NewReplyTxsEntryAny helper function.
+func TestNewReplyTxsEntryAny(t *testing.T) {
+	input := ts.NewReplyTxsEntryAny()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if !input.IsResponse {
+		t.Error("expected IsResponse to be true")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeReplyTxs {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeReplyTxs,
+			input.MessageType,
+		)
+	}
+
+	if input.Message != nil {
+		t.Error("expected Message to be nil for 'any' entry")
+	}
+}
+
+// TestNewDoneEntry tests the NewDoneEntry helper function.
+func TestNewDoneEntry(t *testing.T) {
+	input := ts.NewDoneEntry()
+
+	if input.ProtocolId != txsubmission.ProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			txsubmission.ProtocolId,
+			input.ProtocolId,
+		)
+	}
+
+	if input.IsResponse {
+		t.Error("expected IsResponse to be false")
+	}
+
+	if input.MessageType != txsubmission.MessageTypeDone {
+		t.Errorf(
+			"expected MessageType %d, got %d",
+			txsubmission.MessageTypeDone,
+			input.MessageType,
+		)
+	}
+}
+
+// TestMockEraConway tests the MockEraConway constant.
+func TestMockEraConway(t *testing.T) {
+	if ts.MockEraConway != 6 {
+		t.Errorf("expected MockEraConway to be 6, got %d", ts.MockEraConway)
+	}
+}
+
+// TestMockTxHashes tests the mock transaction hash fixtures.
+func TestMockTxHashes(t *testing.T) {
+	t.Run("MockTxHash1", func(t *testing.T) {
+		if len(ts.MockTxHash1) != 32 {
+			t.Errorf(
+				"expected MockTxHash1 length 32, got %d",
+				len(ts.MockTxHash1),
+			)
+		}
+		if ts.MockTxHash1[0] != 0x01 {
+			t.Errorf(
+				"expected MockTxHash1[0] to be 0x01, got %#x",
+				ts.MockTxHash1[0],
+			)
+		}
+		if ts.MockTxHash1[31] != 0x20 {
+			t.Errorf(
+				"expected MockTxHash1[31] to be 0x20, got %#x",
+				ts.MockTxHash1[31],
+			)
+		}
+	})
+
+	t.Run("MockTxHash2", func(t *testing.T) {
+		if len(ts.MockTxHash2) != 32 {
+			t.Errorf(
+				"expected MockTxHash2 length 32, got %d",
+				len(ts.MockTxHash2),
+			)
+		}
+		if ts.MockTxHash2[0] != 0x21 {
+			t.Errorf(
+				"expected MockTxHash2[0] to be 0x21, got %#x",
+				ts.MockTxHash2[0],
+			)
+		}
+		if ts.MockTxHash2[31] != 0x40 {
+			t.Errorf(
+				"expected MockTxHash2[31] to be 0x40, got %#x",
+				ts.MockTxHash2[31],
+			)
+		}
+	})
+
+	t.Run("MockTxHash3", func(t *testing.T) {
+		if len(ts.MockTxHash3) != 32 {
+			t.Errorf(
+				"expected MockTxHash3 length 32, got %d",
+				len(ts.MockTxHash3),
+			)
+		}
+		if ts.MockTxHash3[0] != 0x41 {
+			t.Errorf(
+				"expected MockTxHash3[0] to be 0x41, got %#x",
+				ts.MockTxHash3[0],
+			)
+		}
+		if ts.MockTxHash3[31] != 0x60 {
+			t.Errorf(
+				"expected MockTxHash3[31] to be 0x60, got %#x",
+				ts.MockTxHash3[31],
+			)
+		}
+	})
+
+	t.Run("hashes are unique", func(t *testing.T) {
+		if ts.MockTxHash1 == ts.MockTxHash2 {
+			t.Error("MockTxHash1 and MockTxHash2 should be different")
+		}
+		if ts.MockTxHash2 == ts.MockTxHash3 {
+			t.Error("MockTxHash2 and MockTxHash3 should be different")
+		}
+		if ts.MockTxHash1 == ts.MockTxHash3 {
+			t.Error("MockTxHash1 and MockTxHash3 should be different")
+		}
+	})
+}
+
+// TestMockTxIds tests the mock transaction ID fixtures.
+func TestMockTxIds(t *testing.T) {
+	t.Run("MockTxId1", func(t *testing.T) {
+		if ts.MockTxId1.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTxId1.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTxId1.EraId,
+			)
+		}
+		if ts.MockTxId1.TxId != ts.MockTxHash1 {
+			t.Error("expected MockTxId1.TxId to equal MockTxHash1")
+		}
+	})
+
+	t.Run("MockTxId2", func(t *testing.T) {
+		if ts.MockTxId2.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTxId2.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTxId2.EraId,
+			)
+		}
+		if ts.MockTxId2.TxId != ts.MockTxHash2 {
+			t.Error("expected MockTxId2.TxId to equal MockTxHash2")
+		}
+	})
+
+	t.Run("MockTxId3", func(t *testing.T) {
+		if ts.MockTxId3.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTxId3.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTxId3.EraId,
+			)
+		}
+		if ts.MockTxId3.TxId != ts.MockTxHash3 {
+			t.Error("expected MockTxId3.TxId to equal MockTxHash3")
+		}
+	})
+}
+
+// TestMockTxSizes tests the mock transaction size constants.
+func TestMockTxSizes(t *testing.T) {
+	if ts.MockTxSize1 != 256 {
+		t.Errorf("expected MockTxSize1 to be 256, got %d", ts.MockTxSize1)
+	}
+
+	if ts.MockTxSize2 != 512 {
+		t.Errorf("expected MockTxSize2 to be 512, got %d", ts.MockTxSize2)
+	}
+
+	if ts.MockTxSize3 != 1024 {
+		t.Errorf("expected MockTxSize3 to be 1024, got %d", ts.MockTxSize3)
+	}
+}
+
+// TestMockTxIdAndSizes tests the mock TxIdAndSize fixtures.
+func TestMockTxIdAndSizes(t *testing.T) {
+	t.Run("MockTxIdAndSize1", func(t *testing.T) {
+		if ts.MockTxIdAndSize1.TxId != ts.MockTxId1 {
+			t.Error("expected MockTxIdAndSize1.TxId to equal MockTxId1")
+		}
+		if ts.MockTxIdAndSize1.Size != ts.MockTxSize1 {
+			t.Errorf(
+				"expected MockTxIdAndSize1.Size to be %d, got %d",
+				ts.MockTxSize1,
+				ts.MockTxIdAndSize1.Size,
+			)
+		}
+	})
+
+	t.Run("MockTxIdAndSize2", func(t *testing.T) {
+		if ts.MockTxIdAndSize2.TxId != ts.MockTxId2 {
+			t.Error("expected MockTxIdAndSize2.TxId to equal MockTxId2")
+		}
+		if ts.MockTxIdAndSize2.Size != ts.MockTxSize2 {
+			t.Errorf(
+				"expected MockTxIdAndSize2.Size to be %d, got %d",
+				ts.MockTxSize2,
+				ts.MockTxIdAndSize2.Size,
+			)
+		}
+	})
+
+	t.Run("MockTxIdAndSize3", func(t *testing.T) {
+		if ts.MockTxIdAndSize3.TxId != ts.MockTxId3 {
+			t.Error("expected MockTxIdAndSize3.TxId to equal MockTxId3")
+		}
+		if ts.MockTxIdAndSize3.Size != ts.MockTxSize3 {
+			t.Errorf(
+				"expected MockTxIdAndSize3.Size to be %d, got %d",
+				ts.MockTxSize3,
+				ts.MockTxIdAndSize3.Size,
+			)
+		}
+	})
+}
+
+// TestMockTxBodies tests the mock transaction CBOR body fixtures.
+func TestMockTxBodies(t *testing.T) {
+	t.Run("MockTxBody1", func(t *testing.T) {
+		if len(ts.MockTxBody1) == 0 {
+			t.Error("expected MockTxBody1 to have non-zero length")
+		}
+		// Check CBOR array tag (0x84 = array of 4 elements)
+		if ts.MockTxBody1[0] != 0x84 {
+			t.Errorf(
+				"expected MockTxBody1[0] to be 0x84, got %#x",
+				ts.MockTxBody1[0],
+			)
+		}
+	})
+
+	t.Run("MockTxBody2", func(t *testing.T) {
+		if len(ts.MockTxBody2) == 0 {
+			t.Error("expected MockTxBody2 to have non-zero length")
+		}
+		// Check CBOR array tag (0x84 = array of 4 elements)
+		if ts.MockTxBody2[0] != 0x84 {
+			t.Errorf(
+				"expected MockTxBody2[0] to be 0x84, got %#x",
+				ts.MockTxBody2[0],
+			)
+		}
+	})
+
+	t.Run("MockTxBody3", func(t *testing.T) {
+		if len(ts.MockTxBody3) == 0 {
+			t.Error("expected MockTxBody3 to have non-zero length")
+		}
+		// Check CBOR array tag (0x84 = array of 4 elements)
+		if ts.MockTxBody3[0] != 0x84 {
+			t.Errorf(
+				"expected MockTxBody3[0] to be 0x84, got %#x",
+				ts.MockTxBody3[0],
+			)
+		}
+	})
+
+	t.Run("bodies are unique", func(t *testing.T) {
+		// Check each pair separately to ensure all are unique
+		if bytes.Equal(ts.MockTxBody1, ts.MockTxBody2) {
+			t.Error("MockTxBody1 and MockTxBody2 should be different")
+		}
+		if bytes.Equal(ts.MockTxBody2, ts.MockTxBody3) {
+			t.Error("MockTxBody2 and MockTxBody3 should be different")
+		}
+		if bytes.Equal(ts.MockTxBody1, ts.MockTxBody3) {
+			t.Error("MockTxBody1 and MockTxBody3 should be different")
+		}
+	})
+}
+
+// TestMockTxs tests the mock TxBody fixtures.
+func TestMockTxs(t *testing.T) {
+	t.Run("MockTx1", func(t *testing.T) {
+		if ts.MockTx1.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTx1.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTx1.EraId,
+			)
+		}
+		if len(ts.MockTx1.TxBody) == 0 {
+			t.Error("expected MockTx1.TxBody to have non-zero length")
+		}
+	})
+
+	t.Run("MockTx2", func(t *testing.T) {
+		if ts.MockTx2.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTx2.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTx2.EraId,
+			)
+		}
+		if len(ts.MockTx2.TxBody) == 0 {
+			t.Error("expected MockTx2.TxBody to have non-zero length")
+		}
+	})
+
+	t.Run("MockTx3", func(t *testing.T) {
+		if ts.MockTx3.EraId != ts.MockEraConway {
+			t.Errorf(
+				"expected MockTx3.EraId to be %d, got %d",
+				ts.MockEraConway,
+				ts.MockTx3.EraId,
+			)
+		}
+		if len(ts.MockTx3.TxBody) == 0 {
+			t.Error("expected MockTx3.TxBody to have non-zero length")
+		}
+	})
+}
+
+// TestConversationTxSubmissionBasic tests that the basic conversation fixture
+// is a valid slice with expected entries.
+func TestConversationTxSubmissionBasic(t *testing.T) {
+	if ts.ConversationTxSubmissionBasic == nil {
+		t.Fatal("ConversationTxSubmissionBasic should not be nil")
+	}
+
+	if len(ts.ConversationTxSubmissionBasic) == 0 {
+		t.Fatal("ConversationTxSubmissionBasic should not be empty")
+	}
+
+	// Expected entry count: 2 handshake + 7 tx submission = 9
+	expectedLen := 9
+	if len(ts.ConversationTxSubmissionBasic) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(ts.ConversationTxSubmissionBasic),
+		)
+	}
+
+	// Verify all entries are not nil
+	for i, entry := range ts.ConversationTxSubmissionBasic {
+		if entry == nil {
+			t.Errorf("entry %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationTxSubmissionMultipleTxs tests that the multiple transactions
+// conversation fixture is a valid slice with expected entries.
+func TestConversationTxSubmissionMultipleTxs(t *testing.T) {
+	if ts.ConversationTxSubmissionMultipleTxs == nil {
+		t.Fatal("ConversationTxSubmissionMultipleTxs should not be nil")
+	}
+
+	if len(ts.ConversationTxSubmissionMultipleTxs) == 0 {
+		t.Fatal("ConversationTxSubmissionMultipleTxs should not be empty")
+	}
+
+	// Expected entry count: 2 handshake + 11 tx submission = 13
+	expectedLen := 13
+	if len(ts.ConversationTxSubmissionMultipleTxs) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(ts.ConversationTxSubmissionMultipleTxs),
+		)
+	}
+
+	// Verify all entries are not nil
+	for i, entry := range ts.ConversationTxSubmissionMultipleTxs {
+		if entry == nil {
+			t.Errorf("entry %d should not be nil", i)
+		}
+	}
+}
+
+// TestConversationTxSubmissionEmpty tests that the empty conversation fixture
+// is a valid slice with expected entries.
+func TestConversationTxSubmissionEmpty(t *testing.T) {
+	if ts.ConversationTxSubmissionEmpty == nil {
+		t.Fatal("ConversationTxSubmissionEmpty should not be nil")
+	}
+
+	if len(ts.ConversationTxSubmissionEmpty) == 0 {
+		t.Fatal("ConversationTxSubmissionEmpty should not be empty")
+	}
+
+	// Expected entry count: 2 handshake + 5 tx submission = 7
+	expectedLen := 7
+	if len(ts.ConversationTxSubmissionEmpty) != expectedLen {
+		t.Errorf(
+			"expected %d entries, got %d",
+			expectedLen,
+			len(ts.ConversationTxSubmissionEmpty),
+		)
+	}
+
+	// Verify all entries are not nil
+	for i, entry := range ts.ConversationTxSubmissionEmpty {
+		if entry == nil {
+			t.Errorf("entry %d should not be nil", i)
+		}
+	}
+}
+
+// TestProtocolId verifies the protocol ID constant is as expected.
+func TestProtocolId(t *testing.T) {
+	// The TxSubmission protocol ID should be 4
+	expectedProtocolId := uint16(4)
+	if txsubmission.ProtocolId != expectedProtocolId {
+		t.Errorf(
+			"expected ProtocolId %d, got %d",
+			expectedProtocolId,
+			txsubmission.ProtocolId,
+		)
+	}
+}
+
+// TestMessageTypes verifies the message type constants are as expected.
+func TestMessageTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   uint
+		expected uint
+	}{
+		{"MessageTypeRequestTxIds", txsubmission.MessageTypeRequestTxIds, 0},
+		{"MessageTypeReplyTxIds", txsubmission.MessageTypeReplyTxIds, 1},
+		{"MessageTypeRequestTxs", txsubmission.MessageTypeRequestTxs, 2},
+		{"MessageTypeReplyTxs", txsubmission.MessageTypeReplyTxs, 3},
+		{"MessageTypeDone", txsubmission.MessageTypeDone, 4},
+		{"MessageTypeInit", txsubmission.MessageTypeInit, 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.actual != tt.expected {
+				t.Errorf(
+					"expected %s to be %d, got %d",
+					tt.name,
+					tt.expected,
+					tt.actual,
+				)
+			}
+		})
+	}
+}
+
+// TestMsgFromCborFunc verifies that the MsgFromCborFunc is set correctly
+// in ConversationEntryInput entries.
+func TestMsgFromCborFunc(t *testing.T) {
+	t.Run("Init entry has MsgFromCborFunc", func(t *testing.T) {
+		input := ts.NewInitEntry()
+		if input.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ReplyTxIds entry has MsgFromCborFunc", func(t *testing.T) {
+		input := ts.NewReplyTxIdsEntryAny()
+		if input.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("ReplyTxs entry has MsgFromCborFunc", func(t *testing.T) {
+		input := ts.NewReplyTxsEntryAny()
+		if input.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+
+	t.Run("Done entry has MsgFromCborFunc", func(t *testing.T) {
+		input := ts.NewDoneEntry()
+		if input.MsgFromCborFunc == nil {
+			t.Error("expected MsgFromCborFunc to be set")
+		}
+	})
+}

--- a/txsubmission/fixtures.go
+++ b/txsubmission/fixtures.go
@@ -1,0 +1,243 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txsubmission
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mock constants for TxSubmission testing
+
+// MockEraConway is the era ID for Conway era transactions
+const MockEraConway uint16 = 6
+
+// MockTxHash1 is a sample transaction hash for testing
+var MockTxHash1 = [32]byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+// MockTxHash2 is a second sample transaction hash for testing
+var MockTxHash2 = [32]byte{
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+	0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+	0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+	0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
+}
+
+// MockTxHash3 is a third sample transaction hash for testing
+var MockTxHash3 = [32]byte{
+	0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+	0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+	0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+	0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
+}
+
+// MockTxId1 is a sample transaction ID for testing
+var MockTxId1 = txsubmission.TxId{
+	EraId: MockEraConway,
+	TxId:  MockTxHash1,
+}
+
+// MockTxId2 is a second sample transaction ID for testing
+var MockTxId2 = txsubmission.TxId{
+	EraId: MockEraConway,
+	TxId:  MockTxHash2,
+}
+
+// MockTxId3 is a third sample transaction ID for testing
+var MockTxId3 = txsubmission.TxId{
+	EraId: MockEraConway,
+	TxId:  MockTxHash3,
+}
+
+// MockTxSize1 is a sample transaction size for testing (256 bytes)
+const MockTxSize1 uint32 = 256
+
+// MockTxSize2 is a second sample transaction size for testing (512 bytes)
+const MockTxSize2 uint32 = 512
+
+// MockTxSize3 is a third sample transaction size for testing (1024 bytes)
+const MockTxSize3 uint32 = 1024
+
+// MockTxIdAndSize1 is a sample TxIdAndSize for testing
+var MockTxIdAndSize1 = txsubmission.TxIdAndSize{
+	TxId: MockTxId1,
+	Size: MockTxSize1,
+}
+
+// MockTxIdAndSize2 is a second sample TxIdAndSize for testing
+var MockTxIdAndSize2 = txsubmission.TxIdAndSize{
+	TxId: MockTxId2,
+	Size: MockTxSize2,
+}
+
+// MockTxIdAndSize3 is a third sample TxIdAndSize for testing
+var MockTxIdAndSize3 = txsubmission.TxIdAndSize{
+	TxId: MockTxId3,
+	Size: MockTxSize3,
+}
+
+// MockTxBody1 is sample transaction CBOR body for testing
+var MockTxBody1 = []byte{
+	0x84, // Array of 4 (transaction structure)
+	0xa0, // Empty map (inputs)
+	0x80, // Empty array (outputs)
+	0xa0, // Empty map (fee, etc)
+	0xa0, // Empty map (witnesses)
+}
+
+// MockTxBody2 is a second sample transaction CBOR body for testing
+var MockTxBody2 = []byte{
+	0x84,             // Array of 4
+	0xa1, 0x00, 0x80, // Map with inputs
+	0x81, 0xa0, // Array with one output
+	0xa1, 0x02, 0x00, // Map with fee
+	0xa0, // Empty witnesses
+}
+
+// MockTxBody3 is a third sample transaction CBOR body for testing
+var MockTxBody3 = []byte{
+	0x84,                               // Array of 4
+	0xa1, 0x00, 0x81, 0x82, 0x58, 0x20, // Map with inputs
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	0x00,       // Index 0
+	0x80,       // Empty outputs
+	0xa1, 0x02, // Fee
+	0x19, 0x01, 0x00, // 256
+	0xa0, // Empty witnesses
+}
+
+// MockTx1 is a sample TxBody for testing
+var MockTx1 = txsubmission.TxBody{
+	EraId:  MockEraConway,
+	TxBody: MockTxBody1,
+}
+
+// MockTx2 is a second sample TxBody for testing
+var MockTx2 = txsubmission.TxBody{
+	EraId:  MockEraConway,
+	TxBody: MockTxBody2,
+}
+
+// MockTx3 is a third sample TxBody for testing
+var MockTx3 = txsubmission.TxBody{
+	EraId:  MockEraConway,
+	TxBody: MockTxBody3,
+}
+
+// Pre-defined conversations for common TxSubmission scenarios
+
+// ConversationTxSubmissionBasic is a pre-defined conversation for basic tx submission flow:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - Init (client starts protocol)
+// - RequestTxIds (server requests tx IDs, non-blocking)
+// - ReplyTxIds (client sends one tx ID)
+// - RequestTxs (server requests the transaction)
+// - ReplyTxs (client sends the transaction body)
+// - RequestTxIds (server requests more, blocking)
+// - Done (client terminates, no more transactions)
+var ConversationTxSubmissionBasic = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// Init (expect from client)
+	NewInitEntry(),
+	// Server sends request for tx IDs (non-blocking)
+	NewRequestTxIdsEntry(false, 0, 10),
+	// Expect client to reply with tx IDs
+	NewReplyTxIdsEntryAny(),
+	// Server sends request for the transactions
+	NewRequestTxsEntry([]txsubmission.TxId{MockTxId1}),
+	// Expect client to send the transaction body
+	NewReplyTxsEntryAny(),
+	// Server sends request for more tx IDs (blocking)
+	NewRequestTxIdsEntry(true, 1, 10),
+	// Expect client to terminate (no more transactions)
+	NewDoneEntry(),
+}
+
+// ConversationTxSubmissionMultipleTxs is a pre-defined conversation for multiple transactions:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - Init (client starts protocol)
+// - RequestTxIds (server requests tx IDs)
+// - ReplyTxIds (client sends multiple tx IDs)
+// - RequestTxs (server requests transactions)
+// - ReplyTxs (client sends transaction bodies)
+// - RequestTxIds (server requests more)
+// - ReplyTxIds (client sends one more)
+// - RequestTxs (server requests that transaction)
+// - ReplyTxs (client sends the transaction)
+// - RequestTxIds (blocking)
+// - Done (no more transactions)
+var ConversationTxSubmissionMultipleTxs = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// Init (expect from client)
+	NewInitEntry(),
+	// First batch: server sends request for tx IDs
+	NewRequestTxIdsEntry(false, 0, 10),
+	// Expect client to reply with tx IDs
+	NewReplyTxIdsEntryAny(),
+	// Server sends request for both transactions
+	NewRequestTxsEntry([]txsubmission.TxId{MockTxId1, MockTxId2}),
+	// Expect client to send transaction bodies
+	NewReplyTxsEntryAny(),
+	// Second batch: server sends request for more tx IDs
+	NewRequestTxIdsEntry(false, 2, 10),
+	// Expect client to reply with more tx IDs
+	NewReplyTxIdsEntryAny(),
+	// Server sends request for that transaction
+	NewRequestTxsEntry([]txsubmission.TxId{MockTxId3}),
+	// Expect client to send the transaction body
+	NewReplyTxsEntryAny(),
+	// Server sends request for more tx IDs (blocking)
+	NewRequestTxIdsEntry(true, 1, 10),
+	// Expect client to terminate (no more transactions)
+	NewDoneEntry(),
+}
+
+// ConversationTxSubmissionEmpty is a pre-defined conversation when no transactions are available:
+// - Handshake request (generic)
+// - Handshake NtN response
+// - Init (client starts protocol)
+// - RequestTxIds (server requests tx IDs, non-blocking)
+// - ReplyTxIds (client sends empty list)
+// - RequestTxIds (server requests again, blocking)
+// - Done (client terminates, no transactions)
+var ConversationTxSubmissionEmpty = []ouroboros_mock.ConversationEntry{
+	// Handshake
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	// Init (expect from client)
+	NewInitEntry(),
+	// Server sends request for tx IDs (non-blocking)
+	NewRequestTxIdsEntry(false, 0, 10),
+	// Expect client to reply with empty list
+	NewReplyTxIdsEntryAny(),
+	// Server sends request again (blocking, waiting for new transactions)
+	NewRequestTxIdsEntry(true, 0, 10),
+	// Expect client to terminate (no transactions available)
+	NewDoneEntry(),
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enhanced mock support with builders, fixtures, and conversation entries across all Ouroboros protocols and eras to enable deterministic tests and easier local development. This includes block/ledger mock builders and end-to-end protocol coverage for BlockFetch, ChainSync, LocalStateQuery/Monitor, LocalTxSubmission, TxSubmission, and PeerSharing.

- **New Features**
  - Block builders for Byron, Shelley, Allegra, Mary, Alonzo, Babbage, Conway, plus a ChainBuilder for linked sequences with auto hashes.
  - Ledger mock builders: transactions (multi-asset, Plutus), UTXO, protocol params (per era), rewards/Ada pots, pools, governance, and runtime state.
  - Conversation entry types and fixtures for BlockFetch, ChainSync, LocalStateQuery/Monitor, LocalTxSubmission, TxSubmission, and PeerSharing; helpers convert to gouroboros ConversationEntry inputs/outputs.
  - Genesis fixtures for Byron/Shelley/Conway.
  - Comprehensive unit tests for blocks, ledger, and all protocol entries.

- **Dependencies**
  - Added github.com/blinklabs-io/plutigo and github.com/utxorpc/go-codegen as direct dependencies.

<sup>Written for commit 3b82040bb62fd033822c7f0ee9422ddbcc2a23b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large set of mock builders and fixtures for multiple eras (blocks, headers, chains, transactions, UTxOs, governance, pools, rewards, genesis) and protocol conversation helpers to simplify testing and scenario simulation.

* **Tests**
  * Extensive unit/integration test coverage across conversation entries, builders, fixtures, encoders, RPC/Plutus conversions, and cross-era scenarios.

* **Chores**
  * Simplified Makefile and updated module dependency list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->