### PR TITLE
feat: accept dingo database and ledger subsystems as a backing store

### DIFF
--- a/conformance/example_backend_test.go
+++ b/conformance/example_backend_test.go
@@ -56,51 +56,66 @@ import (
 	"github.com/blinklabs-io/ouroboros-mock/ledger"
 )
 
-// stubBackend is a trivial ledger.StateProvider that returns empty/zero values
-// for every method.  Replace this with your real database implementation.
-type stubBackend struct{}
+// stubBackend is a ledger.StateProvider that delegates all reads to an inner
+// provider supplied at construction time.  This lets GetStateProvider() return
+// the custom backend while the conformance vectors still pass.
+//
+// A real Dingo integration replaces each delegating call with an actual
+// database read:
+//
+//	func (s *stubBackend) UtxoById(id common.TransactionInput) (common.Utxo, error) {
+//	    return s.db.GetUtxo(id)   // ← your real database call
+//	}
+type stubBackend struct {
+	// getInner returns the current in-memory state.  Calling it on every
+	// method ensures the backend sees state that was written by ApplyTransaction.
+	// Replace the delegation with your own database reads to exercise real persistence.
+	getInner func() ledger.StateProvider
+}
 
 // Verify the stub satisfies the interface at compile time.
 var _ ledger.StateProvider = (*stubBackend)(nil)
 
-func (s *stubBackend) NetworkId() uint { return 0 }
+func (s *stubBackend) NetworkId() uint { return s.getInner().NetworkId() }
 
 func (s *stubBackend) UtxoById(
-	_ common.TransactionInput,
+	id common.TransactionInput,
 ) (common.Utxo, error) {
-	return common.Utxo{}, ledger.ErrNotFound
+	return s.getInner().UtxoById(id)
 }
 
 func (s *stubBackend) StakeRegistration(
-	_ []byte,
+	hash []byte,
 ) ([]common.StakeRegistrationCertificate, error) {
-	return nil, nil
+	return s.getInner().StakeRegistration(hash)
 }
 
-func (s *stubBackend) IsStakeCredentialRegistered(_ common.Credential) bool {
-	return false
+func (s *stubBackend) IsStakeCredentialRegistered(c common.Credential) bool {
+	return s.getInner().IsStakeCredentialRegistered(c)
 }
 
-func (s *stubBackend) SlotToTime(_ uint64) (time.Time, error) {
-	return time.Time{}, nil
+func (s *stubBackend) SlotToTime(slot uint64) (time.Time, error) {
+	return s.getInner().SlotToTime(slot)
 }
 
-func (s *stubBackend) TimeToSlot(_ time.Time) (uint64, error) {
-	return 0, nil
+func (s *stubBackend) TimeToSlot(t time.Time) (uint64, error) {
+	return s.getInner().TimeToSlot(t)
 }
 
 func (s *stubBackend) PoolCurrentState(
-	_ common.PoolKeyHash,
+	id common.PoolKeyHash,
 ) (*common.PoolRegistrationCertificate, *uint64, error) {
-	return nil, nil, nil
+	return s.getInner().PoolCurrentState(id)
 }
 
-func (s *stubBackend) IsPoolRegistered(_ common.PoolKeyHash) bool { return false }
+func (s *stubBackend) IsPoolRegistered(id common.PoolKeyHash) bool {
+	return s.getInner().IsPoolRegistered(id)
+}
 
 func (s *stubBackend) IsVrfKeyInUse(
-	_ common.Blake2b256,
+	vrf common.Blake2b256,
 ) (bool, common.PoolKeyHash, error) {
-	return false, common.PoolKeyHash{}, nil
+	return s.getInner().IsVrfKeyInUse(vrf)
 }
 
 func (s *stubBackend) CalculateRewards(
@@ -108,61 +123,67 @@ func (s *stubBackend) CalculateRewards(
 	snapshot common.RewardSnapshot,
 	params common.RewardParameters,
 ) (*common.RewardCalculationResult, error) {
-	return common.CalculateRewards(pots, snapshot, params)
+	return s.getInner().CalculateRewards(pots, snapshot, params)
 }
 
-func (s *stubBackend) GetAdaPots() common.AdaPots { return common.AdaPots{} }
+func (s *stubBackend) GetAdaPots() common.AdaPots { return s.getInner().GetAdaPots() }
 
-func (s *stubBackend) UpdateAdaPots(_ common.AdaPots) error { return nil }
-
-func (s *stubBackend) GetRewardSnapshot(_ uint64) (common.RewardSnapshot, error) {
-	return common.RewardSnapshot{}, nil
+func (s *stubBackend) UpdateAdaPots(p common.AdaPots) error {
+	return s.getInner().UpdateAdaPots(p)
 }
 
-func (s *stubBackend) IsRewardAccountRegistered(_ common.Credential) bool {
-	return false
+func (s *stubBackend) GetRewardSnapshot(epoch uint64) (common.RewardSnapshot, error) {
+	return s.getInner().GetRewardSnapshot(epoch)
+}
+
+func (s *stubBackend) IsRewardAccountRegistered(c common.Credential) bool {
+	return s.getInner().IsRewardAccountRegistered(c)
 }
 
 func (s *stubBackend) RewardAccountBalance(
-	_ common.Credential,
+	c common.Credential,
 ) (*uint64, error) {
-	return nil, nil
+	return s.getInner().RewardAccountBalance(c)
 }
 
 func (s *stubBackend) CommitteeMember(
-	_ common.Blake2b224,
+	hash common.Blake2b224,
 ) (*common.CommitteeMember, error) {
-	return nil, nil
+	return s.getInner().CommitteeMember(hash)
 }
 
 func (s *stubBackend) CommitteeMembers() ([]common.CommitteeMember, error) {
-	return nil, nil
+	return s.getInner().CommitteeMembers()
 }
 
 func (s *stubBackend) DRepRegistration(
-	_ common.Blake2b224,
+	hash common.Blake2b224,
 ) (*common.DRepRegistration, error) {
-	return nil, nil
+	return s.getInner().DRepRegistration(hash)
 }
 
 func (s *stubBackend) DRepRegistrations() ([]common.DRepRegistration, error) {
-	return nil, nil
+	return s.getInner().DRepRegistrations()
 }
 
-func (s *stubBackend) Constitution() (*common.Constitution, error) { return nil, nil }
+func (s *stubBackend) Constitution() (*common.Constitution, error) {
+	return s.getInner().Constitution()
+}
 
-func (s *stubBackend) TreasuryValue() (uint64, error) { return 0, nil }
+func (s *stubBackend) TreasuryValue() (uint64, error) { return s.getInner().TreasuryValue() }
 
 func (s *stubBackend) GovActionById(
-	_ common.GovActionId,
+	id common.GovActionId,
 ) (*common.GovActionState, error) {
-	return nil, nil
+	return s.getInner().GovActionById(id)
 }
 
-func (s *stubBackend) GovActionExists(_ common.GovActionId) bool { return false }
+func (s *stubBackend) GovActionExists(id common.GovActionId) bool {
+	return s.getInner().GovActionExists(id)
+}
 
 func (s *stubBackend) CostModels() map[common.PlutusLanguage]common.CostModel {
-	return nil
+	return s.getInner().CostModels()
 }
 
 // customStateManager is a conformance.StateManager that delegates state reads
@@ -179,11 +200,15 @@ type customStateManager struct {
 
 var _ conformance.StateManager = (*customStateManager)(nil)
 
-func newCustomStateManager(backend ledger.StateProvider) *customStateManager {
-	return &customStateManager{
-		inner:   conformance.NewMockStateManager(),
-		backend: backend,
+func newCustomStateManager() *customStateManager {
+	m := &customStateManager{
+		inner: conformance.NewMockStateManager(),
 	}
+	// The stub delegates every read to the inner mock's current state so that
+	// conformance vectors pass.  Swap the delegation for real database calls to
+	// exercise actual persistence instead.
+	m.backend = &stubBackend{getInner: m.inner.GetStateProvider}
+	return m
 }
 
 func (m *customStateManager) LoadInitialState(
@@ -209,11 +234,10 @@ func (m *customStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 }
 
 // GetStateProvider returns the backend that the harness uses for read-only
-// validation queries.  Swap stubBackend with your real database here.
+// validation queries.  Replace stubBackend with your real database to exercise
+// actual persistence instead of the in-memory mock.
 func (m *customStateManager) GetStateProvider() conformance.StateProvider {
-	// To exercise real Dingo persistence, return your real backend instead:
-	//   return m.backend
-	return m.inner.GetStateProvider()
+	return m.backend
 }
 
 func (m *customStateManager) GetGovernanceState() *conformance.GovernanceState {
@@ -234,14 +258,12 @@ func (m *customStateManager) Reset() error {
 	return m.inner.Reset()
 }
 
-// TestConformanceWithCustomBackend shows how to wire a custom StateManager
-// (backed by a real database) into the conformance harness.  All existing
-// vectors pass because customStateManager still delegates to MockStateManager;
-// switching GetStateProvider() to return m.backend makes tests exercise real
-// Dingo persistence instead.
+// TestConformanceWithCustomBackend shows how to wire a custom StateManager into
+// the conformance harness.  All reads go through the injected backend
+// (stubBackend here); a real Dingo integration replaces the delegation inside
+// stubBackend with actual database calls.
 func TestConformanceWithCustomBackend(t *testing.T) {
-	backend := &stubBackend{}
-	sm := newCustomStateManager(backend)
+	sm := newCustomStateManager()
 
 	h := conformance.NewHarness(sm, conformance.HarnessConfig{
 		TestdataRoot: "testdata",

--- a/conformance/example_backend_test.go
+++ b/conformance/example_backend_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance_test
+
+// This file demonstrates how an external project (e.g. Dingo) can plug its
+// real database and ledger subsystems into the conformance test harness.
+//
+// Architecture
+// ============
+//
+//   conformance.Harness
+//       │
+//       │ StateManager interface
+//       ▼
+//   CustomStateManager          ← your implementation
+//       │ GetStateProvider()
+//       ▼
+//   CustomBackend               ← wraps your real database
+//       │ implements ledger.StateProvider
+//       ▼
+//   real DB / ledger code
+//
+// The mocked layer stays as-is (network protocols: handshake, chainsync,
+// blockfetch, etc.).  Only the persistence layer changes.
+//
+// Step-by-step
+// ============
+//
+// 1.  Implement ledger.StateProvider with your real database reads.
+// 2.  Implement conformance.StateManager with your real transaction
+//     processing / epoch boundary logic.
+// 3.  Pass your StateManager to conformance.NewHarness.
+//
+// The example below uses a stub that delegates everything to the built-in
+// MockStateManager so it compiles and runs without a real database.  A real
+// integration would replace the stub calls with actual database operations.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
+)
+
+// stubBackend is a trivial ledger.StateProvider that returns empty/zero values
+// for every method.  Replace this with your real database implementation.
+type stubBackend struct{}
+
+// Verify the stub satisfies the interface at compile time.
+var _ ledger.StateProvider = (*stubBackend)(nil)
+
+func (s *stubBackend) NetworkId() uint { return 0 }
+
+func (s *stubBackend) UtxoById(
+	_ common.TransactionInput,
+) (common.Utxo, error) {
+	return common.Utxo{}, ledger.ErrNotFound
+}
+
+func (s *stubBackend) StakeRegistration(
+	_ []byte,
+) ([]common.StakeRegistrationCertificate, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) IsStakeCredentialRegistered(_ common.Credential) bool {
+	return false
+}
+
+func (s *stubBackend) SlotToTime(_ uint64) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (s *stubBackend) TimeToSlot(_ time.Time) (uint64, error) {
+	return 0, nil
+}
+
+func (s *stubBackend) PoolCurrentState(
+	_ common.PoolKeyHash,
+) (*common.PoolRegistrationCertificate, *uint64, error) {
+	return nil, nil, nil
+}
+
+func (s *stubBackend) IsPoolRegistered(_ common.PoolKeyHash) bool { return false }
+
+func (s *stubBackend) IsVrfKeyInUse(
+	_ common.Blake2b256,
+) (bool, common.PoolKeyHash, error) {
+	return false, common.PoolKeyHash{}, nil
+}
+
+func (s *stubBackend) CalculateRewards(
+	pots common.AdaPots,
+	snapshot common.RewardSnapshot,
+	params common.RewardParameters,
+) (*common.RewardCalculationResult, error) {
+	return common.CalculateRewards(pots, snapshot, params)
+}
+
+func (s *stubBackend) GetAdaPots() common.AdaPots { return common.AdaPots{} }
+
+func (s *stubBackend) UpdateAdaPots(_ common.AdaPots) error { return nil }
+
+func (s *stubBackend) GetRewardSnapshot(_ uint64) (common.RewardSnapshot, error) {
+	return common.RewardSnapshot{}, nil
+}
+
+func (s *stubBackend) IsRewardAccountRegistered(_ common.Credential) bool {
+	return false
+}
+
+func (s *stubBackend) RewardAccountBalance(
+	_ common.Credential,
+) (*uint64, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) CommitteeMember(
+	_ common.Blake2b224,
+) (*common.CommitteeMember, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) CommitteeMembers() ([]common.CommitteeMember, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) DRepRegistration(
+	_ common.Blake2b224,
+) (*common.DRepRegistration, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) DRepRegistrations() ([]common.DRepRegistration, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) Constitution() (*common.Constitution, error) { return nil, nil }
+
+func (s *stubBackend) TreasuryValue() (uint64, error) { return 0, nil }
+
+func (s *stubBackend) GovActionById(
+	_ common.GovActionId,
+) (*common.GovActionState, error) {
+	return nil, nil
+}
+
+func (s *stubBackend) GovActionExists(_ common.GovActionId) bool { return false }
+
+func (s *stubBackend) CostModels() map[common.PlutusLanguage]common.CostModel {
+	return nil
+}
+
+// customStateManager is a conformance.StateManager that delegates state reads
+// to a ledger.StateProvider (here: stubBackend) and state mutations to the
+// built-in MockStateManager.
+//
+// A real Dingo integration would replace MockStateManager with Dingo's own
+// transaction application and epoch-boundary logic, and replace stubBackend
+// with a read-path that queries Dingo's real database.
+type customStateManager struct {
+	inner   *conformance.MockStateManager
+	backend ledger.StateProvider
+}
+
+var _ conformance.StateManager = (*customStateManager)(nil)
+
+func newCustomStateManager(backend ledger.StateProvider) *customStateManager {
+	return &customStateManager{
+		inner:   conformance.NewMockStateManager(),
+		backend: backend,
+	}
+}
+
+func (m *customStateManager) LoadInitialState(
+	state *conformance.ParsedInitialState,
+	pp common.ProtocolParameters,
+) error {
+	// In a real integration: hydrate your database from state and pp.
+	// Here we just forward to the in-memory manager so the test runs.
+	return m.inner.LoadInitialState(state, pp)
+}
+
+func (m *customStateManager) ApplyTransaction(
+	tx common.Transaction,
+	slot uint64,
+) error {
+	// In a real integration: call your ledger's transaction application path.
+	return m.inner.ApplyTransaction(tx, slot)
+}
+
+func (m *customStateManager) ProcessEpochBoundary(newEpoch uint64) error {
+	// In a real integration: call your ledger's epoch-boundary logic.
+	return m.inner.ProcessEpochBoundary(newEpoch)
+}
+
+// GetStateProvider returns the backend that the harness uses for read-only
+// validation queries.  Swap stubBackend with your real database here.
+func (m *customStateManager) GetStateProvider() conformance.StateProvider {
+	// To exercise real Dingo persistence, return your real backend instead:
+	//   return m.backend
+	return m.inner.GetStateProvider()
+}
+
+func (m *customStateManager) GetGovernanceState() *conformance.GovernanceState {
+	return m.inner.GetGovernanceState()
+}
+
+func (m *customStateManager) SetRewardBalances(
+	balances map[common.Blake2b224]uint64,
+) {
+	m.inner.SetRewardBalances(balances)
+}
+
+func (m *customStateManager) GetProtocolParameters() common.ProtocolParameters {
+	return m.inner.GetProtocolParameters()
+}
+
+func (m *customStateManager) Reset() error {
+	return m.inner.Reset()
+}
+
+// TestConformanceWithCustomBackend shows how to wire a custom StateManager
+// (backed by a real database) into the conformance harness.  All existing
+// vectors pass because customStateManager still delegates to MockStateManager;
+// switching GetStateProvider() to return m.backend makes tests exercise real
+// Dingo persistence instead.
+func TestConformanceWithCustomBackend(t *testing.T) {
+	backend := &stubBackend{}
+	sm := newCustomStateManager(backend)
+
+	h := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: "testdata",
+	})
+	h.RunAllVectors(t)
+}

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -19,19 +19,14 @@ import (
 	"maps"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
 )
 
-// StateProvider combines all gouroboros state interfaces needed for validation.
-// Implementations provide read-only access to ledger state.
-type StateProvider interface {
-	common.LedgerState
-	common.UtxoState
-	common.CertState
-	common.SlotState
-	common.PoolState
-	common.RewardState
-	common.GovState
-}
+// StateProvider is the read-only ledger state surface required for transaction
+// validation. It is defined in the ledger package and aliased here so that
+// existing code that references conformance.StateProvider continues to compile
+// unchanged. Implementors should refer to ledger.StateProvider directly.
+type StateProvider = ledger.StateProvider
 
 // StateManager handles state mutations during test execution.
 // Implementations manage the full lifecycle of ledger state for a test vector.

--- a/ledger/backend.go
+++ b/ledger/backend.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// StateProvider is the read-only surface of ledger state that ouroboros-mock
+// exercises during transaction validation and protocol operations. It composes
+// the seven gouroboros state interfaces into a single, injectable contract.
+//
+// The default implementation is MockLedgerState, built via LedgerStateBuilder.
+// Custom backends (e.g. a real database or Dingo's ledger subsystem) implement
+// this interface so that conformance tests run mocked network protocols against
+// real persistence instead of in-memory state.
+//
+// Example (custom backend):
+//
+//	type MyBackend struct { db *mydb.DB }
+//
+//	func (b *MyBackend) UtxoById(id lcommon.TransactionInput) (lcommon.Utxo, error) {
+//	    return b.db.GetUtxo(id)
+//	}
+//	// ... implement remaining six interface methods ...
+//
+//	var _ ledger.StateProvider = (*MyBackend)(nil) // compile-time check
+type StateProvider interface {
+	lcommon.LedgerState
+	lcommon.UtxoState
+	lcommon.CertState
+	lcommon.SlotState
+	lcommon.PoolState
+	lcommon.RewardState
+	lcommon.GovState
+}

--- a/ledger/interface_check_test.go
+++ b/ledger/interface_check_test.go
@@ -28,4 +28,7 @@ var (
 	_ lcommon.PoolState   = (*MockLedgerState)(nil)
 	_ lcommon.RewardState = (*MockLedgerState)(nil)
 	_ lcommon.GovState    = (*MockLedgerState)(nil)
+
+	// Verify MockLedgerState satisfies the unified StateProvider interface.
+	_ StateProvider = (*MockLedgerState)(nil)
 )


### PR DESCRIPTION
Closes #176 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified read-only ledger interface so the mock can run against real backends (e.g., Dingo) and includes an example showing how to wire a custom backend into the conformance harness. Existing behavior stays the same by default.

- New Features
  - Introduced `ledger.StateProvider` (in the new `ledger` package) that composes gouroboros state interfaces; aliased as `conformance.StateProvider` for backward compatibility.
  - Added `conformance/example_backend_test.go` showing a custom `StateManager` with a delegating `stubBackend` that implements `ledger.StateProvider` to run harness vectors against a real store.
  - Ensured `MockLedgerState` implements `ledger.StateProvider` with a compile-time check.

<sup>Written for commit 5e02d03b88d2faf7290abac0df983136cdaba8c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a conformance example that demonstrates plugging an external backend into the harness and runs all conformance vectors.
  * Added a compile-time conformance check to ensure the mock ledger satisfies the unified provider contract.

* **Refactor**
  * Unified multiple ledger state contracts into a single StateProvider interface to simplify backend integration and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->