### PR TITLE
ci: pin conventional commits action

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,5 +13,5 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: webiny/action-conventional-commits@v1.4.2
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin CI actions in the Conventional Commits workflow to exact versions for reproducible runs and reduced supply‑chain risk.

- **Dependencies**
  - Pin `actions/checkout` to v6.0.2.
  - Pin `webiny/action-conventional-commits` to v1.4.2.

<sup>Written for commit 13a26f6baa62851cb639145d3e38c889da0c7f9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

