### PR TITLE
build(go): require Go 1.25 minimum

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
       - uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
       - uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,10 @@ on:
 concurrency: ${{ github.ref }}
 
 jobs:
-  create-draft-release:
+  create-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       - uses: actions/github-script@v8
@@ -27,7 +25,7 @@ jobs:
           script: |
             try {
               const response = await github.rest.repos.createRelease({
-                draft: true,
+                draft: false,
                 generate_release_notes: true,
                 name: process.env.RELEASE_TAG,
                 owner: context.repo.owner,
@@ -40,109 +38,3 @@ jobs:
             } catch (error) {
               core.setFailed(error.message);
             }
-
-# TODO: uncomment this when we have useful CLI bits
-#  build-binaries:
-#    strategy:
-#      matrix:
-#        os: [linux, darwin]
-#        arch: [amd64, arm64]
-#    runs-on: ubuntu-latest
-#    needs: [create-draft-release]
-#    steps:
-#      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-go@v5
-#        with:
-#          go-version: 1.24.x
-#      - name: Build binary
-#        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
-#      - name: Upload release asset
-#        if: startsWith(github.ref, 'refs/tags/')
-#        run: |
-#          _filename=ouroboros-mock-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
-#          mv ouroboros-mock ${_filename}
-#          curl \
-#            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-#            -H "Content-Type: application/octet-stream" \
-#            --data-binary @${_filename} \
-#            https://uploads.github.com/repos/${{ github.repository_owner }}/ouroboros-mock/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
-#
-#  build-images:
-#    runs-on: ubuntu-latest
-#    needs: [create-draft-release]
-#    steps:
-#      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-#      - uses: actions/checkout@v4
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: blinklabs
-#          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
-#      - name: Login to GHCR
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#          registry: ghcr.io
-#      - id: meta
-#        uses: docker/metadata-action@v5
-#        with:
-#          images: |
-#            blinklabs/ouroboros-mock
-#            ghcr.io/${{ github.repository }}
-#          tags: |
-#            # Only version, no revision
-#            type=match,pattern=v(.*)-(.*),group=1
-#            # branch
-#            type=ref,event=branch
-#            # semver
-#            type=semver,pattern={{version}}
-#      - name: Build images
-#        uses: docker/build-push-action@v5
-#        with:
-#          outputs: "type=registry,push=true"
-#          platforms: linux/amd64,linux/arm64
-#          tags: ${{ steps.meta.outputs.tags }}
-#          labels: ${{ steps.meta.outputs.labels }}
-#      # Update Docker Hub from README
-#      - name: Docker Hub Description
-#        uses: peter-evans/dockerhub-description@v4
-#        with:
-#          username: blinklabs
-#          password: ${{ secrets.DOCKER_PASSWORD }}
-#          repository: blinklabs/ouroboros-mock
-#          readme-filepath: ./README.md
-#          short-description: "Go library and CLI framework for mocking Ouroboros connections"
-
-  finalize-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    # TODO: uncomment these when we have useful CLI bits
-    needs: [create-draft-release] #, build-binaries, build-images]
-    steps:
-      - uses: actions/github-script@v8
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
-                draft: false,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
-
-      # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
-      - name: Pull new module version
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: andrewslotin/go-proxy-pull-action@v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/blinklabs-io/ouroboros-mock
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.7
 
 require (
 	github.com/blinklabs-io/gouroboros v0.159.2


### PR DESCRIPTION
Closes #177 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the minimum supported Go version to 1.25 and update CI to target Go 1.25/1.26. Simplifies the release workflow by publishing releases directly instead of using drafts/finalization.

- **Refactors**
  - Publish workflow now creates releases directly; removed draft/finalize steps and unused commented jobs.
  - CI test matrix updated to Go 1.25.x and 1.26.x; lint and nil checks run on 1.26.x.

- **Dependencies**
  - Set module go version to 1.25.7 and removed the 1.24 toolchain.

<sup>Written for commit 10ee5582e33a806578ee7919a9ca216db10512e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version requirement to 1.25.7
  * Updated CI pipelines to test against Go 1.25.x and 1.26.x
  * Simplified release workflow to directly publish releases instead of using draft releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->