### PR TITLE
feat(fixtures): add GenerateConwayChain block-chain generator

### DIFF
--- a/fixtures/chain.go
+++ b/fixtures/chain.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"golang.org/x/crypto/blake2b"
+)
+
+// GenerateConwayChain builds count Conway blocks that chain together via
+// PrevHash, with CBOR that round-trips cleanly through
+// ledger.NewBlockFromCbor: a consumer that re-decodes the returned block bytes
+// recovers the same Hash() and PrevHash() the generator produced. This makes
+// the blocks usable as stable fixtures for chain-reconcile and rollback tests
+// in downstream repos.
+//
+// The first block's PrevHash is set to prevHash. Each block's slot is
+// startSlot + i*slotIncrement; block numbers run
+// startBlockNumber..startBlockNumber+count-1. All blocks have empty
+// transaction, witness, auxiliary, and invalid-transaction sets, so they
+// share the same block body hash. A count of zero or less returns an empty,
+// non-nil slice and no error.
+func GenerateConwayChain(
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	count int,
+) ([]ledger.Block, error) {
+	if count <= 0 {
+		return []ledger.Block{}, nil
+	}
+	// All generated blocks have identical empty bodies, so the four component
+	// CBORs and the resulting block body hash are constant across the chain.
+	emptyTxsCbor, err := cbor.Encode([]ledger.ConwayTransactionBody{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty tx bodies: %w", err)
+	}
+	emptyWitsCbor, err := cbor.Encode([]ledger.ConwayTransactionWitnessSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty witnesses: %w", err)
+	}
+	emptyAuxCbor, err := cbor.Encode(common.TransactionMetadataSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty metadata set: %w", err)
+	}
+	emptyInvalidCbor, err := cbor.Encode([]uint{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty invalid txs: %w", err)
+	}
+	bodyHash := ComputeBlockBodyHash(
+		emptyTxsCbor, emptyWitsCbor, emptyAuxCbor, emptyInvalidCbor,
+	)
+	blocks := make([]ledger.Block, 0, count)
+	currentPrev := prevHash
+	for i := range count {
+		body := babbage.BabbageBlockHeaderBody{
+			BlockNumber: startBlockNumber + uint64(i),
+			Slot:        startSlot + uint64(i)*slotIncrement,
+			PrevHash:    currentPrev,
+			IssuerVkey:  common.IssuerVkey{},
+			VrfKey:      make([]byte, 32),
+			VrfResult: common.VrfResult{
+				Output: make([]byte, 64),
+				Proof:  make([]byte, 80),
+			},
+			BlockBodySize: 0,
+			BlockBodyHash: bodyHash,
+			OpCert: babbage.BabbageOpCert{
+				HotVkey:   make([]byte, 32),
+				Signature: make([]byte, 64),
+			},
+			ProtoVersion: babbage.BabbageProtoVersion{Major: 9, Minor: 0},
+		}
+		block := &ledger.ConwayBlock{
+			BlockHeader: &ledger.ConwayBlockHeader{
+				BabbageBlockHeader: ledger.BabbageBlockHeader{
+					Body:      body,
+					Signature: make([]byte, 64),
+				},
+			},
+		}
+		blockCbor, err := cbor.Encode(block)
+		if err != nil {
+			return nil, fmt.Errorf("encode block %d: %w", i, err)
+		}
+		// Re-decode so the returned block carries the canonical Cbor() a
+		// consumer's reconcile path will observe, and so Hash() reads from the
+		// post-round-trip header bytes.
+		decoded, err := conway.NewConwayBlockFromCbor(blockCbor)
+		if err != nil {
+			return nil, fmt.Errorf("decode generated block %d: %w", i, err)
+		}
+		if !bytes.Equal(decoded.Cbor(), blockCbor) {
+			return nil, fmt.Errorf(
+				"block %d Cbor mismatch after round-trip",
+				i,
+			)
+		}
+		blocks = append(blocks, decoded)
+		currentPrev = decoded.Hash()
+	}
+	return blocks, nil
+}
+
+// ComputeBlockBodyHash returns
+// blake2b256(blake2b256(parts[0]) || blake2b256(parts[1]) || ...), which
+// matches the derivation expected by common.ValidateBlockBodyHash.
+func ComputeBlockBodyHash(parts ...[]byte) common.Blake2b256 {
+	var combined []byte
+	for _, p := range parts {
+		h := blake2b.Sum256(p)
+		combined = append(combined, h[:]...)
+	}
+	h := blake2b.Sum256(combined)
+	return common.NewBlake2b256(h[:])
+}

--- a/fixtures/chain_test.go
+++ b/fixtures/chain_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+)
+
+// Generated blocks must round-trip through ledger.NewBlockFromCbor with stable
+// Hash()/PrevHash()/BlockNumber()/SlotNumber(), and link together via PrevHash.
+func TestGenerateConwayChainRoundTrip(t *testing.T) {
+	var origin common.Blake2b256
+	gen, err := fixtures.GenerateConwayChain(1, origin, 0, 20, 5)
+	if err != nil {
+		t.Fatalf("GenerateConwayChain: %s", err)
+	}
+	if len(gen) != 5 {
+		t.Fatalf("expected 5 blocks, got %d", len(gen))
+	}
+	for i, b := range gen {
+		decoded, err := ledger.NewBlockFromCbor(uint(b.Type()), b.Cbor())
+		if err != nil {
+			t.Fatalf("block %d decode failed: %s", i, err)
+		}
+		if decoded.Hash() != b.Hash() {
+			t.Fatalf(
+				"block %d hash changed after round-trip: %s -> %s",
+				i, b.Hash(), decoded.Hash(),
+			)
+		}
+		if decoded.PrevHash() != b.PrevHash() {
+			t.Fatalf(
+				"block %d prev hash changed after round-trip: %s -> %s",
+				i, b.PrevHash(), decoded.PrevHash(),
+			)
+		}
+		if decoded.BlockNumber() != uint64(i+1) {
+			t.Fatalf(
+				"block %d unexpected block number %d",
+				i, decoded.BlockNumber(),
+			)
+		}
+		if decoded.SlotNumber() != uint64(i)*20 {
+			t.Fatalf(
+				"block %d unexpected slot %d",
+				i, decoded.SlotNumber(),
+			)
+		}
+	}
+	for i := 1; i < len(gen); i++ {
+		if gen[i].PrevHash() != gen[i-1].Hash() {
+			t.Fatalf(
+				"chain link mismatch at index %d: prev=%s, want=%s",
+				i, gen[i].PrevHash(), gen[i-1].Hash(),
+			)
+		}
+	}
+}
+
+// The first block's PrevHash must be the caller-supplied prevHash, so chains
+// can be grafted onto an existing block (e.g. to build a fork).
+func TestGenerateConwayChainHonorsPrevHash(t *testing.T) {
+	root, err := fixtures.GenerateConwayChain(1, common.Blake2b256{}, 0, 20, 1)
+	if err != nil {
+		t.Fatalf("GenerateConwayChain root: %s", err)
+	}
+	fork, err := fixtures.GenerateConwayChain(2, root[0].Hash(), 20, 20, 2)
+	if err != nil {
+		t.Fatalf("GenerateConwayChain fork: %s", err)
+	}
+	if fork[0].PrevHash() != root[0].Hash() {
+		t.Fatalf(
+			"fork does not link to root: prev=%s, want=%s",
+			fork[0].PrevHash(), root[0].Hash(),
+		)
+	}
+	if fork[0].BlockNumber() != 2 {
+		t.Fatalf("fork start block number = %d, want 2", fork[0].BlockNumber())
+	}
+}
+
+// A non-positive count returns an empty, non-nil slice and no error.
+func TestGenerateConwayChainEmpty(t *testing.T) {
+	for _, count := range []int{0, -1} {
+		gen, err := fixtures.GenerateConwayChain(1, common.Blake2b256{}, 0, 1, count)
+		if err != nil {
+			t.Fatalf("count %d: unexpected error %s", count, err)
+		}
+		if gen == nil {
+			t.Fatalf("count %d: expected non-nil slice", count)
+		}
+		if len(gen) != 0 {
+			t.Fatalf("count %d: expected empty slice, got %d", count, len(gen))
+		}
+	}
+}
+
+// ComputeBlockBodyHash is deterministic and order-sensitive.
+func TestComputeBlockBodyHash(t *testing.T) {
+	a := fixtures.ComputeBlockBodyHash([]byte("one"), []byte("two"))
+	b := fixtures.ComputeBlockBodyHash([]byte("one"), []byte("two"))
+	if a != b {
+		t.Fatalf("hash not deterministic: %s != %s", a, b)
+	}
+	swapped := fixtures.ComputeBlockBodyHash([]byte("two"), []byte("one"))
+	if a == swapped {
+		t.Fatalf("hash should depend on part order")
+	}
+	if bytes.Equal(a.Bytes(), make([]byte, 32)) {
+		t.Fatalf("hash should not be the zero value")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/utxorpc/go-codegen v0.19.2
 	go.uber.org/goleak v1.3.0
+	golang.org/x/crypto v0.52.0
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Adds a reusable generator for CBOR-stable Conway block chains, so downstream repos don't carry their own protocol-level fixture logic.

This is the first half of the cross-repo move tracked by **blinklabs-io/dingo#2233**: dingo currently has an in-tree `generateTestChain`/`computeBlockBodyHash` in `chain/chain_test.go`, which violates the policy that ledger/consensus/network mocks live in the shared library. Once this lands and is released, dingo bumps its dependency and swaps to these helpers.

## What's added (`fixtures/chain.go`)
- `GenerateConwayChain(startBlockNumber uint64, prevHash common.Blake2b256, startSlot, slotIncrement uint64, count int) ([]ledger.Block, error)` — builds `count` Conway blocks chained via `PrevHash`, whose CBOR round-trips through `ledger.NewBlockFromCbor` so a consumer recovers the same `Hash()`/`PrevHash()`. Empty bodies → constant block-body hash. `count <= 0` returns an empty, non-nil slice.
- `ComputeBlockBodyHash(parts ...[]byte) common.Blake2b256` — `blake2b256(blake2b256(p0) || blake2b256(p1) ...)`, matching `common.ValidateBlockBodyHash`'s derivation.

Returns `(T, error)` rather than taking `testing.TB`, per the package convention (tests/cmd handle errors locally). Lives in `fixtures/` — whose package doc already names dingo as a consumer.

## Tests (`fixtures/chain_test.go`)
`go test -race ./fixtures/` passes:
- round-trip stability of `Hash`/`PrevHash`/`BlockNumber`/`SlotNumber` + chain linkage
- first block honors the caller-supplied `prevHash` (so chains can be grafted to build forks)
- non-positive count → empty, non-nil slice
- `ComputeBlockBodyHash` determinism + order-sensitivity

## Checks
`go build ./...`, `go test -race ./fixtures/`, `golangci-lint run ./fixtures/` — all clean. `go mod tidy` promoted `golang.org/x/crypto` to a direct dependency (blake2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable generator for CBOR-stable Conway block chains to share protocol-level fixtures across repos. Supports `blinklabs-io/dingo#2233` by replacing in-tree chain mocks with shared helpers.

- New Features
  - `fixtures/chain.go`: `GenerateConwayChain(...)` builds N Conway blocks with stable CBOR and correct `Hash()`/`PrevHash()` linkage; honors the supplied `prevHash`; `count <= 0` returns an empty, non-nil slice.
  - `ComputeBlockBodyHash(...)`: computes body hash as concatenated `blake2b256` of part hashes, matching `common.ValidateBlockBodyHash`.

- Dependencies
  - Promoted `golang.org/x/crypto` to a direct dependency.

<sup>Written for commit 220ce280a3c58a0bc09efba44d632a1b055efa29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utilities to generate deterministic blockchain fixture chains for testing and tooling.
  * Added a helper to compute block body hashes in a consistent way.

* **Tests**
  * Added coverage for chain generation, block linking, hash stability, and empty-input handling.

* **Chores**
  * Updated dependency metadata to reflect direct usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->