### PR TITLE
feat: ledger state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.24.1
 
 require (
 	github.com/blinklabs-io/gouroboros v0.149.0
+	github.com/blinklabs-io/plutigo v0.0.21
+	github.com/utxorpc/go-codegen v0.18.1
 	go.uber.org/goleak v1.3.0
 )
 
@@ -13,7 +15,6 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
-	github.com/blinklabs-io/plutigo v0.0.18 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
@@ -26,7 +27,6 @@ require (
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
-	github.com/utxorpc/go-codegen v0.18.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blinklabs-io/gouroboros v0.149.0 h1:Kgnnn6l/ogwdOwppqRzZi8EGtNu0B+/4hjvkgSL/Wes=
 github.com/blinklabs-io/gouroboros v0.149.0/go.mod h1:UqNKi2y70+0s+0QxSwox+pdB++lq2RqUSWtErngs8NQ=
-github.com/blinklabs-io/plutigo v0.0.18 h1:axw0QVrdiqEjt+ssKs5zY2ycogZ+j5r0IETHkAda+8Q=
-github.com/blinklabs-io/plutigo v0.0.18/go.mod h1:L72ik2SFGruMCxqI5nnuMMz0TwSu9Fk+MekKynr3SPQ=
+github.com/blinklabs-io/plutigo v0.0.21 h1:+corf01GABIs8dKQowlYgBk5RFfj0wrficxG1LVF3Qw=
+github.com/blinklabs-io/plutigo v0.0.21/go.mod h1:JwWJQOXVc3Bbb5ot05MUZOACysxTU8TsyDZ9IAJgKeA=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/governance.go
+++ b/ledger/governance.go
@@ -1,0 +1,504 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// CommitteeMemberBuilder defines an interface for building mock committee member state
+type CommitteeMemberBuilder interface {
+	WithColdKey(key []byte) CommitteeMemberBuilder
+	WithHotKey(key []byte) CommitteeMemberBuilder
+	WithExpiryEpoch(epoch uint64) CommitteeMemberBuilder
+	WithResigned(resigned bool) CommitteeMemberBuilder
+	WithResignAnchor(url string, dataHash []byte) CommitteeMemberBuilder
+	Build() (*CommitteeMember, error)
+}
+
+// CommitteeMember represents a committee member state for mock purposes
+type CommitteeMember struct {
+	ColdCredential lcommon.Credential
+	HotCredential  lcommon.Credential
+	ExpiryEpoch    uint64
+	Resigned       bool
+	ResignAnchor   *lcommon.GovAnchor
+}
+
+// committeeMemberBuilder implements CommitteeMemberBuilder
+type committeeMemberBuilder struct {
+	coldKey           []byte
+	hotKey            []byte
+	expiryEpoch       uint64
+	resigned          bool
+	resignAnchor      *lcommon.GovAnchor
+	resignDataHashErr error // Stores dataHash validation error for deferred reporting
+}
+
+// NewCommitteeMemberBuilder creates a new CommitteeMemberBuilder
+func NewCommitteeMemberBuilder() CommitteeMemberBuilder {
+	return &committeeMemberBuilder{}
+}
+
+// WithColdKey sets the cold key credential for the committee member
+func (b *committeeMemberBuilder) WithColdKey(
+	key []byte,
+) CommitteeMemberBuilder {
+	b.coldKey = key
+	return b
+}
+
+// WithHotKey sets the hot key credential for the committee member
+func (b *committeeMemberBuilder) WithHotKey(key []byte) CommitteeMemberBuilder {
+	b.hotKey = key
+	return b
+}
+
+// WithExpiryEpoch sets the expiry epoch for the committee member
+func (b *committeeMemberBuilder) WithExpiryEpoch(
+	epoch uint64,
+) CommitteeMemberBuilder {
+	b.expiryEpoch = epoch
+	return b
+}
+
+// WithResigned sets whether the committee member has resigned
+func (b *committeeMemberBuilder) WithResigned(
+	resigned bool,
+) CommitteeMemberBuilder {
+	b.resigned = resigned
+	return b
+}
+
+// WithResignAnchor sets the resignation anchor for the committee member
+// If dataHash is provided but not exactly 32 bytes, Build() will return an error
+func (b *committeeMemberBuilder) WithResignAnchor(
+	url string,
+	dataHash []byte,
+) CommitteeMemberBuilder {
+	if url != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: url,
+		}
+		if len(dataHash) > 0 {
+			if len(dataHash) != 32 {
+				b.resignDataHashErr = fmt.Errorf(
+					"resign anchor dataHash must be exactly 32 bytes, got %d",
+					len(dataHash),
+				)
+			} else {
+				// Clear any previous error when valid hash is provided
+				b.resignDataHashErr = nil
+				copy(anchor.DataHash[:], dataHash)
+			}
+		}
+		b.resignAnchor = anchor
+	}
+	return b
+}
+
+// Build constructs a CommitteeMember from the builder state
+func (b *committeeMemberBuilder) Build() (*CommitteeMember, error) {
+	if len(b.coldKey) == 0 {
+		return nil, errors.New("cold key is required")
+	}
+	// Return any stored validation errors
+	if b.resignDataHashErr != nil {
+		return nil, b.resignDataHashErr
+	}
+
+	member := &CommitteeMember{
+		ColdCredential: lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.coldKey),
+		},
+		ExpiryEpoch:  b.expiryEpoch,
+		Resigned:     b.resigned,
+		ResignAnchor: b.resignAnchor,
+	}
+
+	if len(b.hotKey) > 0 {
+		member.HotCredential = lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.hotKey),
+		}
+	}
+
+	return member, nil
+}
+
+// DRepRegistrationBuilder defines an interface for building mock DRep registrations
+type DRepRegistrationBuilder interface {
+	WithCredential(cred []byte) DRepRegistrationBuilder
+	WithAnchor(url string, dataHash []byte) DRepRegistrationBuilder
+	WithDeposit(lovelace uint64) DRepRegistrationBuilder
+	Build() (*lcommon.RegistrationDrepCertificate, error)
+}
+
+// drepRegistrationBuilder implements DRepRegistrationBuilder
+type drepRegistrationBuilder struct {
+	credential []byte
+	anchorURL  string
+	dataHash   []byte
+	deposit    uint64
+}
+
+// NewDRepRegistrationBuilder creates a new DRepRegistrationBuilder
+func NewDRepRegistrationBuilder() DRepRegistrationBuilder {
+	return &drepRegistrationBuilder{}
+}
+
+// WithCredential sets the DRep credential
+func (b *drepRegistrationBuilder) WithCredential(
+	cred []byte,
+) DRepRegistrationBuilder {
+	b.credential = cred
+	return b
+}
+
+// WithAnchor sets the anchor URL and data hash for the DRep registration
+func (b *drepRegistrationBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) DRepRegistrationBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// WithDeposit sets the deposit amount in lovelace
+func (b *drepRegistrationBuilder) WithDeposit(
+	lovelace uint64,
+) DRepRegistrationBuilder {
+	b.deposit = lovelace
+	return b
+}
+
+// Build constructs a RegistrationDrepCertificate from the builder state
+func (b *drepRegistrationBuilder) Build() (*lcommon.RegistrationDrepCertificate, error) {
+	if len(b.credential) == 0 {
+		return nil, errors.New("credential is required")
+	}
+
+	// Validate deposit doesn't overflow int64
+	if b.deposit > uint64(math.MaxInt64) {
+		return nil, fmt.Errorf(
+			"deposit %d exceeds maximum int64 value",
+			b.deposit,
+		)
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	cert := &lcommon.RegistrationDrepCertificate{
+		CertType: uint(lcommon.CertificateTypeRegistrationDrep),
+		DrepCredential: lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(b.credential),
+		},
+		Amount: int64(b.deposit),
+	}
+
+	if b.anchorURL != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: b.anchorURL,
+		}
+		if len(b.dataHash) > 0 {
+			copy(anchor.DataHash[:], b.dataHash)
+		}
+		cert.Anchor = anchor
+	}
+
+	return cert, nil
+}
+
+// ConstitutionBuilder defines an interface for building mock constitutions
+type ConstitutionBuilder interface {
+	WithAnchor(url string, dataHash []byte) ConstitutionBuilder
+	WithScriptHash(hash []byte) ConstitutionBuilder
+	Build() (*Constitution, error)
+}
+
+// Constitution represents a constitution for mock purposes
+type Constitution struct {
+	Anchor     lcommon.GovAnchor
+	ScriptHash []byte
+}
+
+// constitutionBuilder implements ConstitutionBuilder
+type constitutionBuilder struct {
+	anchorURL  string
+	dataHash   []byte
+	scriptHash []byte
+}
+
+// NewConstitutionBuilder creates a new ConstitutionBuilder
+func NewConstitutionBuilder() ConstitutionBuilder {
+	return &constitutionBuilder{}
+}
+
+// WithAnchor sets the anchor URL and data hash for the constitution
+func (b *constitutionBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) ConstitutionBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// WithScriptHash sets the optional script hash for the constitution
+func (b *constitutionBuilder) WithScriptHash(hash []byte) ConstitutionBuilder {
+	b.scriptHash = hash
+	return b
+}
+
+// Build constructs a Constitution from the builder state
+func (b *constitutionBuilder) Build() (*Constitution, error) {
+	if b.anchorURL == "" {
+		return nil, errors.New("anchor URL is required")
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	// Validate scriptHash length if provided (Blake2b224 is 28 bytes)
+	if len(b.scriptHash) > 0 && len(b.scriptHash) != 28 {
+		return nil, fmt.Errorf(
+			"scriptHash must be exactly 28 bytes, got %d",
+			len(b.scriptHash),
+		)
+	}
+
+	constitution := &Constitution{
+		Anchor: lcommon.GovAnchor{
+			Url: b.anchorURL,
+		},
+		ScriptHash: b.scriptHash,
+	}
+
+	if len(b.dataHash) > 0 {
+		copy(constitution.Anchor.DataHash[:], b.dataHash)
+	}
+
+	return constitution, nil
+}
+
+// GovAnchorBuilder defines an interface for building governance anchors
+type GovAnchorBuilder interface {
+	WithURL(url string) GovAnchorBuilder
+	WithDataHash(hash []byte) GovAnchorBuilder
+	Build() (*lcommon.GovAnchor, error)
+}
+
+// govAnchorBuilder implements GovAnchorBuilder
+type govAnchorBuilder struct {
+	url      string
+	dataHash []byte
+}
+
+// NewGovAnchorBuilder creates a new GovAnchorBuilder
+func NewGovAnchorBuilder() GovAnchorBuilder {
+	return &govAnchorBuilder{}
+}
+
+// WithURL sets the URL for the governance anchor
+func (b *govAnchorBuilder) WithURL(url string) GovAnchorBuilder {
+	b.url = url
+	return b
+}
+
+// WithDataHash sets the data hash for the governance anchor
+func (b *govAnchorBuilder) WithDataHash(hash []byte) GovAnchorBuilder {
+	b.dataHash = hash
+	return b
+}
+
+// Build constructs a GovAnchor from the builder state
+func (b *govAnchorBuilder) Build() (*lcommon.GovAnchor, error) {
+	if b.url == "" {
+		return nil, errors.New("URL is required")
+	}
+
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	anchor := &lcommon.GovAnchor{
+		Url: b.url,
+	}
+
+	if len(b.dataHash) > 0 {
+		copy(anchor.DataHash[:], b.dataHash)
+	}
+
+	return anchor, nil
+}
+
+// VoterBuilder defines an interface for building mock voters
+type VoterBuilder interface {
+	WithType(voterType uint8) VoterBuilder
+	WithHash(hash []byte) VoterBuilder
+	Build() (*lcommon.Voter, error)
+}
+
+// voterBuilder implements VoterBuilder
+type voterBuilder struct {
+	voterType uint8
+	hash      []byte
+}
+
+// NewVoterBuilder creates a new VoterBuilder
+func NewVoterBuilder() VoterBuilder {
+	return &voterBuilder{}
+}
+
+// WithType sets the voter type (constitutional committee, drep, or pool)
+func (b *voterBuilder) WithType(voterType uint8) VoterBuilder {
+	b.voterType = voterType
+	return b
+}
+
+// WithHash sets the credential hash for the voter
+func (b *voterBuilder) WithHash(hash []byte) VoterBuilder {
+	b.hash = hash
+	return b
+}
+
+// Build constructs a Voter from the builder state
+func (b *voterBuilder) Build() (*lcommon.Voter, error) {
+	if len(b.hash) == 0 {
+		return nil, errors.New("hash is required")
+	}
+	// Validate hash length (Blake2b224 is 28 bytes)
+	if len(b.hash) != 28 {
+		return nil, fmt.Errorf(
+			"hash must be exactly 28 bytes, got %d",
+			len(b.hash),
+		)
+	}
+	// Validate voter type (0-4 per CIP-1694):
+	// 0=CC hot key hash, 1=CC hot script hash, 2=DRep key hash,
+	// 3=DRep script hash, 4=staking pool key hash
+	if b.voterType > 4 {
+		return nil, fmt.Errorf(
+			"invalid voter type %d, must be 0-4",
+			b.voterType,
+		)
+	}
+
+	voter := &lcommon.Voter{
+		Type: b.voterType,
+	}
+	copy(voter.Hash[:], b.hash)
+
+	return voter, nil
+}
+
+// VotingProcedureBuilder defines an interface for building mock voting procedures
+type VotingProcedureBuilder interface {
+	WithVote(vote uint8) VotingProcedureBuilder
+	WithAnchor(url string, dataHash []byte) VotingProcedureBuilder
+	Build() (*lcommon.VotingProcedure, error)
+}
+
+// votingProcedureBuilder implements VotingProcedureBuilder
+type votingProcedureBuilder struct {
+	vote      uint8
+	voteSet   bool // Tracks whether WithVote was called
+	anchorURL string
+	dataHash  []byte
+}
+
+// NewVotingProcedureBuilder creates a new VotingProcedureBuilder
+func NewVotingProcedureBuilder() VotingProcedureBuilder {
+	return &votingProcedureBuilder{}
+}
+
+// WithVote sets the vote value (yes, no, or abstain)
+func (b *votingProcedureBuilder) WithVote(vote uint8) VotingProcedureBuilder {
+	b.vote = vote
+	b.voteSet = true
+	return b
+}
+
+// WithAnchor sets the optional anchor for the voting procedure
+func (b *votingProcedureBuilder) WithAnchor(
+	url string,
+	dataHash []byte,
+) VotingProcedureBuilder {
+	b.anchorURL = url
+	b.dataHash = dataHash
+	return b
+}
+
+// Build constructs a VotingProcedure from the builder state
+func (b *votingProcedureBuilder) Build() (*lcommon.VotingProcedure, error) {
+	// Require explicit vote setting to avoid unintentional defaults
+	if !b.voteSet {
+		return nil, errors.New(
+			"vote is required; call WithVote(0), WithVote(1), or WithVote(2)",
+		)
+	}
+	// Validate vote value (0=no, 1=yes, 2=abstain)
+	if b.vote > 2 {
+		return nil, fmt.Errorf(
+			"invalid vote value %d, must be 0 (no), 1 (yes), or 2 (abstain)",
+			b.vote,
+		)
+	}
+	// Validate dataHash length if provided (Blake2b256 is 32 bytes)
+	if len(b.dataHash) > 0 && len(b.dataHash) != 32 {
+		return nil, fmt.Errorf(
+			"dataHash must be exactly 32 bytes, got %d",
+			len(b.dataHash),
+		)
+	}
+
+	procedure := &lcommon.VotingProcedure{
+		Vote: b.vote,
+	}
+
+	if b.anchorURL != "" {
+		anchor := &lcommon.GovAnchor{
+			Url: b.anchorURL,
+		}
+		if len(b.dataHash) > 0 {
+			copy(anchor.DataHash[:], b.dataHash)
+		}
+		procedure.Anchor = anchor
+	}
+
+	return procedure, nil
+}

--- a/ledger/pools.go
+++ b/ledger/pools.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// PoolBuilder defines an interface for building mock pool registration certificates
+type PoolBuilder interface {
+	WithOperator(keyHash []byte) PoolBuilder
+	WithVrfKeyHash(hash []byte) PoolBuilder
+	WithPledge(lovelace uint64) PoolBuilder
+	WithCost(lovelace uint64) PoolBuilder
+	WithMargin(numerator, denominator uint64) PoolBuilder
+	WithRewardAccountKey(keyHash []byte) PoolBuilder
+	WithOwners(owners ...[]byte) PoolBuilder
+	WithRelays(relays ...lcommon.PoolRelay) PoolBuilder
+	WithMetadata(url string, hash []byte) PoolBuilder
+	Build() (*lcommon.PoolRegistrationCertificate, error)
+}
+
+// MockPool holds the state for building a pool registration certificate
+type MockPool struct {
+	operator        lcommon.PoolKeyHash
+	vrfKeyHash      lcommon.VrfKeyHash
+	vrfKeyHashErr   error // tracks VRF key hash validation error
+	pledge          uint64
+	cost            uint64
+	margin          cbor.Rat
+	marginDenomZero bool // tracks if denominator was set to zero
+	rewardAccount   lcommon.AddrKeyHash
+	poolOwners      []lcommon.AddrKeyHash
+	relays          []lcommon.PoolRelay
+	poolMetadata    *lcommon.PoolMetadata
+	metadataHashErr error // tracks metadata hash validation error
+}
+
+// NewPoolBuilder creates a new MockPool builder
+func NewPoolBuilder() *MockPool {
+	return &MockPool{
+		margin: cbor.Rat{Rat: big.NewRat(0, 1)},
+	}
+}
+
+// WithOperator sets the pool operator key hash
+func (p *MockPool) WithOperator(keyHash []byte) PoolBuilder {
+	p.operator = lcommon.NewBlake2b224(keyHash)
+	return p
+}
+
+// WithVrfKeyHash sets the VRF key hash
+// If hash length is not exactly 32 bytes, Build() will return an error
+func (p *MockPool) WithVrfKeyHash(hash []byte) PoolBuilder {
+	if len(hash) != len(p.vrfKeyHash) {
+		p.vrfKeyHashErr = fmt.Errorf(
+			"VRF key hash must be exactly %d bytes, got %d",
+			len(p.vrfKeyHash),
+			len(hash),
+		)
+		return p
+	}
+	// Clear any previous error when valid hash is provided
+	p.vrfKeyHashErr = nil
+	copy(p.vrfKeyHash[:], hash)
+	return p
+}
+
+// WithPledge sets the pool pledge amount in lovelace
+func (p *MockPool) WithPledge(lovelace uint64) PoolBuilder {
+	p.pledge = lovelace
+	return p
+}
+
+// WithCost sets the pool fixed cost in lovelace
+func (p *MockPool) WithCost(lovelace uint64) PoolBuilder {
+	p.cost = lovelace
+	return p
+}
+
+// WithMargin sets the pool margin as a ratio (numerator/denominator)
+// If denominator is zero, Build() will return an error
+func (p *MockPool) WithMargin(numerator, denominator uint64) PoolBuilder {
+	if denominator == 0 {
+		p.marginDenomZero = true
+		return p
+	}
+	// Clear any previous error flag when valid denominator is provided
+	p.marginDenomZero = false
+	// Use big.Int to avoid int64 overflow for large uint64 values
+	num := new(big.Int).SetUint64(numerator)
+	denom := new(big.Int).SetUint64(denominator)
+	p.margin = cbor.Rat{Rat: new(big.Rat).SetFrac(num, denom)}
+	return p
+}
+
+// WithRewardAccountKey sets the pool reward account key hash
+// The keyHash should be a Blake2b224 hash (28 bytes)
+func (p *MockPool) WithRewardAccountKey(keyHash []byte) PoolBuilder {
+	p.rewardAccount = lcommon.NewBlake2b224(keyHash)
+	return p
+}
+
+// WithOwners sets the pool owners
+func (p *MockPool) WithOwners(owners ...[]byte) PoolBuilder {
+	p.poolOwners = make([]lcommon.AddrKeyHash, len(owners))
+	for i, owner := range owners {
+		p.poolOwners[i] = lcommon.NewBlake2b224(owner)
+	}
+	return p
+}
+
+// WithRelays sets the pool relays
+func (p *MockPool) WithRelays(relays ...lcommon.PoolRelay) PoolBuilder {
+	p.relays = relays
+	return p
+}
+
+// WithMetadata sets the pool metadata URL and hash
+// If hash length is not exactly 32 bytes, Build() will return an error
+func (p *MockPool) WithMetadata(url string, hash []byte) PoolBuilder {
+	var metadataHash lcommon.PoolMetadataHash
+	if len(hash) != len(metadataHash) {
+		p.metadataHashErr = fmt.Errorf(
+			"pool metadata hash must be exactly %d bytes, got %d",
+			len(metadataHash),
+			len(hash),
+		)
+		return p
+	}
+	// Clear any previous error when valid hash is provided
+	p.metadataHashErr = nil
+	copy(metadataHash[:], hash)
+	p.poolMetadata = &lcommon.PoolMetadata{
+		Url:  url,
+		Hash: metadataHash,
+	}
+	return p
+}
+
+// Build constructs a PoolRegistrationCertificate from the builder state
+func (p *MockPool) Build() (*lcommon.PoolRegistrationCertificate, error) {
+	// Return any stored validation errors
+	if p.vrfKeyHashErr != nil {
+		return nil, p.vrfKeyHashErr
+	}
+	if p.metadataHashErr != nil {
+		return nil, p.metadataHashErr
+	}
+	// Validate margin denominator was not zero
+	if p.marginDenomZero {
+		return nil, errors.New("pool margin denominator cannot be zero")
+	}
+
+	cert := &lcommon.PoolRegistrationCertificate{
+		CertType:      3, // Pool registration certificate type
+		Operator:      p.operator,
+		VrfKeyHash:    p.vrfKeyHash,
+		Pledge:        p.pledge,
+		Cost:          p.cost,
+		Margin:        p.margin,
+		RewardAccount: p.rewardAccount,
+		PoolOwners:    p.poolOwners,
+		Relays:        p.relays,
+		PoolMetadata:  p.poolMetadata,
+	}
+	return cert, nil
+}

--- a/ledger/pparams.go
+++ b/ledger/pparams.go
@@ -1,0 +1,351 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// Helper function to create a cbor.Rat from numerator and denominator
+func newRat(num, denom int64) *cbor.Rat {
+	return &cbor.Rat{Rat: big.NewRat(num, denom)}
+}
+
+// MockByronProtocolParams represents mock Byron protocol parameters.
+// Note: Byron doesn't have a formal ProtocolParameters struct in gouroboros,
+// but these values represent typical Byron-era parameters.
+type MockByronProtocolParams struct {
+	ScriptVersion     uint16
+	SlotDuration      uint64 // milliseconds
+	MaxBlockSize      uint64
+	MaxHeaderSize     uint64
+	MaxTxSize         uint64
+	MaxProposalSize   uint64
+	MpcThd            uint64
+	HeavyDelThd       uint64
+	UpdateVoteThd     uint64
+	UpdateProposalThd uint64
+	UpdateImplicit    uint64
+	SoftForkRule      [3]uint64 // [initThd, minThd, thdDecrement]
+	TxFeePolicy       [2]uint64 // [summand, multiplier] - fee = summand + multiplier * txSize
+	UnlockStakeEpoch  uint64
+}
+
+// NewMockByronProtocolParams returns mock Byron protocol parameters
+// with typical mainnet values
+func NewMockByronProtocolParams() MockByronProtocolParams {
+	return MockByronProtocolParams{
+		ScriptVersion:     0,
+		SlotDuration:      20000, // 20 seconds
+		MaxBlockSize:      2000000,
+		MaxHeaderSize:     2000000,
+		MaxTxSize:         8192,
+		MaxProposalSize:   700,
+		MpcThd:            20000000000000, // 2% of total stake
+		HeavyDelThd:       300000000000,   // 0.03% of total stake
+		UpdateVoteThd:     1000000000000,  // 0.1% of total stake
+		UpdateProposalThd: 100000000000,   // 0.01% of total stake
+		UpdateImplicit:    10000,          // slots
+		SoftForkRule: [3]uint64{
+			900000000000000,
+			600000000000000,
+			50000000000000,
+		},
+		TxFeePolicy:      [2]uint64{155381, 44}, // fee = 155381 + 44 * txSize
+		UnlockStakeEpoch: 18446744073709551615,  // max uint64 (never)
+	}
+}
+
+// NewMockShelleyProtocolParams returns mock Shelley protocol parameters
+// with typical mainnet values at Shelley launch
+func NewMockShelleyProtocolParams() shelley.ShelleyProtocolParameters {
+	return shelley.ShelleyProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,         // 2 ADA
+		PoolDeposit:        500000000,       // 500 ADA
+		MaxEpoch:           18,              // pool retirement max epochs
+		NOpt:               150,             // desired number of pools
+		A0:                 newRat(3, 10),   // pool influence factor 0.3
+		Rho:                newRat(3, 1000), // monetary expansion 0.003
+		Tau:                newRat(2, 10),   // treasury cut 0.2
+		Decentralization: newRat(
+			1,
+			1,
+		), // d=1 means fully federated (Shelley launch)
+		ExtraEntropy:  lcommon.Nonce{}, // neutral nonce
+		ProtocolMajor: 2,
+		ProtocolMinor: 0,
+		MinUtxoValue:  1000000, // 1 ADA minimum UTxO
+	}
+}
+
+// NewMockAllegraProtocolParams returns mock Allegra protocol parameters
+// Allegra uses the same parameter structure as Shelley
+func NewMockAllegraProtocolParams() shelley.ShelleyProtocolParameters {
+	params := NewMockShelleyProtocolParams()
+	params.ProtocolMajor = 3
+	params.ProtocolMinor = 0
+	return params
+}
+
+// NewMockMaryProtocolParams returns mock Mary protocol parameters
+// with typical mainnet values
+func NewMockMaryProtocolParams() mary.MaryProtocolParameters {
+	return mary.MaryProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,   // 2 ADA
+		PoolDeposit:        500000000, // 500 ADA
+		MaxEpoch:           18,
+		NOpt:               500,             // increased from Shelley
+		A0:                 newRat(3, 10),   // 0.3
+		Rho:                newRat(3, 1000), // 0.003
+		Tau:                newRat(2, 10),   // 0.2
+		Decentralization:   newRat(0, 1),    // fully decentralized (d=0)
+		ExtraEntropy:       lcommon.Nonce{},
+		ProtocolMajor:      4,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000000,   // 1 ADA
+		MinPoolCost:        340000000, // 340 ADA minimum pool cost
+	}
+}
+
+// NewMockAlonzoProtocolParams returns mock Alonzo protocol parameters
+// with typical mainnet values including Plutus support
+func NewMockAlonzoProtocolParams() alonzo.AlonzoProtocolParameters {
+	return alonzo.AlonzoProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   73728, // increased for smart contracts
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		Decentralization:   newRat(0, 1),
+		ExtraEntropy:       lcommon.Nonce{},
+		ProtocolMajor:      5,
+		ProtocolMinor:      0,
+		MinUtxoValue:       0, // deprecated, use AdaPerUtxoByte
+		MinPoolCost:        340000000,
+		AdaPerUtxoByte:     4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(), // PlutusV1
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),    // 0.0577 lovelace per memory unit
+			StepPrice: newRat(721, 10000000), // 0.0000721 lovelace per step
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 10000000,    // 10M memory units
+			Steps:  10000000000, // 10B CPU steps
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 50000000,    // 50M memory units
+			Steps:  40000000000, // 40B CPU steps
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150, // 150% collateral required
+		MaxCollateralInputs:  3,
+	}
+}
+
+// NewMockBabbageProtocolParams returns mock Babbage protocol parameters
+// with typical mainnet values including reference scripts
+func NewMockBabbageProtocolParams() babbage.BabbageProtocolParameters {
+	return babbage.BabbageProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   90112, // increased from Alonzo
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		ProtocolMajor:      7,
+		ProtocolMinor:      0,
+		MinPoolCost:        170000000, // reduced to 170 ADA
+		AdaPerUtxoByte:     4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(),
+			1: mockPlutusV2CostModel(),
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),
+			StepPrice: newRat(721, 10000000),
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 14000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+	}
+}
+
+// NewMockConwayProtocolParams returns mock Conway protocol parameters
+// with typical mainnet values including governance parameters
+func NewMockConwayProtocolParams() conway.ConwayProtocolParameters {
+	return conway.ConwayProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   90112,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 newRat(3, 10),
+		Rho:                newRat(3, 1000),
+		Tau:                newRat(2, 10),
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+			Major: 9,
+			Minor: 0,
+		},
+		MinPoolCost:    170000000,
+		AdaPerUtxoByte: 4310,
+		CostModels: map[uint][]int64{
+			0: mockPlutusV1CostModel(),
+			1: mockPlutusV2CostModel(),
+			2: mockPlutusV3CostModel(),
+		},
+		ExecutionCosts: lcommon.ExUnitPrice{
+			MemPrice:  newRat(577, 10000),
+			StepPrice: newRat(721, 10000000),
+		},
+		MaxTxExUnits: lcommon.ExUnits{
+			Memory: 14000000,
+			Steps:  10000000000,
+		},
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  40000000000,
+		},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+		// Conway governance parameters
+		PoolVotingThresholds: conway.PoolVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(51, 100)}, // 51%
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(51, 100)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(51, 100)},
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(51, 100)},
+			PpSecurityGroup:       cbor.Rat{Rat: big.NewRat(51, 100)},
+		},
+		DRepVotingThresholds: conway.DRepVotingThresholds{
+			MotionNoConfidence:    cbor.Rat{Rat: big.NewRat(67, 100)}, // 67%
+			CommitteeNormal:       cbor.Rat{Rat: big.NewRat(67, 100)},
+			CommitteeNoConfidence: cbor.Rat{Rat: big.NewRat(60, 100)}, // 60%
+			UpdateToConstitution:  cbor.Rat{Rat: big.NewRat(75, 100)}, // 75%
+			HardForkInitiation:    cbor.Rat{Rat: big.NewRat(60, 100)},
+			PpNetworkGroup:        cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpEconomicGroup:       cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpTechnicalGroup:      cbor.Rat{Rat: big.NewRat(67, 100)},
+			PpGovGroup:            cbor.Rat{Rat: big.NewRat(75, 100)},
+			TreasuryWithdrawal:    cbor.Rat{Rat: big.NewRat(67, 100)},
+		},
+		MinCommitteeSize:           7,
+		CommitteeTermLimit:         146,          // ~2 years in epochs
+		GovActionValidityPeriod:    6,            // epochs
+		GovActionDeposit:           100000000000, // 100,000 ADA
+		DRepDeposit:                500000000,    // 500 ADA
+		DRepInactivityPeriod:       20,           // epochs
+		MinFeeRefScriptCostPerByte: newRat(15, 1),
+	}
+}
+
+// mockPlutusV1CostModel returns a mock Plutus V1 cost model (166 parameters)
+func mockPlutusV1CostModel() []int64 {
+	// These are representative values, not actual mainnet values
+	// PlutusV1 has 166 parameters
+	costModel := make([]int64, 166)
+
+	// Set some representative values for common operations
+	// Integer operations
+	costModel[0] = 205665 // addInteger-cpu-arguments-intercept
+	costModel[1] = 812    // addInteger-cpu-arguments-slope
+	costModel[2] = 1      // addInteger-memory-arguments-intercept
+	costModel[3] = 1      // addInteger-memory-arguments-slope
+
+	// Fill remaining with reasonable defaults
+	for i := 4; i < 166; i++ {
+		costModel[i] = 1000 + int64(i*100)
+	}
+
+	return costModel
+}
+
+// mockPlutusV2CostModel returns a mock Plutus V2 cost model (175 parameters)
+func mockPlutusV2CostModel() []int64 {
+	// PlutusV2 has 175 parameters (166 from V1 + 9 new)
+	costModel := make([]int64, 175)
+
+	// Copy V1 model as base
+	v1Model := mockPlutusV1CostModel()
+	copy(costModel, v1Model)
+
+	// Add V2 specific parameters
+	for i := 166; i < 175; i++ {
+		costModel[i] = 2000 + int64(i*50)
+	}
+
+	return costModel
+}
+
+// mockPlutusV3CostModel returns a mock Plutus V3 cost model (223 parameters)
+func mockPlutusV3CostModel() []int64 {
+	// PlutusV3 has 223 parameters
+	costModel := make([]int64, 223)
+
+	// Copy V2 model as base
+	v2Model := mockPlutusV2CostModel()
+	copy(costModel, v2Model)
+
+	// Add V3 specific parameters
+	for i := 175; i < 223; i++ {
+		costModel[i] = 3000 + int64(i*50)
+	}
+
+	return costModel
+}

--- a/ledger/rewards.go
+++ b/ledger/rewards.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// AdaPotsBuilder defines an interface for building mock AdaPots
+type AdaPotsBuilder interface {
+	WithReserves(lovelace uint64) AdaPotsBuilder
+	WithTreasury(lovelace uint64) AdaPotsBuilder
+	WithRewards(lovelace uint64) AdaPotsBuilder
+	Build() (*lcommon.AdaPots, error)
+}
+
+// MockAdaPots holds the state for building AdaPots
+type MockAdaPots struct {
+	reserves uint64
+	treasury uint64
+	rewards  uint64
+}
+
+// NewAdaPotsBuilder creates a new MockAdaPots builder
+func NewAdaPotsBuilder() *MockAdaPots {
+	return &MockAdaPots{}
+}
+
+// WithReserves sets the reserves pot
+func (m *MockAdaPots) WithReserves(lovelace uint64) AdaPotsBuilder {
+	m.reserves = lovelace
+	return m
+}
+
+// WithTreasury sets the treasury pot
+func (m *MockAdaPots) WithTreasury(lovelace uint64) AdaPotsBuilder {
+	m.treasury = lovelace
+	return m
+}
+
+// WithRewards sets the rewards pot
+func (m *MockAdaPots) WithRewards(lovelace uint64) AdaPotsBuilder {
+	m.rewards = lovelace
+	return m
+}
+
+// Build constructs an AdaPots from the builder state
+func (m *MockAdaPots) Build() (*lcommon.AdaPots, error) {
+	pots := &lcommon.AdaPots{
+		Reserves: m.reserves,
+		Treasury: m.treasury,
+		Rewards:  m.rewards,
+	}
+	return pots, nil
+}
+
+// RewardSnapshotBuilder defines an interface for building mock RewardSnapshots
+type RewardSnapshotBuilder interface {
+	WithTotalActiveStake(stake uint64) RewardSnapshotBuilder
+	WithPoolStake(pool lcommon.PoolKeyHash, stake uint64) RewardSnapshotBuilder
+	WithDelegatorStake(delegator []byte, stake uint64) RewardSnapshotBuilder
+	WithDelegatorStakeForPool(
+		pool lcommon.PoolKeyHash,
+		delegator []byte,
+		stake uint64,
+	) RewardSnapshotBuilder
+	WithPoolParams(
+		pool lcommon.PoolKeyHash,
+		cert *lcommon.PoolRegistrationCertificate,
+	) RewardSnapshotBuilder
+	WithPoolBlocks(pool lcommon.PoolKeyHash, blocks uint64) RewardSnapshotBuilder
+	Build() (*lcommon.RewardSnapshot, error)
+}
+
+// MockRewardSnapshot holds the state for building a RewardSnapshot
+type MockRewardSnapshot struct {
+	totalActiveStake uint64
+	poolStake        map[lcommon.PoolKeyHash]uint64
+	delegatorStake   map[lcommon.PoolKeyHash]map[lcommon.AddrKeyHash]uint64
+	poolParams       map[lcommon.PoolKeyHash]*lcommon.PoolRegistrationCertificate
+	poolBlocks       map[lcommon.PoolKeyHash]uint32
+	// Track which pool a delegator belongs to for delegator stake
+	delegatorPools    map[lcommon.AddrKeyHash]lcommon.PoolKeyHash
+	poolBlocksErr     error // tracks if pool blocks exceeded uint32
+	delegatorStakeErr error // tracks if delegator stake was called with no pools
+}
+
+// NewRewardSnapshotBuilder creates a new MockRewardSnapshot builder
+func NewRewardSnapshotBuilder() *MockRewardSnapshot {
+	return &MockRewardSnapshot{
+		poolStake: make(map[lcommon.PoolKeyHash]uint64),
+		delegatorStake: make(
+			map[lcommon.PoolKeyHash]map[lcommon.AddrKeyHash]uint64,
+		),
+		poolParams: make(
+			map[lcommon.PoolKeyHash]*lcommon.PoolRegistrationCertificate,
+		),
+		poolBlocks:     make(map[lcommon.PoolKeyHash]uint32),
+		delegatorPools: make(map[lcommon.AddrKeyHash]lcommon.PoolKeyHash),
+	}
+}
+
+// WithTotalActiveStake sets the total active stake in the system
+func (m *MockRewardSnapshot) WithTotalActiveStake(
+	stake uint64,
+) RewardSnapshotBuilder {
+	m.totalActiveStake = stake
+	return m
+}
+
+// WithPoolStake sets the stake for a specific pool
+func (m *MockRewardSnapshot) WithPoolStake(
+	pool lcommon.PoolKeyHash,
+	stake uint64,
+) RewardSnapshotBuilder {
+	m.poolStake[pool] = stake
+	// Clear any previous delegatorStakeErr since pools now exist
+	m.delegatorStakeErr = nil
+	return m
+}
+
+// WithDelegatorStake sets the stake for a delegator
+// This selects the lexicographically smallest pool key from the existing pool
+// stake map for deterministic behavior. For explicit pool selection, use
+// WithDelegatorStakeForPool instead. If no pools exist, Build() will return
+// an error.
+func (m *MockRewardSnapshot) WithDelegatorStake(
+	delegator []byte,
+	stake uint64,
+) RewardSnapshotBuilder {
+	// Fail-fast if no pools exist
+	if len(m.poolStake) == 0 {
+		m.delegatorStakeErr = errors.New(
+			"WithDelegatorStake called but no pools exist; call WithPoolStake first",
+		)
+		return m
+	}
+
+	delegatorKey := lcommon.NewBlake2b224(delegator)
+
+	// Collect pool keys and sort for deterministic selection
+	pools := make([]lcommon.PoolKeyHash, 0, len(m.poolStake))
+	for p := range m.poolStake {
+		pools = append(pools, p)
+	}
+	slices.SortFunc(pools, func(a, b lcommon.PoolKeyHash) int {
+		return bytes.Compare(a.Bytes(), b.Bytes())
+	})
+	// Select the lexicographically smallest pool
+	pool := pools[0]
+
+	if m.delegatorStake[pool] == nil {
+		m.delegatorStake[pool] = make(map[lcommon.AddrKeyHash]uint64)
+	}
+	m.delegatorStake[pool][delegatorKey] = stake
+	m.delegatorPools[delegatorKey] = pool
+	return m
+}
+
+// WithDelegatorStakeForPool sets the stake for a delegator associated with a specific pool
+func (m *MockRewardSnapshot) WithDelegatorStakeForPool(
+	pool lcommon.PoolKeyHash,
+	delegator []byte,
+	stake uint64,
+) RewardSnapshotBuilder {
+	delegatorKey := lcommon.NewBlake2b224(delegator)
+
+	if m.delegatorStake[pool] == nil {
+		m.delegatorStake[pool] = make(map[lcommon.AddrKeyHash]uint64)
+	}
+	m.delegatorStake[pool][delegatorKey] = stake
+	m.delegatorPools[delegatorKey] = pool
+	return m
+}
+
+// WithPoolParams sets the pool parameters for a specific pool
+func (m *MockRewardSnapshot) WithPoolParams(
+	pool lcommon.PoolKeyHash,
+	cert *lcommon.PoolRegistrationCertificate,
+) RewardSnapshotBuilder {
+	m.poolParams[pool] = cert
+	return m
+}
+
+// WithPoolBlocks sets the number of blocks produced by a pool
+// If blocks exceeds uint32 max value, Build() will return an error
+func (m *MockRewardSnapshot) WithPoolBlocks(
+	pool lcommon.PoolKeyHash,
+	blocks uint64,
+) RewardSnapshotBuilder {
+	if blocks > math.MaxUint32 {
+		m.poolBlocksErr = fmt.Errorf(
+			"blocks %d exceeds maximum uint32 value",
+			blocks,
+		)
+		return m
+	}
+	// Clear any previous error when valid value is provided
+	m.poolBlocksErr = nil
+	m.poolBlocks[pool] = uint32(blocks)
+	return m
+}
+
+// Build constructs a RewardSnapshot from the builder state
+func (m *MockRewardSnapshot) Build() (*lcommon.RewardSnapshot, error) {
+	// Check for validation errors
+	if m.poolBlocksErr != nil {
+		return nil, m.poolBlocksErr
+	}
+	if m.delegatorStakeErr != nil {
+		return nil, m.delegatorStakeErr
+	}
+
+	// Calculate total blocks in uint64 to detect overflow
+	var totalBlocksSum uint64
+	for _, blocks := range m.poolBlocks {
+		totalBlocksSum += uint64(blocks)
+	}
+	if totalBlocksSum > math.MaxUint32 {
+		return nil, fmt.Errorf(
+			"total blocks %d exceeds maximum uint32 value",
+			totalBlocksSum,
+		)
+	}
+	totalBlocks := uint32(totalBlocksSum)
+
+	snapshot := &lcommon.RewardSnapshot{
+		TotalActiveStake:     m.totalActiveStake,
+		PoolStake:            m.poolStake,
+		DelegatorStake:       m.delegatorStake,
+		PoolParams:           m.poolParams,
+		StakeRegistrations:   make(map[lcommon.AddrKeyHash]bool),
+		PoolBlocks:           m.poolBlocks,
+		TotalBlocksInEpoch:   totalBlocks,
+		EarlyDeregistrations: make(map[lcommon.AddrKeyHash]uint64),
+		LateDeregistrations:  make(map[lcommon.AddrKeyHash]uint64),
+		RetiredPools: make(
+			map[lcommon.PoolKeyHash]lcommon.PoolRetirementInfo,
+		),
+		StakeKeyPoolAssociations: make(
+			map[lcommon.AddrKeyHash][]lcommon.PoolKeyHash,
+		),
+	}
+
+	// Mark all delegators as registered
+	for _, delegators := range m.delegatorStake {
+		for delegator := range delegators {
+			snapshot.StakeRegistrations[delegator] = true
+		}
+	}
+
+	// Populate stake key pool associations from delegator pools
+	for delegator, pool := range m.delegatorPools {
+		snapshot.StakeKeyPoolAssociations[delegator] = []lcommon.PoolKeyHash{
+			pool,
+		}
+	}
+
+	return snapshot, nil
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1,0 +1,436 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ErrNotFound is returned when a requested item is not found
+var ErrNotFound = errors.New("ledger: not found")
+
+// PlutusLanguage represents a Plutus language version
+type PlutusLanguage uint
+
+const (
+	PlutusV1 PlutusLanguage = 1
+	PlutusV2 PlutusLanguage = 2
+	PlutusV3 PlutusLanguage = 3
+)
+
+// CostModel represents a Plutus cost model
+type CostModel []int64
+
+// UtxoByIdFunc is a callback for UTxO lookups by transaction input
+type UtxoByIdFunc func(lcommon.TransactionInput) (lcommon.Utxo, error)
+
+// StakeRegistrationFunc is a callback for stake registration lookups
+type StakeRegistrationFunc func([]byte) ([]lcommon.StakeRegistrationCertificate, error)
+
+// SlotToTimeFunc is a callback for converting slots to time
+type SlotToTimeFunc func(uint64) (time.Time, error)
+
+// TimeToSlotFunc is a callback for converting time to slots
+type TimeToSlotFunc func(time.Time) (uint64, error)
+
+// PoolCurrentStateFunc is a callback for pool state lookups
+type PoolCurrentStateFunc func(lcommon.PoolKeyHash) (*lcommon.PoolRegistrationCertificate, *uint64, error)
+
+// CalculateRewardsFunc is a callback for reward calculation
+type CalculateRewardsFunc func(lcommon.AdaPots, lcommon.RewardSnapshot, lcommon.RewardParameters) (*lcommon.RewardCalculationResult, error)
+
+// GetRewardSnapshotFunc is a callback for reward snapshot lookups
+type GetRewardSnapshotFunc func(uint64) (lcommon.RewardSnapshot, error)
+
+// CommitteeMemberFunc is a callback for committee member lookups
+type CommitteeMemberFunc func(lcommon.Blake2b224) (*CommitteeMember, error)
+
+// DRepRegistrationFunc is a callback for DRep registration lookups
+type DRepRegistrationFunc func(lcommon.Blake2b224) (*lcommon.RegistrationDrepCertificate, error)
+
+// ConstitutionFunc is a callback for constitution lookups
+type ConstitutionFunc func() (*Constitution, error)
+
+// TreasuryValueFunc is a callback for treasury value lookups
+type TreasuryValueFunc func() (uint64, error)
+
+// CostModelsFunc is a callback for cost models lookups
+type CostModelsFunc func() map[PlutusLanguage]CostModel
+
+// MockLedgerState implements the ledger.LedgerState interface from gouroboros
+// using callback functions for customizable behavior
+type MockLedgerState struct {
+	// UtxoState callbacks
+	UtxoByIdCallback UtxoByIdFunc
+
+	// CertState callbacks
+	StakeRegistrationCallback StakeRegistrationFunc
+
+	// SlotState callbacks
+	SlotToTimeCallback SlotToTimeFunc
+	TimeToSlotCallback TimeToSlotFunc
+
+	// PoolState callbacks
+	PoolCurrentStateCallback PoolCurrentStateFunc
+
+	// RewardState callbacks
+	CalculateRewardsCallback  CalculateRewardsFunc
+	GetRewardSnapshotCallback GetRewardSnapshotFunc
+
+	// GovState callbacks (for future governance queries)
+	CommitteeMemberCallback  CommitteeMemberFunc
+	DRepRegistrationCallback DRepRegistrationFunc
+	ConstitutionCallback     ConstitutionFunc
+	TreasuryValueCallback    TreasuryValueFunc
+	CostModelsCallback       CostModelsFunc
+
+	// Static fields
+	networkId uint
+	adaPots   lcommon.AdaPots
+}
+
+// NetworkId returns the network identifier
+func (ls *MockLedgerState) NetworkId() uint {
+	return ls.networkId
+}
+
+// UtxoById looks up a UTxO by transaction input
+func (ls *MockLedgerState) UtxoById(
+	id lcommon.TransactionInput,
+) (lcommon.Utxo, error) {
+	if ls.UtxoByIdCallback != nil {
+		return ls.UtxoByIdCallback(id)
+	}
+	return lcommon.Utxo{}, ErrNotFound
+}
+
+// StakeRegistration looks up stake registrations by staking key
+func (ls *MockLedgerState) StakeRegistration(
+	stakingKey []byte,
+) ([]lcommon.StakeRegistrationCertificate, error) {
+	if ls.StakeRegistrationCallback != nil {
+		return ls.StakeRegistrationCallback(stakingKey)
+	}
+	return []lcommon.StakeRegistrationCertificate{}, nil
+}
+
+// SlotToTime converts a slot number to a time
+func (ls *MockLedgerState) SlotToTime(slot uint64) (time.Time, error) {
+	if ls.SlotToTimeCallback != nil {
+		return ls.SlotToTimeCallback(slot)
+	}
+	return time.Time{}, nil
+}
+
+// TimeToSlot converts a time to a slot number
+func (ls *MockLedgerState) TimeToSlot(t time.Time) (uint64, error) {
+	if ls.TimeToSlotCallback != nil {
+		return ls.TimeToSlotCallback(t)
+	}
+	return 0, nil
+}
+
+// PoolCurrentState returns the current state of a pool
+func (ls *MockLedgerState) PoolCurrentState(
+	poolKeyHash lcommon.PoolKeyHash,
+) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
+	if ls.PoolCurrentStateCallback != nil {
+		return ls.PoolCurrentStateCallback(poolKeyHash)
+	}
+	return nil, nil, nil
+}
+
+// CalculateRewards calculates rewards for the given epoch
+func (ls *MockLedgerState) CalculateRewards(
+	pots lcommon.AdaPots,
+	snapshot lcommon.RewardSnapshot,
+	params lcommon.RewardParameters,
+) (*lcommon.RewardCalculationResult, error) {
+	if ls.CalculateRewardsCallback != nil {
+		return ls.CalculateRewardsCallback(pots, snapshot, params)
+	}
+	return lcommon.CalculateRewards(pots, snapshot, params)
+}
+
+// GetAdaPots returns the current ADA pots
+func (ls *MockLedgerState) GetAdaPots() lcommon.AdaPots {
+	return ls.adaPots
+}
+
+// UpdateAdaPots updates the ADA pots
+func (ls *MockLedgerState) UpdateAdaPots(pots lcommon.AdaPots) error {
+	ls.adaPots = pots
+	return nil
+}
+
+// GetRewardSnapshot returns the stake snapshot for reward calculation
+func (ls *MockLedgerState) GetRewardSnapshot(
+	epoch uint64,
+) (lcommon.RewardSnapshot, error) {
+	if ls.GetRewardSnapshotCallback != nil {
+		return ls.GetRewardSnapshotCallback(epoch)
+	}
+	return lcommon.RewardSnapshot{}, nil
+}
+
+// CommitteeMember looks up a constitutional committee member by credential hash
+func (ls *MockLedgerState) CommitteeMember(
+	credHash lcommon.Blake2b224,
+) (*CommitteeMember, error) {
+	if ls.CommitteeMemberCallback != nil {
+		return ls.CommitteeMemberCallback(credHash)
+	}
+	return nil, ErrNotFound
+}
+
+// DRepRegistration looks up a DRep registration by credential hash
+func (ls *MockLedgerState) DRepRegistration(
+	credHash lcommon.Blake2b224,
+) (*lcommon.RegistrationDrepCertificate, error) {
+	if ls.DRepRegistrationCallback != nil {
+		return ls.DRepRegistrationCallback(credHash)
+	}
+	return nil, ErrNotFound
+}
+
+// Constitution returns the current constitution
+func (ls *MockLedgerState) Constitution() (*Constitution, error) {
+	if ls.ConstitutionCallback != nil {
+		return ls.ConstitutionCallback()
+	}
+	return nil, ErrNotFound
+}
+
+// TreasuryValue returns the current treasury value
+func (ls *MockLedgerState) TreasuryValue() (uint64, error) {
+	if ls.TreasuryValueCallback != nil {
+		return ls.TreasuryValueCallback()
+	}
+	return ls.adaPots.Treasury, nil
+}
+
+// CostModels returns the current cost models for Plutus scripts
+func (ls *MockLedgerState) CostModels() map[PlutusLanguage]CostModel {
+	if ls.CostModelsCallback != nil {
+		return ls.CostModelsCallback()
+	}
+	return make(map[PlutusLanguage]CostModel)
+}
+
+// LedgerStateBuilder provides a fluent API for setting up MockLedgerState
+type LedgerStateBuilder struct {
+	state *MockLedgerState
+}
+
+// NewLedgerStateBuilder creates a new LedgerStateBuilder
+func NewLedgerStateBuilder() *LedgerStateBuilder {
+	return &LedgerStateBuilder{
+		state: &MockLedgerState{},
+	}
+}
+
+// WithNetworkId sets the network ID
+func (b *LedgerStateBuilder) WithNetworkId(networkId uint) *LedgerStateBuilder {
+	b.state.networkId = networkId
+	return b
+}
+
+// WithAdaPots sets the ADA pots
+func (b *LedgerStateBuilder) WithAdaPots(
+	pots lcommon.AdaPots,
+) *LedgerStateBuilder {
+	b.state.adaPots = pots
+	return b
+}
+
+// WithUtxoById sets the UTxO lookup callback
+func (b *LedgerStateBuilder) WithUtxoById(fn UtxoByIdFunc) *LedgerStateBuilder {
+	b.state.UtxoByIdCallback = fn
+	return b
+}
+
+// WithStakeRegistration sets the stake registration lookup callback
+func (b *LedgerStateBuilder) WithStakeRegistration(
+	fn StakeRegistrationFunc,
+) *LedgerStateBuilder {
+	b.state.StakeRegistrationCallback = fn
+	return b
+}
+
+// WithSlotToTime sets the slot to time conversion callback
+func (b *LedgerStateBuilder) WithSlotToTime(
+	fn SlotToTimeFunc,
+) *LedgerStateBuilder {
+	b.state.SlotToTimeCallback = fn
+	return b
+}
+
+// WithTimeToSlot sets the time to slot conversion callback
+func (b *LedgerStateBuilder) WithTimeToSlot(
+	fn TimeToSlotFunc,
+) *LedgerStateBuilder {
+	b.state.TimeToSlotCallback = fn
+	return b
+}
+
+// WithPoolCurrentState sets the pool current state callback
+func (b *LedgerStateBuilder) WithPoolCurrentState(
+	fn PoolCurrentStateFunc,
+) *LedgerStateBuilder {
+	b.state.PoolCurrentStateCallback = fn
+	return b
+}
+
+// WithCalculateRewards sets the calculate rewards callback
+func (b *LedgerStateBuilder) WithCalculateRewards(
+	fn CalculateRewardsFunc,
+) *LedgerStateBuilder {
+	b.state.CalculateRewardsCallback = fn
+	return b
+}
+
+// WithGetRewardSnapshot sets the get reward snapshot callback
+func (b *LedgerStateBuilder) WithGetRewardSnapshot(
+	fn GetRewardSnapshotFunc,
+) *LedgerStateBuilder {
+	b.state.GetRewardSnapshotCallback = fn
+	return b
+}
+
+// WithCommitteeMember sets the committee member lookup callback
+func (b *LedgerStateBuilder) WithCommitteeMember(
+	fn CommitteeMemberFunc,
+) *LedgerStateBuilder {
+	b.state.CommitteeMemberCallback = fn
+	return b
+}
+
+// WithDRepRegistration sets the DRep registration lookup callback
+func (b *LedgerStateBuilder) WithDRepRegistration(
+	fn DRepRegistrationFunc,
+) *LedgerStateBuilder {
+	b.state.DRepRegistrationCallback = fn
+	return b
+}
+
+// WithConstitution sets the constitution lookup callback
+func (b *LedgerStateBuilder) WithConstitution(
+	fn ConstitutionFunc,
+) *LedgerStateBuilder {
+	b.state.ConstitutionCallback = fn
+	return b
+}
+
+// WithTreasuryValue sets the treasury value lookup callback
+func (b *LedgerStateBuilder) WithTreasuryValue(
+	fn TreasuryValueFunc,
+) *LedgerStateBuilder {
+	b.state.TreasuryValueCallback = fn
+	return b
+}
+
+// WithCostModels sets the cost models lookup callback
+func (b *LedgerStateBuilder) WithCostModels(
+	fn CostModelsFunc,
+) *LedgerStateBuilder {
+	b.state.CostModelsCallback = fn
+	return b
+}
+
+// WithUtxos configures the mock with a static set of UTxOs for lookup
+func (b *LedgerStateBuilder) WithUtxos(
+	utxos []lcommon.Utxo,
+) *LedgerStateBuilder {
+	b.state.UtxoByIdCallback = func(id lcommon.TransactionInput) (lcommon.Utxo, error) {
+		// Guard against nil input
+		if id == nil {
+			return lcommon.Utxo{}, ErrNotFound
+		}
+		inputId := id.Id()
+		if inputId == (lcommon.Blake2b256{}) {
+			return lcommon.Utxo{}, ErrNotFound
+		}
+
+		for _, utxo := range utxos {
+			// Guard against nil utxo.Id
+			if utxo.Id == nil {
+				continue
+			}
+			utxoId := utxo.Id.Id()
+
+			// Compare index and ID using bytes.Equal
+			if id.Index() != utxo.Id.Index() {
+				continue
+			}
+			if !bytes.Equal(inputId.Bytes(), utxoId.Bytes()) {
+				continue
+			}
+			return utxo, nil
+		}
+		return lcommon.Utxo{}, ErrNotFound
+	}
+	return b
+}
+
+// WithPools configures the mock with a static set of pool registrations
+func (b *LedgerStateBuilder) WithPools(
+	pools []*lcommon.PoolRegistrationCertificate,
+) *LedgerStateBuilder {
+	b.state.PoolCurrentStateCallback = func(poolKeyHash lcommon.PoolKeyHash) (*lcommon.PoolRegistrationCertificate, *uint64, error) {
+		for _, pool := range pools {
+			// Skip nil pool entries
+			if pool == nil {
+				continue
+			}
+			// Compare pool operator hash directly with the lookup key using bytes.Equal
+			// (both are already Blake2b224 hashes, no need to hash again)
+			if bytes.Equal(pool.Operator.Bytes(), poolKeyHash.Bytes()) {
+				return pool, nil, nil
+			}
+		}
+		return nil, nil, nil
+	}
+	return b
+}
+
+// WithStakeRegistrations configures the mock with a static set of stake registrations
+func (b *LedgerStateBuilder) WithStakeRegistrations(
+	certs []lcommon.StakeRegistrationCertificate,
+) *LedgerStateBuilder {
+	b.state.StakeRegistrationCallback = func(stakingKey []byte) ([]lcommon.StakeRegistrationCertificate, error) {
+		var result []lcommon.StakeRegistrationCertificate
+		for _, cert := range certs {
+			// Compare credential directly using bytes.Equal
+			// (it's already a Blake2b224 hash, no need to hash again)
+			if bytes.Equal(
+				cert.StakeCredential.Credential.Bytes(),
+				stakingKey,
+			) {
+				result = append(result, cert)
+			}
+		}
+		return result, nil
+	}
+	return b
+}
+
+// Build constructs the MockLedgerState
+func (b *LedgerStateBuilder) Build() *MockLedgerState {
+	return b.state
+}

--- a/ledger/transaction.go
+++ b/ledger/transaction.go
@@ -1,0 +1,904 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// TransactionBuilder defines an interface for building mock transactions
+type TransactionBuilder interface {
+	WithId(txId []byte) TransactionBuilder
+	WithInputs(inputs ...lcommon.TransactionInput) TransactionBuilder
+	WithOutputs(outputs ...lcommon.TransactionOutput) TransactionBuilder
+	WithFee(fee uint64) TransactionBuilder
+	WithTTL(ttl uint64) TransactionBuilder
+	WithMetadata(metadata []byte) TransactionBuilder
+	WithValid(valid bool) TransactionBuilder
+	Build() (lcommon.Transaction, error)
+}
+
+// TransactionInputBuilder defines an interface for building mock transaction inputs
+type TransactionInputBuilder interface {
+	WithTxId(txId []byte) TransactionInputBuilder
+	WithIndex(idx uint32) TransactionInputBuilder
+	Build() (lcommon.TransactionInput, error)
+}
+
+// TransactionOutputBuilder defines an interface for building mock transaction outputs
+type TransactionOutputBuilder interface {
+	WithAddress(addr string) TransactionOutputBuilder
+	WithLovelace(amount uint64) TransactionOutputBuilder
+	WithAssets(assets ...Asset) TransactionOutputBuilder
+	WithDatum(datum []byte) TransactionOutputBuilder
+	WithDatumHash(hash []byte) TransactionOutputBuilder
+	Build() (lcommon.TransactionOutput, error)
+}
+
+// MockTransaction implements lcommon.Transaction interface
+type MockTransaction struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	txId        lcommon.Blake2b256
+	inputs      []lcommon.TransactionInput
+	outputs     []lcommon.TransactionOutput
+	fee         uint64
+	ttl         uint64
+	metadata    lcommon.TransactionMetadatum
+	metadataErr error // Stores metadata decoding error for deferred reporting
+	valid       bool
+	txType      int
+	witnesses   *MockTransactionWitnessSet
+	leiosHash   lcommon.Blake2b256
+	refInputs   []lcommon.TransactionInput
+	collateral  []lcommon.TransactionInput
+	collReturn  lcommon.TransactionOutput
+	totalColl   uint64
+	certs       []lcommon.Certificate
+	wdrls       map[*lcommon.Address]uint64
+	auxHash     *lcommon.Blake2b256
+	reqSigners  []lcommon.Blake2b224
+	mint        *lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	scriptHash  *lcommon.Blake2b256
+	votingProc  lcommon.VotingProcedures
+	proposals   []lcommon.ProposalProcedure
+	treasury    int64
+	donation    uint64
+	ppUpdEpoch  uint64
+	ppUpdates   map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate
+	validStart  uint64
+}
+
+// NewTransactionBuilder creates a new MockTransaction builder
+func NewTransactionBuilder() *MockTransaction {
+	return &MockTransaction{
+		valid:     true,
+		witnesses: NewMockTransactionWitnessSet(),
+	}
+}
+
+// WithId sets the transaction ID
+func (t *MockTransaction) WithId(txId []byte) TransactionBuilder {
+	t.txId = lcommon.NewBlake2b256(txId)
+	return t
+}
+
+// WithInputs sets the transaction inputs
+func (t *MockTransaction) WithInputs(
+	inputs ...lcommon.TransactionInput,
+) TransactionBuilder {
+	t.inputs = append(t.inputs, inputs...)
+	return t
+}
+
+// WithOutputs sets the transaction outputs
+func (t *MockTransaction) WithOutputs(
+	outputs ...lcommon.TransactionOutput,
+) TransactionBuilder {
+	t.outputs = append(t.outputs, outputs...)
+	return t
+}
+
+// WithFee sets the transaction fee
+func (t *MockTransaction) WithFee(fee uint64) TransactionBuilder {
+	t.fee = fee
+	return t
+}
+
+// WithTTL sets the transaction time-to-live
+func (t *MockTransaction) WithTTL(ttl uint64) TransactionBuilder {
+	t.ttl = ttl
+	return t
+}
+
+// WithMetadata sets the transaction metadata from raw bytes
+func (t *MockTransaction) WithMetadata(metadata []byte) TransactionBuilder {
+	if metadata != nil {
+		decoded, err := lcommon.DecodeAuxiliaryDataToMetadata(metadata)
+		if err != nil {
+			// Store the error for reporting in Build()
+			t.metadataErr = fmt.Errorf("invalid metadata CBOR: %w", err)
+		} else {
+			t.metadata = decoded
+			t.metadataErr = nil
+		}
+	}
+	return t
+}
+
+// WithValid sets the transaction validity flag
+func (t *MockTransaction) WithValid(valid bool) TransactionBuilder {
+	t.valid = valid
+	return t
+}
+
+// Build constructs a Transaction from the builder state
+func (t *MockTransaction) Build() (lcommon.Transaction, error) {
+	// Return any stored parsing errors
+	if t.metadataErr != nil {
+		return nil, t.metadataErr
+	}
+	if len(t.inputs) == 0 {
+		return nil, errors.New("transaction must have at least one input")
+	}
+	if len(t.outputs) == 0 {
+		return nil, errors.New("transaction must have at least one output")
+	}
+	// Check for nil entries in inputs and outputs
+	for i, input := range t.inputs {
+		if input == nil {
+			return nil, fmt.Errorf("transaction contains nil input at index %d", i)
+		}
+	}
+	for i, output := range t.outputs {
+		if output == nil {
+			return nil, fmt.Errorf("transaction contains nil output at index %d", i)
+		}
+	}
+	return t, nil
+}
+
+// Type returns the transaction type identifier
+func (t *MockTransaction) Type() int {
+	return t.txType
+}
+
+// Cbor returns the CBOR-encoded transaction
+func (t *MockTransaction) Cbor() []byte {
+	return t.DecodeStoreCbor.Cbor()
+}
+
+// Hash returns the transaction hash (ID)
+func (t *MockTransaction) Hash() lcommon.Blake2b256 {
+	return t.txId
+}
+
+// LeiosHash returns the Leios hash of the transaction
+func (t *MockTransaction) LeiosHash() lcommon.Blake2b256 {
+	return t.leiosHash
+}
+
+// Metadata returns the transaction metadata
+func (t *MockTransaction) Metadata() lcommon.TransactionMetadatum {
+	return t.metadata
+}
+
+// AuxiliaryData returns the transaction auxiliary data
+func (t *MockTransaction) AuxiliaryData() lcommon.AuxiliaryData {
+	return nil
+}
+
+// IsValid returns whether the transaction is valid
+func (t *MockTransaction) IsValid() bool {
+	return t.valid
+}
+
+// Consumed returns the transaction inputs that are consumed
+func (t *MockTransaction) Consumed() []lcommon.TransactionInput {
+	return t.inputs
+}
+
+// Produced returns the UTxOs produced by this transaction
+func (t *MockTransaction) Produced() []lcommon.Utxo {
+	utxos := make([]lcommon.Utxo, 0, len(t.outputs))
+	for idx, output := range t.outputs {
+		input := &MockTransactionInput{
+			txId: t.txId,
+			// #nosec G115 - transaction output index is bounded by protocol limits
+			index: uint32(idx),
+		}
+		utxos = append(utxos, lcommon.Utxo{
+			Id:     input,
+			Output: output,
+		})
+	}
+	return utxos
+}
+
+// Witnesses returns the transaction witness set
+func (t *MockTransaction) Witnesses() lcommon.TransactionWitnessSet {
+	return t.witnesses
+}
+
+// Fee returns the transaction fee as *big.Int
+func (t *MockTransaction) Fee() *big.Int {
+	return new(big.Int).SetUint64(t.fee)
+}
+
+// Id returns the transaction ID
+func (t *MockTransaction) Id() lcommon.Blake2b256 {
+	return t.txId
+}
+
+// Inputs returns the transaction inputs
+func (t *MockTransaction) Inputs() []lcommon.TransactionInput {
+	return t.inputs
+}
+
+// Outputs returns the transaction outputs
+func (t *MockTransaction) Outputs() []lcommon.TransactionOutput {
+	return t.outputs
+}
+
+// TTL returns the transaction time-to-live
+func (t *MockTransaction) TTL() uint64 {
+	return t.ttl
+}
+
+// ProtocolParameterUpdates returns protocol parameter updates (if any)
+func (t *MockTransaction) ProtocolParameterUpdates() (uint64, map[lcommon.Blake2b224]lcommon.ProtocolParameterUpdate) {
+	return t.ppUpdEpoch, t.ppUpdates
+}
+
+// ValidityIntervalStart returns the validity interval start slot
+func (t *MockTransaction) ValidityIntervalStart() uint64 {
+	return t.validStart
+}
+
+// ReferenceInputs returns the reference inputs
+func (t *MockTransaction) ReferenceInputs() []lcommon.TransactionInput {
+	return t.refInputs
+}
+
+// Collateral returns the collateral inputs
+func (t *MockTransaction) Collateral() []lcommon.TransactionInput {
+	return t.collateral
+}
+
+// CollateralReturn returns the collateral return output
+func (t *MockTransaction) CollateralReturn() lcommon.TransactionOutput {
+	return t.collReturn
+}
+
+// TotalCollateral returns the total collateral amount as *big.Int
+func (t *MockTransaction) TotalCollateral() *big.Int {
+	return new(big.Int).SetUint64(t.totalColl)
+}
+
+// Certificates returns the certificates in the transaction
+func (t *MockTransaction) Certificates() []lcommon.Certificate {
+	return t.certs
+}
+
+// Withdrawals returns the stake withdrawals in the transaction as map[*lcommon.Address]*big.Int
+func (t *MockTransaction) Withdrawals() map[*lcommon.Address]*big.Int {
+	if t.wdrls == nil {
+		return nil
+	}
+	result := make(map[*lcommon.Address]*big.Int, len(t.wdrls))
+	for addr, amount := range t.wdrls {
+		result[addr] = new(big.Int).SetUint64(amount)
+	}
+	return result
+}
+
+// AuxDataHash returns the auxiliary data hash
+func (t *MockTransaction) AuxDataHash() *lcommon.Blake2b256 {
+	return t.auxHash
+}
+
+// RequiredSigners returns the required signers for the transaction
+func (t *MockTransaction) RequiredSigners() []lcommon.Blake2b224 {
+	return t.reqSigners
+}
+
+// AssetMint returns the native asset minting/burning in the transaction
+func (t *MockTransaction) AssetMint() *lcommon.MultiAsset[lcommon.MultiAssetTypeMint] {
+	return t.mint
+}
+
+// ScriptDataHash returns the script data hash
+func (t *MockTransaction) ScriptDataHash() *lcommon.Blake2b256 {
+	return t.scriptHash
+}
+
+// VotingProcedures returns the voting procedures in the transaction
+func (t *MockTransaction) VotingProcedures() lcommon.VotingProcedures {
+	return t.votingProc
+}
+
+// ProposalProcedures returns the governance proposals in the transaction
+func (t *MockTransaction) ProposalProcedures() []lcommon.ProposalProcedure {
+	return t.proposals
+}
+
+// CurrentTreasuryValue returns the current treasury value as *big.Int
+func (t *MockTransaction) CurrentTreasuryValue() *big.Int {
+	return big.NewInt(t.treasury)
+}
+
+// Donation returns the donation amount as *big.Int
+func (t *MockTransaction) Donation() *big.Int {
+	return new(big.Int).SetUint64(t.donation)
+}
+
+// Utxorpc returns the UTxO RPC representation of the transaction
+func (t *MockTransaction) Utxorpc() (*utxorpc.Tx, error) {
+	tx := &utxorpc.Tx{
+		Hash: t.txId.Bytes(),
+		Fee:  lcommon.ToUtxorpcBigInt(t.fee),
+	}
+
+	for _, input := range t.inputs {
+		utxorpcInput, err := input.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		tx.Inputs = append(tx.Inputs, utxorpcInput)
+	}
+
+	for _, output := range t.outputs {
+		utxorpcOutput, err := output.Utxorpc()
+		if err != nil {
+			return nil, err
+		}
+		tx.Outputs = append(tx.Outputs, utxorpcOutput)
+	}
+
+	return tx, nil
+}
+
+// MockTransactionInputBuilder holds the state for building a transaction input
+type MockTransactionInputBuilder struct {
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
+// NewTransactionInputBuilder creates a new transaction input builder
+func NewTransactionInputBuilder() *MockTransactionInputBuilder {
+	return &MockTransactionInputBuilder{}
+}
+
+// WithTxId sets the transaction ID for the input
+func (b *MockTransactionInputBuilder) WithTxId(
+	txId []byte,
+) TransactionInputBuilder {
+	b.txId = lcommon.NewBlake2b256(txId)
+	return b
+}
+
+// WithIndex sets the output index for the input
+func (b *MockTransactionInputBuilder) WithIndex(
+	idx uint32,
+) TransactionInputBuilder {
+	b.index = idx
+	return b
+}
+
+// Build constructs a TransactionInput from the builder state
+func (b *MockTransactionInputBuilder) Build() (lcommon.TransactionInput, error) {
+	if b.txId == (lcommon.Blake2b256{}) {
+		return nil, errors.New("transaction ID is required")
+	}
+	return &MockTransactionInput{
+		txId:  b.txId,
+		index: b.index,
+	}, nil
+}
+
+// MockTransactionOutputBuilder holds the state for building a transaction output
+type MockTransactionOutputBuilder struct {
+	address   lcommon.Address
+	amount    uint64
+	assets    *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum     *lcommon.Datum
+	datumHash *lcommon.Blake2b256
+	addrErr   error // Stores address parsing error for deferred reporting
+	datumErr  error // Stores datum decoding error for deferred reporting
+}
+
+// NewTransactionOutputBuilder creates a new transaction output builder
+func NewTransactionOutputBuilder() *MockTransactionOutputBuilder {
+	return &MockTransactionOutputBuilder{}
+}
+
+// WithAddress sets the address for the output
+func (b *MockTransactionOutputBuilder) WithAddress(
+	addr string,
+) TransactionOutputBuilder {
+	parsedAddr, err := lcommon.NewAddress(addr)
+	if err != nil {
+		// Store the error for reporting in Build()
+		b.address = lcommon.Address{}
+		b.addrErr = fmt.Errorf("invalid address %q: %w", addr, err)
+	} else {
+		b.address = parsedAddr
+		b.addrErr = nil
+	}
+	return b
+}
+
+// WithLovelace sets the ADA amount in lovelace for the output
+func (b *MockTransactionOutputBuilder) WithLovelace(
+	amount uint64,
+) TransactionOutputBuilder {
+	b.amount = amount
+	return b
+}
+
+// WithAssets sets the native assets for the output
+func (b *MockTransactionOutputBuilder) WithAssets(
+	assets ...Asset,
+) TransactionOutputBuilder {
+	b.assets = buildMultiAsset(assets)
+	return b
+}
+
+// WithDatum sets the inline datum for the output
+func (b *MockTransactionOutputBuilder) WithDatum(
+	datum []byte,
+) TransactionOutputBuilder {
+	if datum != nil {
+		d := lcommon.Datum{}
+		if _, err := cbor.Decode(datum, &d); err != nil {
+			// Store the error for reporting in Build()
+			b.datumErr = fmt.Errorf("invalid datum CBOR: %w", err)
+		} else {
+			b.datum = &d
+			b.datumErr = nil
+		}
+	}
+	return b
+}
+
+// WithDatumHash sets the datum hash for the output
+func (b *MockTransactionOutputBuilder) WithDatumHash(
+	hash []byte,
+) TransactionOutputBuilder {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		b.datumHash = &h
+	}
+	return b
+}
+
+// Build constructs a TransactionOutput from the builder state
+func (b *MockTransactionOutputBuilder) Build() (lcommon.TransactionOutput, error) {
+	// Return any stored parsing errors
+	if b.addrErr != nil {
+		return nil, b.addrErr
+	}
+	if b.datumErr != nil {
+		return nil, b.datumErr
+	}
+	if b.address.String() == "" {
+		return nil, errors.New("address is required")
+	}
+	return &MockTransactionOutput{
+		address:   b.address,
+		amount:    b.amount,
+		assets:    b.assets,
+		datum:     b.datum,
+		datumHash: b.datumHash,
+	}, nil
+}
+
+// MockTransactionWitnessSet implements lcommon.TransactionWitnessSet
+type MockTransactionWitnessSet struct {
+	vkeys        []lcommon.VkeyWitness
+	native       []lcommon.NativeScript
+	bootstrap    []lcommon.BootstrapWitness
+	plutusData   []lcommon.Datum
+	plutusV1     []lcommon.PlutusV1Script
+	plutusV2     []lcommon.PlutusV2Script
+	plutusV3     []lcommon.PlutusV3Script
+	redeemerData lcommon.TransactionWitnessRedeemers
+}
+
+// NewMockTransactionWitnessSet creates a new empty witness set
+func NewMockTransactionWitnessSet() *MockTransactionWitnessSet {
+	return &MockTransactionWitnessSet{}
+}
+
+// Vkey returns the VKey witnesses
+func (w *MockTransactionWitnessSet) Vkey() []lcommon.VkeyWitness {
+	return w.vkeys
+}
+
+// NativeScripts returns the native scripts
+func (w *MockTransactionWitnessSet) NativeScripts() []lcommon.NativeScript {
+	return w.native
+}
+
+// Bootstrap returns the bootstrap witnesses
+func (w *MockTransactionWitnessSet) Bootstrap() []lcommon.BootstrapWitness {
+	return w.bootstrap
+}
+
+// PlutusData returns the Plutus data
+func (w *MockTransactionWitnessSet) PlutusData() []lcommon.Datum {
+	return w.plutusData
+}
+
+// PlutusV1Scripts returns the Plutus V1 scripts
+func (w *MockTransactionWitnessSet) PlutusV1Scripts() []lcommon.PlutusV1Script {
+	return w.plutusV1
+}
+
+// PlutusV2Scripts returns the Plutus V2 scripts
+func (w *MockTransactionWitnessSet) PlutusV2Scripts() []lcommon.PlutusV2Script {
+	return w.plutusV2
+}
+
+// PlutusV3Scripts returns the Plutus V3 scripts
+func (w *MockTransactionWitnessSet) PlutusV3Scripts() []lcommon.PlutusV3Script {
+	return w.plutusV3
+}
+
+// Redeemers returns the transaction redeemers
+func (w *MockTransactionWitnessSet) Redeemers() lcommon.TransactionWitnessRedeemers {
+	return w.redeemerData
+}
+
+// Additional builder methods for MockTransaction to support advanced features
+
+// WithType sets the transaction type
+func (t *MockTransaction) WithType(txType int) *MockTransaction {
+	t.txType = txType
+	return t
+}
+
+// WithLeiosHash sets the Leios hash
+func (t *MockTransaction) WithLeiosHash(hash []byte) *MockTransaction {
+	t.leiosHash = lcommon.NewBlake2b256(hash)
+	return t
+}
+
+// WithReferenceInputs sets the reference inputs
+func (t *MockTransaction) WithReferenceInputs(
+	inputs ...lcommon.TransactionInput,
+) *MockTransaction {
+	t.refInputs = append(t.refInputs, inputs...)
+	return t
+}
+
+// WithCollateral sets the collateral inputs
+func (t *MockTransaction) WithCollateral(
+	inputs ...lcommon.TransactionInput,
+) *MockTransaction {
+	t.collateral = append(t.collateral, inputs...)
+	return t
+}
+
+// WithCollateralReturn sets the collateral return output
+func (t *MockTransaction) WithCollateralReturn(
+	output lcommon.TransactionOutput,
+) *MockTransaction {
+	t.collReturn = output
+	return t
+}
+
+// WithTotalCollateral sets the total collateral amount
+func (t *MockTransaction) WithTotalCollateral(amount uint64) *MockTransaction {
+	t.totalColl = amount
+	return t
+}
+
+// WithCertificates sets the certificates
+func (t *MockTransaction) WithCertificates(
+	certs ...lcommon.Certificate,
+) *MockTransaction {
+	t.certs = append(t.certs, certs...)
+	return t
+}
+
+// WithWithdrawals sets the stake withdrawals
+func (t *MockTransaction) WithWithdrawals(
+	wdrls map[*lcommon.Address]uint64,
+) *MockTransaction {
+	t.wdrls = wdrls
+	return t
+}
+
+// WithAuxDataHash sets the auxiliary data hash
+func (t *MockTransaction) WithAuxDataHash(hash []byte) *MockTransaction {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		t.auxHash = &h
+	}
+	return t
+}
+
+// WithRequiredSigners sets the required signers
+func (t *MockTransaction) WithRequiredSigners(
+	signers ...lcommon.Blake2b224,
+) *MockTransaction {
+	t.reqSigners = append(t.reqSigners, signers...)
+	return t
+}
+
+// WithMint sets the asset minting/burning
+func (t *MockTransaction) WithMint(
+	mint *lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
+) *MockTransaction {
+	t.mint = mint
+	return t
+}
+
+// WithScriptDataHash sets the script data hash
+func (t *MockTransaction) WithScriptDataHash(hash []byte) *MockTransaction {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		t.scriptHash = &h
+	}
+	return t
+}
+
+// WithVotingProcedures sets the voting procedures
+func (t *MockTransaction) WithVotingProcedures(
+	procs lcommon.VotingProcedures,
+) *MockTransaction {
+	t.votingProc = procs
+	return t
+}
+
+// WithProposalProcedures sets the governance proposals
+func (t *MockTransaction) WithProposalProcedures(
+	proposals ...lcommon.ProposalProcedure,
+) *MockTransaction {
+	t.proposals = append(t.proposals, proposals...)
+	return t
+}
+
+// WithTreasuryValue sets the current treasury value
+func (t *MockTransaction) WithTreasuryValue(value int64) *MockTransaction {
+	t.treasury = value
+	return t
+}
+
+// WithDonation sets the donation amount
+func (t *MockTransaction) WithDonation(amount uint64) *MockTransaction {
+	t.donation = amount
+	return t
+}
+
+// WithValidityIntervalStart sets the validity interval start slot
+func (t *MockTransaction) WithValidityIntervalStart(
+	slot uint64,
+) *MockTransaction {
+	t.validStart = slot
+	return t
+}
+
+// WithWitnesses sets the witness set
+func (t *MockTransaction) WithWitnesses(
+	witnesses *MockTransactionWitnessSet,
+) *MockTransaction {
+	t.witnesses = witnesses
+	return t
+}
+
+// Witness set builder methods
+
+// WithVkeyWitnesses adds VKey witnesses to the witness set
+func (w *MockTransactionWitnessSet) WithVkeyWitnesses(
+	vkeys ...lcommon.VkeyWitness,
+) *MockTransactionWitnessSet {
+	w.vkeys = append(w.vkeys, vkeys...)
+	return w
+}
+
+// WithNativeScripts adds native scripts to the witness set
+func (w *MockTransactionWitnessSet) WithNativeScripts(
+	scripts ...lcommon.NativeScript,
+) *MockTransactionWitnessSet {
+	w.native = append(w.native, scripts...)
+	return w
+}
+
+// WithBootstrapWitnesses adds bootstrap witnesses to the witness set
+func (w *MockTransactionWitnessSet) WithBootstrapWitnesses(
+	witnesses ...lcommon.BootstrapWitness,
+) *MockTransactionWitnessSet {
+	w.bootstrap = append(w.bootstrap, witnesses...)
+	return w
+}
+
+// WithPlutusData adds Plutus data to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusData(
+	datum ...lcommon.Datum,
+) *MockTransactionWitnessSet {
+	w.plutusData = append(w.plutusData, datum...)
+	return w
+}
+
+// WithPlutusV1Scripts adds Plutus V1 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV1Scripts(
+	scripts ...lcommon.PlutusV1Script,
+) *MockTransactionWitnessSet {
+	w.plutusV1 = append(w.plutusV1, scripts...)
+	return w
+}
+
+// WithPlutusV2Scripts adds Plutus V2 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV2Scripts(
+	scripts ...lcommon.PlutusV2Script,
+) *MockTransactionWitnessSet {
+	w.plutusV2 = append(w.plutusV2, scripts...)
+	return w
+}
+
+// WithPlutusV3Scripts adds Plutus V3 scripts to the witness set
+func (w *MockTransactionWitnessSet) WithPlutusV3Scripts(
+	scripts ...lcommon.PlutusV3Script,
+) *MockTransactionWitnessSet {
+	w.plutusV3 = append(w.plutusV3, scripts...)
+	return w
+}
+
+// WithRedeemers sets the redeemers for the witness set
+func (w *MockTransactionWitnessSet) WithRedeemers(
+	redeemers lcommon.TransactionWitnessRedeemers,
+) *MockTransactionWitnessSet {
+	w.redeemerData = redeemers
+	return w
+}
+
+// Ensure MockTransactionOutput implements the Cbor() method required by lcommon.TransactionOutput
+// The existing MockTransactionOutput in utxo.go already has most methods, but we need Cbor()
+
+// MockTransactionOutputWithCbor wraps MockTransactionOutput to add CBOR support
+type MockTransactionOutputWithCbor struct {
+	*MockTransactionOutput
+	cborData []byte
+}
+
+// Cbor returns the CBOR-encoded output
+func (o *MockTransactionOutputWithCbor) Cbor() []byte {
+	return o.cborData
+}
+
+// NewTransactionOutputFromUtxo creates a transaction output builder from an existing MockTransactionOutput.
+// Returns nil if output is nil.
+func NewTransactionOutputFromUtxo(
+	output *MockTransactionOutput,
+) *MockTransactionOutputBuilder {
+	if output == nil {
+		return nil
+	}
+	return &MockTransactionOutputBuilder{
+		address:   output.address,
+		amount:    output.amount,
+		assets:    output.assets,
+		datum:     output.datum,
+		datumHash: output.datumHash,
+	}
+}
+
+// Helper function to create a simple transaction for testing
+func NewSimpleTransaction(
+	txId []byte,
+	inputs []lcommon.TransactionInput,
+	outputs []lcommon.TransactionOutput,
+	fee uint64,
+) (*MockTransaction, error) {
+	tx := NewTransactionBuilder().
+		WithId(txId).
+		WithFee(fee)
+
+	for _, input := range inputs {
+		tx.WithInputs(input)
+	}
+	for _, output := range outputs {
+		tx.WithOutputs(output)
+	}
+
+	result, err := tx.Build()
+	if err != nil {
+		return nil, err
+	}
+	mockTx, ok := result.(*MockTransaction)
+	if !ok {
+		return nil, errors.New("unexpected transaction type")
+	}
+	return mockTx, nil
+}
+
+// Helper function to create a simple transaction input
+func NewSimpleTransactionInput(
+	txId []byte,
+	index uint32,
+) (*MockTransactionInput, error) {
+	input, err := NewTransactionInputBuilder().
+		WithTxId(txId).
+		WithIndex(index).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	mockInput, ok := input.(*MockTransactionInput)
+	if !ok {
+		return nil, errors.New("unexpected transaction input type")
+	}
+	return mockInput, nil
+}
+
+// Helper function to create a simple transaction output
+func NewSimpleTransactionOutput(
+	address string,
+	lovelace uint64,
+) (*MockTransactionOutput, error) {
+	output, err := NewTransactionOutputBuilder().
+		WithAddress(address).
+		WithLovelace(lovelace).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	mockOutput, ok := output.(*MockTransactionOutput)
+	if !ok {
+		return nil, errors.New("unexpected transaction output type")
+	}
+	return mockOutput, nil
+}
+
+// String returns a string representation of the transaction
+func (t *MockTransaction) String() string {
+	return fmt.Sprintf(
+		"Transaction{id=%s, inputs=%d, outputs=%d, fee=%d}",
+		t.txId.String(),
+		len(t.inputs),
+		len(t.outputs),
+		t.fee,
+	)
+}
+
+// ToPlutusData converts the transaction to Plutus data representation
+func (t *MockTransaction) ToPlutusData() data.PlutusData {
+	// Build inputs list
+	inputsList := make([]data.PlutusData, len(t.inputs))
+	for i, input := range t.inputs {
+		inputsList[i] = input.ToPlutusData()
+	}
+
+	// Build outputs list
+	outputsList := make([]data.PlutusData, len(t.outputs))
+	for i, output := range t.outputs {
+		outputsList[i] = output.ToPlutusData()
+	}
+
+	return data.NewConstr(0,
+		data.NewList(inputsList...),
+		data.NewList(outputsList...),
+		data.NewInteger(new(big.Int).SetUint64(t.fee)),
+	)
+}

--- a/ledger/utxo.go
+++ b/ledger/utxo.go
@@ -1,0 +1,441 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// Asset represents a native asset with policy ID, asset name, and amount
+type Asset struct {
+	PolicyId  []byte
+	AssetName []byte
+	Amount    uint64
+}
+
+// buildMultiAsset constructs a MultiAsset from a slice of Asset.
+// Returns nil if assets is empty.
+func buildMultiAsset(
+	assets []Asset,
+) *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	if len(assets) == 0 {
+		return nil
+	}
+	assetData := make(
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput,
+	)
+	for _, asset := range assets {
+		policyId := lcommon.NewBlake2b224(asset.PolicyId)
+		if _, ok := assetData[policyId]; !ok {
+			assetData[policyId] = make(
+				map[cbor.ByteString]lcommon.MultiAssetTypeOutput,
+			)
+		}
+		assetData[policyId][cbor.NewByteString(asset.AssetName)] = new(
+			big.Int,
+		).SetUint64(asset.Amount)
+	}
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](assetData)
+	return &multiAsset
+}
+
+// UtxoBuilder defines an interface for building mock UTxOs
+type UtxoBuilder interface {
+	WithTxId(txId []byte) UtxoBuilder
+	WithIndex(idx uint32) UtxoBuilder
+	WithAddress(addr string) UtxoBuilder
+	WithLovelace(amount uint64) UtxoBuilder
+	WithAssets(assets ...Asset) UtxoBuilder
+	WithDatum(datum []byte) UtxoBuilder
+	WithDatumHash(hash []byte) UtxoBuilder
+	WithScriptRef(script []byte) UtxoBuilder
+	WithScriptRefLanguage(language PlutusLanguage) UtxoBuilder
+	Build() (lcommon.Utxo, error)
+}
+
+// MockUtxo holds the state for building a UTxO
+type MockUtxo struct {
+	txId          lcommon.Blake2b256
+	index         uint32
+	address       lcommon.Address
+	lovelace      uint64
+	assets        *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum         *lcommon.Datum
+	datumHash     *lcommon.Blake2b256
+	scriptRef     lcommon.Script
+	scriptRefLang PlutusLanguage // Language version for script reference
+	addrErr       error          // Stores address parsing error for deferred reporting
+	datumErr      error          // Stores datum CBOR decode error for deferred reporting
+	scriptRefErr  error          // Stores script ref CBOR decode error for deferred reporting
+}
+
+// NewUtxoBuilder creates a new MockUtxo builder
+func NewUtxoBuilder() *MockUtxo {
+	return &MockUtxo{}
+}
+
+// WithTxId sets the transaction ID for the UTxO
+func (u *MockUtxo) WithTxId(txId []byte) UtxoBuilder {
+	u.txId = lcommon.NewBlake2b256(txId)
+	return u
+}
+
+// WithIndex sets the output index for the UTxO
+func (u *MockUtxo) WithIndex(idx uint32) UtxoBuilder {
+	u.index = idx
+	return u
+}
+
+// WithAddress sets the address for the UTxO
+func (u *MockUtxo) WithAddress(addr string) UtxoBuilder {
+	parsedAddr, err := lcommon.NewAddress(addr)
+	if err != nil {
+		// Store the error for reporting in Build()
+		u.address = lcommon.Address{}
+		u.addrErr = fmt.Errorf("invalid address %q: %w", addr, err)
+	} else {
+		u.address = parsedAddr
+		u.addrErr = nil
+	}
+	return u
+}
+
+// WithLovelace sets the ADA amount in lovelace for the UTxO
+func (u *MockUtxo) WithLovelace(amount uint64) UtxoBuilder {
+	u.lovelace = amount
+	return u
+}
+
+// WithAssets sets the native assets for the UTxO
+func (u *MockUtxo) WithAssets(assets ...Asset) UtxoBuilder {
+	u.assets = buildMultiAsset(assets)
+	return u
+}
+
+// WithDatum sets the inline datum for the UTxO
+func (u *MockUtxo) WithDatum(datum []byte) UtxoBuilder {
+	if datum != nil {
+		d := lcommon.Datum{}
+		if _, err := cbor.Decode(datum, &d); err != nil {
+			u.datumErr = fmt.Errorf("failed to decode datum CBOR: %w", err)
+		} else {
+			u.datum = &d
+			u.datumErr = nil
+		}
+	}
+	return u
+}
+
+// WithDatumHash sets the datum hash for the UTxO
+func (u *MockUtxo) WithDatumHash(hash []byte) UtxoBuilder {
+	if hash != nil {
+		h := lcommon.NewBlake2b256(hash)
+		u.datumHash = &h
+	}
+	return u
+}
+
+// WithScriptRef sets the script reference for the UTxO
+func (u *MockUtxo) WithScriptRef(script []byte) UtxoBuilder {
+	if script != nil {
+		// Try to decode as a script reference
+		var scriptRef lcommon.ScriptRef
+		if _, err := cbor.Decode(script, &scriptRef); err != nil {
+			u.scriptRefErr = fmt.Errorf(
+				"failed to decode script reference CBOR: %w",
+				err,
+			)
+		} else {
+			u.scriptRef = scriptRef.Script
+			u.scriptRefErr = nil
+		}
+	}
+	return u
+}
+
+// WithScriptRefLanguage sets the Plutus language version for the script reference
+func (u *MockUtxo) WithScriptRefLanguage(language PlutusLanguage) UtxoBuilder {
+	u.scriptRefLang = language
+	return u
+}
+
+// Build constructs a Utxo from the builder state
+func (u *MockUtxo) Build() (lcommon.Utxo, error) {
+	// Validate required fields
+	if u.txId == (lcommon.Blake2b256{}) {
+		return lcommon.Utxo{}, errors.New("transaction ID is required")
+	}
+	// Return any stored errors from deferred validation
+	if u.addrErr != nil {
+		return lcommon.Utxo{}, u.addrErr
+	}
+	if u.datumErr != nil {
+		return lcommon.Utxo{}, u.datumErr
+	}
+	if u.scriptRefErr != nil {
+		return lcommon.Utxo{}, u.scriptRefErr
+	}
+	// Validate address is not zero/invalid
+	if u.address.String() == "" {
+		return lcommon.Utxo{}, errors.New("address is required")
+	}
+
+	// Create the transaction input
+	input := &MockTransactionInput{
+		txId:  u.txId,
+		index: u.index,
+	}
+
+	// Create the transaction output
+	output := &MockTransactionOutput{
+		address:       u.address,
+		amount:        u.lovelace,
+		assets:        u.assets,
+		datum:         u.datum,
+		datumHash:     u.datumHash,
+		scriptRef:     u.scriptRef,
+		scriptRefLang: u.scriptRefLang,
+	}
+
+	return lcommon.Utxo{
+		Id:     input,
+		Output: output,
+	}, nil
+}
+
+// MockTransactionInput implements lcommon.TransactionInput
+type MockTransactionInput struct {
+	cbor.StructAsArray
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
+// Id returns the transaction ID
+func (i *MockTransactionInput) Id() lcommon.Blake2b256 {
+	return i.txId
+}
+
+// Index returns the output index
+func (i *MockTransactionInput) Index() uint32 {
+	return i.index
+}
+
+// String returns a string representation of the input
+func (i *MockTransactionInput) String() string {
+	return fmt.Sprintf("%s#%d", i.txId.String(), i.index)
+}
+
+// Utxorpc returns the UTxO RPC representation
+func (i *MockTransactionInput) Utxorpc() (*utxorpc.TxInput, error) {
+	return &utxorpc.TxInput{
+		TxHash:      i.txId.Bytes(),
+		OutputIndex: i.index,
+	}, nil
+}
+
+// ToPlutusData converts the input to Plutus data
+func (i *MockTransactionInput) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0,
+		data.NewByteString(i.txId.Bytes()),
+		data.NewInteger(big.NewInt(int64(i.index))),
+	)
+}
+
+// MockTransactionOutput implements lcommon.TransactionOutput
+type MockTransactionOutput struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	address       lcommon.Address
+	amount        uint64
+	assets        *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	datum         *lcommon.Datum
+	datumHash     *lcommon.Blake2b256
+	scriptRef     lcommon.Script
+	scriptRefLang PlutusLanguage // Language version for script reference in Utxorpc()
+}
+
+// Address returns the output address
+func (o *MockTransactionOutput) Address() lcommon.Address {
+	return o.address
+}
+
+// Amount returns the lovelace amount as *big.Int
+func (o *MockTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.amount)
+}
+
+// Assets returns the native assets
+func (o *MockTransactionOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return o.assets
+}
+
+// Datum returns the inline datum
+func (o *MockTransactionOutput) Datum() *lcommon.Datum {
+	return o.datum
+}
+
+// DatumHash returns the datum hash
+func (o *MockTransactionOutput) DatumHash() *lcommon.Blake2b256 {
+	return o.datumHash
+}
+
+// ScriptRef returns the script reference
+func (o *MockTransactionOutput) ScriptRef() lcommon.Script {
+	return o.scriptRef
+}
+
+// Utxorpc returns the UTxO RPC representation
+func (o *MockTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
+	addrBytes, err := o.address.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	output := &utxorpc.TxOutput{
+		Address: addrBytes,
+		Coin:    lcommon.ToUtxorpcBigInt(o.amount),
+	}
+
+	// Add assets if present
+	if o.assets != nil {
+		var multiassets []*utxorpc.Multiasset
+		for _, policyId := range o.assets.Policies() {
+			var assets []*utxorpc.Asset
+			for _, assetName := range o.assets.Assets(policyId) {
+				amount := o.assets.Asset(policyId, assetName)
+				// Convert *big.Int to utxorpc BigInt
+				utxorpcAmount := &utxorpc.BigInt{
+					BigInt: &utxorpc.BigInt_BigUInt{
+						BigUInt: amount.Bytes(),
+					},
+				}
+				assets = append(assets, &utxorpc.Asset{
+					Name: assetName,
+					Quantity: &utxorpc.Asset_OutputCoin{
+						OutputCoin: utxorpcAmount,
+					},
+				})
+			}
+			multiassets = append(multiassets, &utxorpc.Multiasset{
+				PolicyId: policyId.Bytes(),
+				Assets:   assets,
+			})
+		}
+		output.Assets = multiassets
+	}
+
+	// Add datum if present (inline datum or datum hash)
+	if o.datum != nil {
+		output.Datum = &utxorpc.Datum{
+			Hash:         o.datum.Hash().Bytes(),
+			OriginalCbor: o.datum.Cbor(),
+		}
+	} else if o.datumHash != nil {
+		// Datum hash only (referenced datum)
+		output.Datum = &utxorpc.Datum{
+			Hash: o.datumHash.Bytes(),
+		}
+	}
+
+	// Add script reference if present
+	if o.scriptRef != nil {
+		scriptBytes := o.scriptRef.RawScriptBytes()
+		switch o.scriptRefLang {
+		case PlutusV1:
+			output.Script = &utxorpc.Script{
+				Script: &utxorpc.Script_PlutusV1{
+					PlutusV1: scriptBytes,
+				},
+			}
+		case PlutusV2:
+			output.Script = &utxorpc.Script{
+				Script: &utxorpc.Script_PlutusV2{
+					PlutusV2: scriptBytes,
+				},
+			}
+		case PlutusV3:
+			output.Script = &utxorpc.Script{
+				Script: &utxorpc.Script_PlutusV3{
+					PlutusV3: scriptBytes,
+				},
+			}
+		default:
+			// Default to PlutusV2 for backwards compatibility (e.g., when language is 0/unset)
+			output.Script = &utxorpc.Script{
+				Script: &utxorpc.Script_PlutusV2{
+					PlutusV2: scriptBytes,
+				},
+			}
+		}
+	}
+
+	return output, nil
+}
+
+// ToPlutusData converts the output to Plutus data
+func (o *MockTransactionOutput) ToPlutusData() data.PlutusData {
+	// Build address data
+	addressPd := o.address.ToPlutusData()
+
+	// Build value data (lovelace + assets)
+	var valuePd data.PlutusData
+	if o.assets != nil {
+		valuePd = data.NewConstr(0,
+			data.NewInteger(new(big.Int).SetUint64(o.amount)),
+			o.assets.ToPlutusData(),
+		)
+	} else {
+		valuePd = data.NewInteger(new(big.Int).SetUint64(o.amount))
+	}
+
+	// Build datum option
+	var datumPd data.PlutusData
+	if o.datum != nil {
+		datumPd = data.NewConstr(2, o.datum.Data)
+	} else if o.datumHash != nil {
+		datumPd = data.NewConstr(1, data.NewByteString(o.datumHash.Bytes()))
+	} else {
+		datumPd = data.NewConstr(0)
+	}
+
+	// Build script ref option
+	var scriptRefPd data.PlutusData
+	if o.scriptRef != nil {
+		scriptRefPd = data.NewConstr(
+			0,
+			data.NewByteString(o.scriptRef.Hash().Bytes()),
+		)
+	} else {
+		scriptRefPd = data.NewConstr(1)
+	}
+
+	return data.NewConstr(0,
+		addressPd,
+		valuePd,
+		datumPd,
+		scriptRefPd,
+	)
+}
+
+// String returns a string representation of the output
+func (o *MockTransactionOutput) String() string {
+	return fmt.Sprintf("%s: %d lovelace", o.address.String(), o.amount)
+}


### PR DESCRIPTION
This is being extracted from #126 which is simply too big to review. This is based on the code in gouroboros' internal/test/ledger package. The goal is for this to completely replace that package in the future, allowing it to be shared across implementations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a reusable mock ledger state with builder utilities for transactions, UTxOs, pools, governance, rewards, and protocol params, extracted from gouroboros tests. This sets the foundation to replace the internal/test/ledger package and share mocks across implementations.

- **New Features**
  - Callback-based MockLedgerState for UTxO, stake registration, slot↔time, pools, rewards, and governance lookups.
  - Builders for Transaction, Input/Output, UTxO, Pool, CommitteeMember, DRep, Constitution, Voter, VotingProcedure, AdaPots, RewardSnapshot, and LedgerState.
  - Mock protocol parameter presets for Byron→Conway with Plutus V1/V2/V3 cost models.
  - UTXORPC and Plutigo integrations for Tx/Output conversion and PlutusData helpers.
  - go.mod: promote plutigo and utxorpc/go-codegen to direct dependencies.

<sup>Written for commit df8681331166a53a3ccbda9fedaaeba4b417d1f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core module dependencies to direct requirements for enhanced compatibility.

* **Tests**
  * Introduced extensive mock builders enabling flexible construction of ledger components: transactions, UTxOs, governance entities, protocol parameters across multiple Cardano eras, reward snapshots, ADA pots, and complete ledger state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->