### PR TITLE
fix(ledger): use hex#index key format for GovActionById

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"time"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -116,7 +117,7 @@ type MockLedgerState struct {
 	GovActionByIdCallback    GovActionByIdFunc
 	committeeMembers         []lcommon.CommitteeMember
 	drepRegistrations        []lcommon.DRepRegistration
-	govActions               map[string]*lcommon.GovActionState // "txhash#index" -> state
+	govActions               map[string]*lcommon.GovActionState // "hex(txhash)#index" -> state
 	// ProposedCommitteeMembers tracks committee members proposed in pending
 	// UpdateCommittee governance actions. Per Cardano ledger spec, AUTH_CC
 	// should succeed if the member is either a current member OR proposed
@@ -350,8 +351,9 @@ func (ls *MockLedgerState) GovActionById(
 	if ls.govActions == nil {
 		return nil, nil
 	}
-	// Key format matches gouroboros internal mock: "txhash#index"
-	key := id.String()
+	// Key format: hex-encoded transaction ID + "#" + decimal index
+	// This matches the format used in test vectors and debugging output
+	key := fmt.Sprintf("%x#%d", id.TransactionId[:], id.GovActionIdx)
 	state, exists := ls.govActions[key]
 	if !exists {
 		return nil, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix GovActionById lookups by switching to the hex(txhash)#index key format in MockLedgerState, preventing missed governance actions during retrieval.

- **Bug Fixes**
  - Build lookup key as fmt.Sprintf("%x#%d", txId[:], idx).
  - Updated internal docs to reflect "hex(txhash)#index" format.
  - Added a test to ensure GovActionById resolves actions with the new key format.

<sup>Written for commit 37fb3840b34a85e88f3efc1bebd70a4982112693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how governance actions are stored and retrieved by standardizing their internal key format.

* **Tests**
  * Added test coverage to verify governance action lookup functionality works correctly with the updated key format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->