### PR TITLE
feat(conformance): embed testdata

### DIFF
--- a/conformance/embed.go
+++ b/conformance/embed.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+//go:embed testdata
+var embeddedTestdata embed.FS
+
+// EmbeddedTestdata returns the embedded testdata filesystem.
+// This allows consumers to use the conformance test vectors without
+// needing to reference external files.
+func EmbeddedTestdata() embed.FS {
+	return embeddedTestdata
+}
+
+// ExtractEmbeddedTestdata extracts the embedded testdata to a temporary directory
+// and returns the path. The caller is responsible for cleaning up the directory
+// when done (e.g., using t.TempDir() or defer os.RemoveAll()).
+//
+// Usage with testing.T:
+//
+//	tmpDir := t.TempDir()
+//	testdataRoot, err := conformance.ExtractEmbeddedTestdata(tmpDir)
+//	if err != nil {
+//	    t.Fatal(err)
+//	}
+//	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+//	    TestdataRoot: testdataRoot,
+//	})
+func ExtractEmbeddedTestdata(destDir string) (string, error) {
+	return extractFS(embeddedTestdata, "testdata", destDir)
+}
+
+// extractFS extracts files from an embed.FS to a destination directory.
+func extractFS(fsys embed.FS, root string, destDir string) (string, error) {
+	testdataRoot := filepath.Join(destDir, root)
+
+	err := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(destDir, path)
+
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0o755)
+		}
+
+		data, err := fsys.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(destPath, data, 0o600)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return testdataRoot, nil
+}

--- a/conformance/harness.go
+++ b/conformance/harness.go
@@ -105,7 +105,12 @@ func (h *Harness) RunAllVectors(t *testing.T) {
 	}
 
 	for _, path := range vectors {
-		t.Run(path, func(t *testing.T) {
+		// Use relative path for cleaner test names
+		testName := path
+		if rel, err := filepath.Rel(h.testdataRoot, path); err == nil {
+			testName = rel
+		}
+		t.Run(testName, func(t *testing.T) {
 			h.runVectorFile(t, path)
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Embeds conformance testdata and adds helpers to access or extract it, removing the need for external files. Also uses relative paths for cleaner test names.

- **New Features**
  - Embed testdata via go:embed; expose EmbeddedTestdata().
  - Add ExtractEmbeddedTestdata(destDir) to write embedded testdata to disk and return its root.
  - Harness now uses relative paths for t.Run names to improve test output.

<sup>Written for commit b9d610c3f36af96759023520218480b4fc1759cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

