### PR TITLE
feat(chainsync): add observable server-callback test harness

### DIFF
--- a/chainsync/doc.go
+++ b/chainsync/doc.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chainsync provides an observable server-callback test harness for the
+// Ouroboros chain-sync mini-protocol.
+//
+// The harness stands up a real gouroboros chain-sync server (the system under
+// test), configured with the caller's own [github.com/blinklabs-io/gouroboros/protocol/chainsync.Config]
+// callbacks, and connects it to a lightweight mock client driver over an
+// in-memory pipe. Tests drive the server by sending FindIntersect and
+// RequestNext, and observe every message the server sends back — RollForward,
+// RollBackward, AwaitReply, IntersectFound, and IntersectNotFound — decoded and
+// delivered over a channel. All synchronization is channel-based; the harness
+// never sleeps.
+//
+// Both node-to-node (NtN) and node-to-client (NtC) modes are supported via
+// [Config.Mode].
+//
+// # Composition with builders
+//
+// The harness deliberately exposes only standard gouroboros protocol types
+// (points, tips, block CBOR) so it composes with the message/conversation
+// builders and block builders tracked in this repository. The block helpers in
+// this package ([BuildChain], [PointOf], [TipOf]) wrap
+// [github.com/blinklabs-io/ouroboros-mock/fixtures.GenerateConwayChain] to
+// produce chains whose points and tips line up with what a server callback
+// would report. Callers who need richer, multi-era blocks can substitute the
+// block builders and continue to use [PointOf]/[TipOf] to derive the matching
+// points and tips.
+package chainsync

--- a/chainsync/example_test.go
+++ b/chainsync/example_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	csmock "github.com/blinklabs-io/ouroboros-mock/chainsync"
+)
+
+// exampleChainServer is the kind of chain-sync server a downstream consumer
+// (e.g. dingo) writes: it serves a fixed chain and tracks a per-connection read
+// cursor. It implements the two chain-sync server callbacks — FindIntersect and
+// RequestNext — using nothing but standard gouroboros types, so the harness can
+// drive it without any knowledge of consumer-specific internals.
+//
+// The RequestNext behaviour follows the usual node convention: the first reply
+// after an intersect is a RollBackward to the intersection point, subsequent
+// replies roll the chain forward block by block, and once the chain is
+// exhausted the server parks the client with AwaitReply.
+type exampleChainServer struct {
+	mu         sync.Mutex
+	chain      csmock.Chain
+	cursor     int  // index of the next block to roll forward
+	rolledBack bool // whether the post-intersect rollback has been sent
+}
+
+func (s *exampleChainServer) findIntersect(
+	_ chainsync.CallbackContext,
+	points []pcommon.Point,
+) (pcommon.Point, chainsync.Tip, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rolledBack = false
+	// Match the first requested point that exists on our chain.
+	for _, p := range points {
+		for i, cp := range s.chain.Points {
+			if pointsEqual(p, cp) {
+				s.cursor = i + 1
+				return cp, s.chain.Tip(), nil
+			}
+		}
+	}
+	// Otherwise intersect at origin and serve from the start of the chain.
+	s.cursor = 0
+	return csmock.OriginPoint(), s.chain.Tip(), nil
+}
+
+func (s *exampleChainServer) requestNext(ctx chainsync.CallbackContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// First reply after an intersect is a rollback to the intersection point.
+	if !s.rolledBack {
+		s.rolledBack = true
+		point := csmock.OriginPoint()
+		if s.cursor > 0 {
+			point = s.chain.Points[s.cursor-1]
+		}
+		return ctx.Server.RollBackward(point, s.chain.Tip())
+	}
+	// Chain exhausted: park the client until more blocks arrive.
+	if s.cursor >= s.chain.Len() {
+		return ctx.Server.AwaitReply()
+	}
+	// Roll the next block forward.
+	block := s.chain.Blocks[s.cursor]
+	tip := s.chain.Tips[s.cursor]
+	s.cursor++
+	return ctx.Server.RollForward(uint(block.Type()), block.Cbor(), tip)
+}
+
+func pointsEqual(a, b pcommon.Point) bool {
+	return a.Slot == b.Slot && bytes.Equal(a.Hash, b.Hash)
+}
+
+// TestExampleDriveChainServer is an end-to-end walkthrough of using the harness
+// as an external consumer would: stand up a chain-sync server, drive it through
+// a full intersect → rollback → roll-forward → await-reply sequence, and assert
+// on the messages the server emits at each step.
+func TestExampleDriveChainServer(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Build a small Conway chain to serve. In a real test the block builders
+	// (issue #199) could substitute richer, multi-era blocks here.
+	chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 3)
+	require.NoError(t, err)
+
+	srv := &exampleChainServer{chain: chain}
+
+	h, err := csmock.New(csmock.Config{
+		Mode: csmock.ModeNtC,
+		ChainSync: chainsync.NewConfig(
+			chainsync.WithFindIntersectFunc(srv.findIntersect),
+			chainsync.WithRequestNextFunc(srv.requestNext),
+		),
+	})
+	require.NoError(t, err)
+	defer h.Close()
+
+	// 1. Find an intersection at origin.
+	require.NoError(t, h.FindIntersect([]pcommon.Point{csmock.OriginPoint()}))
+	found := observe(t, h)
+	require.True(t, found.IsIntersectFound())
+	gotPoint, ok := found.Point()
+	require.True(t, ok)
+	require.Equal(t, csmock.OriginPoint(), gotPoint)
+
+	// 2. The first RequestNext yields a rollback to the intersection point.
+	require.NoError(t, h.RequestNext())
+	rollback := observe(t, h)
+	require.True(t, rollback.IsRollBackward())
+	rbPoint, ok := rollback.Point()
+	require.True(t, ok)
+	require.Equal(t, csmock.OriginPoint(), rbPoint)
+
+	// 3. Subsequent RequestNext calls roll each block forward in order.
+	for i := range chain.Len() {
+		require.NoError(t, h.RequestNext())
+		forward := observe(t, h)
+		require.True(t, forward.IsRollForward())
+		_, blockCbor, tip, ok := forward.RollForwardNtC()
+		require.True(t, ok)
+		require.Equal(t, chain.Blocks[i].Cbor(), blockCbor)
+		require.Equal(t, chain.Tips[i], tip)
+	}
+
+	// 4. With the chain exhausted, the server parks us with AwaitReply.
+	require.NoError(t, h.RequestNext())
+	awaitReply := observe(t, h)
+	require.True(t, awaitReply.IsAwaitReply())
+}

--- a/chainsync/harness.go
+++ b/chainsync/harness.go
@@ -1,0 +1,450 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	gchainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/handshake"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+)
+
+// Mode selects the chain-sync protocol variant the harness negotiates.
+type Mode int
+
+const (
+	// ModeNtC drives the node-to-client chain-sync protocol (the default).
+	ModeNtC Mode = iota
+	// ModeNtN drives the node-to-node chain-sync protocol.
+	ModeNtN
+)
+
+const (
+	defaultObserveBuffer    = 32
+	defaultHandshakeTimeout = 10 * time.Second
+)
+
+// ErrClosed is returned by driver and observe operations after the harness has
+// been closed.
+var ErrClosed = errors.New("chainsync harness closed")
+
+// Config configures a [Harness].
+type Config struct {
+	// Mode selects NtN or NtC. The zero value is ModeNtC.
+	Mode Mode
+
+	// ChainSync is the chain-sync configuration for the server under test. Its
+	// FindIntersectFunc and RequestNextFunc callbacks are what the harness
+	// exercises. It is required.
+	ChainSync gchainsync.Config
+
+	// NetworkMagic is the handshake network magic. Defaults to
+	// ouroboros_mock.MockNetworkMagic when zero.
+	NetworkMagic uint32
+
+	// ObserveBuffer is the buffer size of the observed-message channel.
+	// Defaults to 32 when non-positive.
+	ObserveBuffer int
+
+	// HandshakeTimeout bounds how long New waits for the handshake to complete.
+	// Defaults to 10s when non-positive.
+	HandshakeTimeout time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.NetworkMagic == 0 {
+		c.NetworkMagic = ouroboros_mock.MockNetworkMagic
+	}
+	if c.ObserveBuffer <= 0 {
+		c.ObserveBuffer = defaultObserveBuffer
+	}
+	if c.HandshakeTimeout <= 0 {
+		c.HandshakeTimeout = defaultHandshakeTimeout
+	}
+	return c
+}
+
+// Harness wires a real gouroboros chain-sync server (the system under test) to
+// a mock client driver over an in-memory pipe. Tests drive the server with
+// [Harness.FindIntersect] and [Harness.RequestNext] and observe every message
+// the server emits with [Harness.Observe].
+//
+// A Harness must be created with [New] and released with [Harness.Close].
+type Harness struct {
+	cfg Config
+
+	sut    *ouroboros.Connection
+	server *gchainsync.Server
+
+	driverConn   net.Conn
+	muxer        *muxer.Muxer
+	recvChan     chan *muxer.Segment
+	csProtocolId uint16
+	msgFromCbor  protocol.MessageFromCborFunc
+
+	observed  chan ServerMessage
+	doneChan  chan struct{}
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+}
+
+// New creates and starts a Harness. It stands up the chain-sync server under
+// test, completes the handshake with the mock driver, and starts observing
+// server traffic. The returned Harness is ready to be driven.
+func New(cfg Config) (*Harness, error) {
+	cfg = cfg.withDefaults()
+
+	driverConn, sutConn := net.Pipe()
+
+	m := muxer.New(driverConn)
+	// A single ProtocolUnknown catch-all receiver collects inbound segments for
+	// every protocol, exactly as the scripted mock Connection does. The driver
+	// can still send on any protocol ID via muxer.Send.
+	_, recvChan, _ := m.RegisterProtocol(
+		muxer.ProtocolUnknown,
+		muxer.ProtocolRoleInitiator,
+	)
+	m.Start()
+
+	h := &Harness{
+		cfg:          cfg,
+		driverConn:   driverConn,
+		muxer:        m,
+		recvChan:     recvChan,
+		csProtocolId: cfg.Mode.chainSyncProtocolId(),
+		msgFromCbor:  cfg.Mode.msgFromCborFunc(),
+		observed:     make(chan ServerMessage, cfg.ObserveBuffer),
+		doneChan:     make(chan struct{}),
+	}
+
+	// ouroboros.New blocks until the handshake completes, so run it concurrently
+	// while the driver performs the client half of the handshake.
+	sutCh := make(chan sutResult, 1)
+	go func() {
+		conn, err := ouroboros.New(h.sutOptions(sutConn)...)
+		sutCh <- sutResult{conn: conn, err: err}
+	}()
+
+	if err := h.clientHandshake(); err != nil {
+		h.abort(sutCh, sutConn)
+		return nil, err
+	}
+
+	res := <-sutCh
+	if res.err != nil {
+		h.teardownDriver()
+		return nil, fmt.Errorf("server setup failed: %w", res.err)
+	}
+	h.sut = res.conn
+
+	// Start ONLY the chain-sync server. In NtN mode the block-fetch and
+	// tx-submission servers would otherwise emit unsolicited traffic onto the
+	// driver's catch-all channel; delaying and selectively starting keeps the
+	// observed stream limited to chain-sync.
+	cs := h.sut.ChainSync()
+	if cs == nil || cs.Server == nil {
+		_ = h.Close()
+		return nil, errors.New("chain-sync server was not initialized")
+	}
+	h.server = cs.Server
+	h.server.Start()
+
+	// The handshake response has been consumed; everything from here on is
+	// chain-sync traffic.
+	h.wg.Add(1)
+	go h.readLoop()
+
+	return h, nil
+}
+
+// sutResult carries the outcome of the concurrent ouroboros.New call.
+type sutResult struct {
+	conn *ouroboros.Connection
+	err  error
+}
+
+// abort cleans up after a failed handshake, ensuring the concurrently-running
+// ouroboros.New goroutine unblocks and its connection (if any) is closed.
+func (h *Harness) abort(sutCh <-chan sutResult, sutConn net.Conn) {
+	// Closing our side unblocks the server's handshake so its New returns.
+	h.teardownDriver()
+	_ = sutConn.Close()
+	res := <-sutCh
+	if res.conn != nil {
+		_ = res.conn.Close()
+	}
+}
+
+func (h *Harness) sutOptions(
+	sutConn net.Conn,
+) []ouroboros.ConnectionOptionFunc {
+	opts := []ouroboros.ConnectionOptionFunc{
+		ouroboros.WithConnection(sutConn),
+		ouroboros.WithNetworkMagic(h.cfg.NetworkMagic),
+		ouroboros.WithServer(true),
+		// Delay protocol start so we can start only chain-sync ourselves.
+		ouroboros.WithDelayProtocolStart(true),
+		ouroboros.WithChainSyncConfig(h.cfg.ChainSync),
+	}
+	if h.cfg.Mode == ModeNtN {
+		opts = append(opts, ouroboros.WithNodeToNode(true))
+	}
+	return opts
+}
+
+// clientHandshake sends ProposeVersions and consumes the server's
+// AcceptVersion so the server transitions into running the mini-protocols.
+func (h *Harness) clientHandshake() error {
+	proposeMsg := h.cfg.Mode.proposeVersionsMsg(h.cfg.NetworkMagic)
+	if err := h.sendSegment(handshake.ProtocolId, false, proposeMsg); err != nil {
+		return fmt.Errorf("send handshake propose: %w", err)
+	}
+	timer := time.NewTimer(h.cfg.HandshakeTimeout)
+	defer timer.Stop()
+	select {
+	case seg, ok := <-h.recvChan:
+		if !ok {
+			return errors.New(
+				"handshake failed: connection closed before response",
+			)
+		}
+		if seg.GetProtocolId() != handshake.ProtocolId {
+			return fmt.Errorf(
+				"handshake: unexpected protocol id %d",
+				seg.GetProtocolId(),
+			)
+		}
+		// Reaching here means the server accepted our proposal; the negotiated
+		// version detail is not needed by the harness.
+		return nil
+	case <-timer.C:
+		return errors.New("handshake timed out")
+	}
+}
+
+// FindIntersect drives the server with a FindIntersect request for the provided
+// points, invoking the server's FindIntersectFunc callback.
+func (h *Harness) FindIntersect(points []pcommon.Point) error {
+	return h.sendChainSync(gchainsync.NewMsgFindIntersect(points))
+}
+
+// RequestNext drives the server with a RequestNext request, invoking the
+// server's RequestNextFunc callback.
+func (h *Harness) RequestNext() error {
+	return h.sendChainSync(gchainsync.NewMsgRequestNext())
+}
+
+// SendDone sends a chain-sync Done message, asking the server to stop the
+// protocol. The server restarts its protocol instance in response.
+func (h *Harness) SendDone() error {
+	return h.sendChainSync(gchainsync.NewMsgDone())
+}
+
+func (h *Harness) sendChainSync(msg protocol.Message) error {
+	select {
+	case <-h.doneChan:
+		return ErrClosed
+	default:
+	}
+	return h.sendSegment(h.csProtocolId, false, msg)
+}
+
+func (h *Harness) sendSegment(
+	protocolId uint16,
+	isResponse bool,
+	msg protocol.Message,
+) error {
+	data := msg.Cbor()
+	if data == nil {
+		var err error
+		data, err = cbor.Encode(msg)
+		if err != nil {
+			return fmt.Errorf("encode message: %w", err)
+		}
+	}
+	seg := muxer.NewSegment(protocolId, data, isResponse)
+	if err := h.muxer.Send(seg); err != nil {
+		return fmt.Errorf("send segment: %w", err)
+	}
+	return nil
+}
+
+// Observe returns the next server message, blocking until one arrives, the
+// context is cancelled, or the harness is closed. It returns the context error
+// on cancellation and [ErrClosed] once the harness is closed and drained.
+func (h *Harness) Observe(ctx context.Context) (ServerMessage, error) {
+	select {
+	case <-ctx.Done():
+		return ServerMessage{}, ctx.Err()
+	case msg, ok := <-h.observed:
+		if !ok {
+			return ServerMessage{}, ErrClosed
+		}
+		return msg, nil
+	}
+}
+
+// Observed returns the channel of decoded server messages. It is closed once
+// the harness shuts down. Most callers should prefer [Harness.Observe].
+func (h *Harness) Observed() <-chan ServerMessage {
+	return h.observed
+}
+
+// ServerErrors returns the error channel of the server-under-test connection.
+// A protocol error raised by a server callback, or a send failure after
+// [Harness.Disconnect], is surfaced here.
+func (h *Harness) ServerErrors() <-chan error {
+	return h.sut.ErrorChan()
+}
+
+// Server returns the chain-sync server under test. Callbacks receive the same
+// server via their CallbackContext; this accessor is provided for tests that
+// push messages (e.g. a late RollForward after an AwaitReply) out of band.
+func (h *Harness) Server() *gchainsync.Server {
+	return h.server
+}
+
+// Disconnect abruptly closes the driver side of the connection without a
+// protocol Done. An in-flight or subsequent server send fails, which the server
+// surfaces on [Harness.ServerErrors]. Use it to exercise send-failure paths
+// deterministically. Call [Harness.Close] afterwards for full teardown.
+func (h *Harness) Disconnect() error {
+	return h.driverConn.Close()
+}
+
+// Close shuts down the harness: the server under test, the driver muxer, and
+// all goroutines. It is safe to call multiple times.
+func (h *Harness) Close() error {
+	h.closeOnce.Do(func() {
+		close(h.doneChan)
+		if h.sut != nil {
+			_ = h.sut.Close()
+		}
+		h.teardownDriver()
+		h.wg.Wait()
+	})
+	return nil
+}
+
+// teardownDriver stops the driver muxer and waits for its goroutines to fully
+// drain (signalled by the muxer error channel closing), so a subsequent
+// goleak check sees no lingering goroutines.
+func (h *Harness) teardownDriver() {
+	h.muxer.Stop()
+	// The muxer closes its error channel only after its internal goroutines
+	// have exited and the connection is closed; draining to closure guarantees
+	// a clean teardown.
+	for range h.muxer.ErrorChan() { //nolint:revive
+	}
+}
+
+func (h *Harness) readLoop() {
+	defer h.wg.Done()
+	defer close(h.observed)
+	var leftover []byte
+	for {
+		select {
+		case <-h.doneChan:
+			return
+		case seg, ok := <-h.recvChan:
+			if !ok {
+				return
+			}
+			if seg.GetProtocolId() != h.csProtocolId {
+				// Only chain-sync traffic is expected; ignore anything else.
+				continue
+			}
+			data := seg.Payload
+			if len(leftover) > 0 {
+				data = append(leftover, data...)
+				leftover = nil
+			}
+			for len(data) > 0 {
+				var raw cbor.RawMessage
+				n, err := cbor.Decode(data, &raw)
+				if err != nil {
+					// Message is split across segments; keep a private copy of
+					// the remainder and wait for more data.
+					leftover = append([]byte(nil), data...)
+					break
+				}
+				msgType, err := cbor.DecodeIdFromList(raw)
+				if err != nil || msgType < 0 {
+					// Undecodable framing; drop the rest of this segment.
+					break
+				}
+				msg, err := h.msgFromCbor(uint(msgType), raw)
+				if err != nil || msg == nil {
+					break
+				}
+				data = data[n:]
+				select {
+				case h.observed <- ServerMessage{msg: msg}:
+				case <-h.doneChan:
+					return
+				}
+			}
+		}
+	}
+}
+
+// chainSyncProtocolId returns the muxer protocol ID for the mode.
+func (m Mode) chainSyncProtocolId() uint16 {
+	if m == ModeNtN {
+		return gchainsync.ProtocolIdNtN
+	}
+	return gchainsync.ProtocolIdNtC
+}
+
+// msgFromCborFunc returns the chain-sync message decoder for the mode.
+func (m Mode) msgFromCborFunc() protocol.MessageFromCborFunc {
+	if m == ModeNtN {
+		return gchainsync.NewMsgFromCborNtN
+	}
+	return gchainsync.NewMsgFromCborNtC
+}
+
+// proposeVersionsMsg builds the handshake ProposeVersions message the driver
+// sends, mirroring the mock connection's negotiated versions.
+func (m Mode) proposeVersionsMsg(networkMagic uint32) protocol.Message {
+	if m == ModeNtN {
+		return handshake.NewMsgProposeVersions(protocol.ProtocolVersionMap{
+			ouroboros_mock.MockProtocolVersionNtN: protocol.VersionDataNtN13andUp{
+				VersionDataNtN11to12: protocol.VersionDataNtN11to12{
+					CborNetworkMagic:                       networkMagic,
+					CborInitiatorAndResponderDiffusionMode: protocol.DiffusionModeInitiatorOnly,
+					CborPeerSharing:                        protocol.PeerSharingModeNoPeerSharing,
+					CborQuery:                              protocol.QueryModeDisabled,
+				},
+			},
+		})
+	}
+	return handshake.NewMsgProposeVersions(protocol.ProtocolVersionMap{
+		ouroboros_mock.MockProtocolVersionNtC: protocol.VersionDataNtC9to14(
+			networkMagic,
+		),
+	})
+}

--- a/chainsync/harness.go
+++ b/chainsync/harness.go
@@ -109,6 +109,10 @@ type Harness struct {
 	doneChan  chan struct{}
 	wg        sync.WaitGroup
 	closeOnce sync.Once
+
+	// sendMu serializes whole messages onto the wire so that a multi-segment
+	// message is written contiguously even across concurrent driver calls.
+	sendMu sync.Mutex
 }
 
 // New creates and starts a Harness. It stands up the chain-sync server under
@@ -293,9 +297,13 @@ func (h *Harness) sendSegment(
 		}
 	}
 	// A muxer segment payload cannot exceed SegmentMaxPayloadLength, so split
-	// oversized messages into sequential fragments. muxer.Send is serialized,
-	// and the peer reassembles segments per protocol before decoding, so
-	// ordering is preserved. This mirrors the reassembly done in readLoop.
+	// oversized messages into sequential fragments. The peer reassembles
+	// segments per protocol before decoding. muxer.Send only serializes a
+	// single segment, so hold sendMu across the whole loop; otherwise a
+	// concurrent driver call could interleave its fragments and corrupt the
+	// peer's reassembled stream. This mirrors the reassembly done in readLoop.
+	h.sendMu.Lock()
+	defer h.sendMu.Unlock()
 	for {
 		chunk := data
 		if len(chunk) > muxer.SegmentMaxPayloadLength {

--- a/chainsync/harness.go
+++ b/chainsync/harness.go
@@ -258,7 +258,14 @@ func (h *Harness) RequestNext() error {
 }
 
 // SendDone sends a chain-sync Done message, asking the server to stop the
-// protocol. The server restarts its protocol instance in response.
+// protocol. It is the deterministic "protocol stop" control: a graceful stop
+// leaves the server-under-test with no protocol error on [Harness.ServerErrors].
+//
+// Done is terminal for the current drive. The gouroboros server handles it by
+// stopping and asynchronously re-initializing a fresh protocol instance, so a
+// request sent immediately after SendDone races that restart and may be
+// dropped. To continue driving after a Done, start a new [Harness] rather than
+// reusing this one.
 func (h *Harness) SendDone() error {
 	return h.sendChainSync(gchainsync.NewMsgDone())
 }
@@ -285,11 +292,30 @@ func (h *Harness) sendSegment(
 			return fmt.Errorf("encode message: %w", err)
 		}
 	}
-	seg := muxer.NewSegment(protocolId, data, isResponse)
-	if err := h.muxer.Send(seg); err != nil {
-		return fmt.Errorf("send segment: %w", err)
+	// A muxer segment payload cannot exceed SegmentMaxPayloadLength, so split
+	// oversized messages into sequential fragments. muxer.Send is serialized,
+	// and the peer reassembles segments per protocol before decoding, so
+	// ordering is preserved. This mirrors the reassembly done in readLoop.
+	for {
+		chunk := data
+		if len(chunk) > muxer.SegmentMaxPayloadLength {
+			chunk = chunk[:muxer.SegmentMaxPayloadLength]
+		}
+		seg := muxer.NewSegment(protocolId, chunk, isResponse)
+		if seg == nil {
+			return fmt.Errorf(
+				"failed to build muxer segment for %d-byte fragment",
+				len(chunk),
+			)
+		}
+		if err := h.muxer.Send(seg); err != nil {
+			return fmt.Errorf("send segment: %w", err)
+		}
+		data = data[len(chunk):]
+		if len(data) == 0 {
+			return nil
+		}
 	}
-	return nil
 }
 
 // Observe returns the next server message, blocking until one arrives, the

--- a/chainsync/harness_test.go
+++ b/chainsync/harness_test.go
@@ -222,6 +222,54 @@ func TestFindIntersectOversizedPayload(t *testing.T) {
 	require.Equal(t, numPoints, <-gotCount)
 }
 
+// Concurrent driver calls, each sending a multi-segment message, must not
+// interleave their fragments on the wire: every message the server decodes
+// must carry the full point set, and no CBOR-decode error may surface.
+func TestConcurrentOversizedSends(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	const numPoints = 2000
+	const senders = 4
+	points := make([]pcommon.Point, numPoints)
+	for i := range points {
+		hash := make([]byte, 32)
+		binary.BigEndian.PutUint64(hash, uint64(i))
+		points[i] = pcommon.NewPoint(uint64(i), hash)
+	}
+
+	gotCounts := make(chan int, senders)
+	r := &responder{
+		findIntersect: func(p []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+			gotCounts <- len(p)
+			return csmock.OriginPoint(), chainsync.Tip{}, nil
+		},
+	}
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+
+	sendErrs := make(chan error, senders)
+	for range senders {
+		go func() { sendErrs <- h.FindIntersect(points) }()
+	}
+	for range senders {
+		require.NoError(t, <-sendErrs)
+	}
+
+	// Every response must be a well-formed IntersectFound whose request
+	// carried all the points; interleaved fragments would corrupt decoding.
+	for range senders {
+		msg := observe(t, h)
+		require.True(t, msg.IsIntersectFound(), "expected IntersectFound")
+		require.Equal(t, numPoints, <-gotCounts)
+	}
+
+	select {
+	case err := <-h.ServerErrors():
+		require.NoError(t, err)
+	default:
+	}
+}
+
 // Drive RequestNext and distinguish the roll-forward path. In NtC the full
 // block CBOR round-trips; in NtN the wrapped header and tip are observed.
 func TestRequestNextRollForward(t *testing.T) {

--- a/chainsync/harness_test.go
+++ b/chainsync/harness_test.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	csmock "github.com/blinklabs-io/ouroboros-mock/chainsync"
+)
+
+// serverAction performs a single outbound send from within a RequestNext
+// callback.
+type serverAction func(*chainsync.Server) error
+
+// responder is a scriptable chain-sync server implementation used to drive the
+// harness deterministically. FindIntersect and each RequestNext consult
+// caller-provided scripts, so tests control exactly which message the server
+// emits in response to each request.
+type responder struct {
+	mu sync.Mutex
+
+	findIntersect func([]pcommon.Point) (pcommon.Point, chainsync.Tip, error)
+	actions       []serverAction
+}
+
+func (r *responder) requestNext(ctx chainsync.CallbackContext) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.actions) == 0 {
+		return ctx.Server.AwaitReply()
+	}
+	action := r.actions[0]
+	r.actions = r.actions[1:]
+	return action(ctx.Server)
+}
+
+func (r *responder) config() chainsync.Config {
+	return chainsync.NewConfig(
+		chainsync.WithFindIntersectFunc(
+			func(_ chainsync.CallbackContext, points []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+				return r.findIntersect(points)
+			},
+		),
+		chainsync.WithRequestNextFunc(r.requestNext),
+	)
+}
+
+// newHarness starts a harness for the given mode wired to the responder. The
+// caller is responsible for closing it (typically `defer h.Close()` placed
+// after `defer goleak.VerifyNone(t)` so teardown runs before the leak check).
+func newHarness(
+	t *testing.T,
+	mode csmock.Mode,
+	r *responder,
+) *csmock.Harness {
+	t.Helper()
+	h, err := csmock.New(csmock.Config{
+		Mode:      mode,
+		ChainSync: r.config(),
+	})
+	require.NoError(t, err)
+	return h
+}
+
+// observe returns the next server message, failing the test on timeout.
+func observe(t *testing.T, h *csmock.Harness) csmock.ServerMessage {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	msg, err := h.Observe(ctx)
+	require.NoError(t, err)
+	return msg
+}
+
+func allModes() []struct {
+	name string
+	mode csmock.Mode
+} {
+	return []struct {
+		name string
+		mode csmock.Mode
+	}{
+		{"NtC", csmock.ModeNtC},
+		{"NtN", csmock.ModeNtN},
+	}
+}
+
+// Drive FindIntersect and verify the matched point and tip round-trip back to
+// the driver via IntersectFound.
+func TestFindIntersectFound(t *testing.T) {
+	for _, tc := range allModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 3)
+			require.NoError(t, err)
+			wantPoint := chain.Points[1]
+			wantTip := chain.Tip()
+
+			r := &responder{
+				findIntersect: func(points []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+					require.NotEmpty(t, points)
+					return wantPoint, wantTip, nil
+				},
+			}
+			h := newHarness(t, tc.mode, r)
+			defer h.Close()
+
+			require.NoError(t, h.FindIntersect(chain.Points))
+
+			msg := observe(t, h)
+			require.True(t, msg.IsIntersectFound(), "expected IntersectFound")
+
+			gotPoint, ok := msg.Point()
+			require.True(t, ok)
+			require.Equal(t, wantPoint, gotPoint)
+
+			gotTip, ok := msg.Tip()
+			require.True(t, ok)
+			require.Equal(t, wantTip, gotTip)
+		})
+	}
+}
+
+// A callback that returns ErrIntersectNotFound must produce an IntersectNotFound
+// carrying the tip.
+func TestFindIntersectNotFound(t *testing.T) {
+	for _, tc := range allModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 2)
+			require.NoError(t, err)
+			wantTip := chain.Tip()
+
+			r := &responder{
+				findIntersect: func([]pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+					return pcommon.Point{}, wantTip, chainsync.ErrIntersectNotFound
+				},
+			}
+			h := newHarness(t, tc.mode, r)
+			defer h.Close()
+
+			require.NoError(
+				t,
+				h.FindIntersect([]pcommon.Point{csmock.OriginPoint()}),
+			)
+
+			msg := observe(t, h)
+			require.True(
+				t,
+				msg.IsIntersectNotFound(),
+				"expected IntersectNotFound",
+			)
+
+			gotTip, ok := msg.Tip()
+			require.True(t, ok)
+			require.Equal(t, wantTip, gotTip)
+		})
+	}
+}
+
+// Drive RequestNext and distinguish the roll-forward path. In NtC the full
+// block CBOR round-trips; in NtN the wrapped header and tip are observed.
+func TestRequestNextRollForward(t *testing.T) {
+	for _, tc := range allModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 1)
+			require.NoError(t, err)
+			block := chain.Blocks[0]
+			tip := chain.Tips[0]
+
+			r := &responder{
+				actions: []serverAction{
+					func(s *chainsync.Server) error {
+						return s.RollForward(
+							uint(block.Type()),
+							block.Cbor(),
+							tip,
+						)
+					},
+				},
+			}
+			h := newHarness(t, tc.mode, r)
+			defer h.Close()
+
+			require.NoError(t, h.RequestNext())
+
+			msg := observe(t, h)
+			require.True(t, msg.IsRollForward(), "expected RollForward")
+
+			gotTip, ok := msg.Tip()
+			require.True(t, ok)
+			require.Equal(t, tip, gotTip)
+
+			switch tc.mode {
+			case csmock.ModeNtC:
+				blockType, blockCbor, rfTip, ok := msg.RollForwardNtC()
+				require.True(t, ok)
+				require.Equal(t, uint(block.Type()), blockType)
+				require.Equal(t, block.Cbor(), blockCbor)
+				require.Equal(t, tip, rfTip)
+			case csmock.ModeNtN:
+				header, rfTip, ok := msg.RollForwardNtN()
+				require.True(t, ok)
+				require.Equal(t, tip, rfTip)
+				require.NotEmpty(t, header.HeaderCbor())
+			}
+		})
+	}
+}
+
+// Drive RequestNext and distinguish the rollback path, verifying the point and
+// tip.
+func TestRequestNextRollBackward(t *testing.T) {
+	for _, tc := range allModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 2)
+			require.NoError(t, err)
+			rollbackPoint := chain.Points[0]
+			tip := chain.Tip()
+
+			r := &responder{
+				actions: []serverAction{
+					func(s *chainsync.Server) error {
+						return s.RollBackward(rollbackPoint, tip)
+					},
+				},
+			}
+			h := newHarness(t, tc.mode, r)
+			defer h.Close()
+
+			require.NoError(t, h.RequestNext())
+
+			msg := observe(t, h)
+			require.True(t, msg.IsRollBackward(), "expected RollBackward")
+
+			gotPoint, ok := msg.Point()
+			require.True(t, ok)
+			require.Equal(t, rollbackPoint, gotPoint)
+
+			gotTip, ok := msg.Tip()
+			require.True(t, ok)
+			require.Equal(t, tip, gotTip)
+		})
+	}
+}
+
+// A server may answer RequestNext with AwaitReply and deliver the block later
+// out of band. The harness observes both, exercising the Server accessor.
+func TestRequestNextAwaitReplyThenRollForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 1)
+	require.NoError(t, err)
+	block := chain.Blocks[0]
+	tip := chain.Tips[0]
+
+	r := &responder{
+		actions: []serverAction{
+			func(s *chainsync.Server) error { return s.AwaitReply() },
+		},
+	}
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+
+	require.NoError(t, h.RequestNext())
+
+	awaitMsg := observe(t, h)
+	require.True(t, awaitMsg.IsAwaitReply(), "expected AwaitReply")
+
+	// Deliver the block out of band via the server accessor.
+	require.NoError(
+		t,
+		h.Server().RollForward(uint(block.Type()), block.Cbor(), tip),
+	)
+
+	fwdMsg := observe(t, h)
+	require.True(t, fwdMsg.IsRollForward(), "expected RollForward")
+	gotTip, ok := fwdMsg.Tip()
+	require.True(t, ok)
+	require.Equal(t, tip, gotTip)
+}
+
+// Disconnecting the driver while the server is mid-callback deterministically
+// fails the server's send path and surfaces a non-nil error on ServerErrors.
+// The callback is held in CanAwait (a non-idle state) across the disconnect, so
+// gouroboros never treats the close as graceful and never suppresses the error.
+func TestSendFailureOnDisconnect(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 1)
+	require.NoError(t, err)
+	block := chain.Blocks[0]
+	tip := chain.Tips[0]
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
+	// Always release the blocked callback so its goroutine can exit before the
+	// leak check, even if an assertion fails first.
+	defer doRelease()
+
+	r := &responder{
+		actions: []serverAction{
+			func(s *chainsync.Server) error {
+				close(entered)
+				<-release
+				// The connection is gone by now; this send fails.
+				return s.RollForward(uint(block.Type()), block.Cbor(), tip)
+			},
+		},
+	}
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+
+	require.NoError(t, h.RequestNext())
+
+	// Wait until the callback is executing (chain-sync now in CanAwait), then
+	// disconnect the driver while the protocol is non-idle.
+	<-entered
+	require.NoError(t, h.Disconnect())
+
+	select {
+	case err, ok := <-h.ServerErrors():
+		require.True(t, ok, "expected an error, not a closed channel")
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server send failure")
+	}
+
+	// Let the callback attempt its (doomed) send and unwind.
+	doRelease()
+}
+
+// Observe honours context cancellation without any sleeps.
+func TestObserveCancellation(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	r := &responder{
+		findIntersect: func([]pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+			return pcommon.Point{}, chainsync.Tip{}, nil
+		},
+	}
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := h.Observe(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// Observe returns ErrClosed once the harness is closed.
+func TestObserveAfterClose(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	r := &responder{
+		findIntersect: func([]pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+			return pcommon.Point{}, chainsync.Tip{}, nil
+		},
+	}
+	h, err := csmock.New(
+		csmock.Config{Mode: csmock.ModeNtC, ChainSync: r.config()},
+	)
+	require.NoError(t, err)
+	require.NoError(t, h.Close())
+
+	_, err = h.Observe(context.Background())
+	require.ErrorIs(t, err, csmock.ErrClosed)
+}

--- a/chainsync/harness_test.go
+++ b/chainsync/harness_test.go
@@ -16,6 +16,7 @@ package chainsync_test
 
 import (
 	"context"
+	"encoding/binary"
 	"sync"
 	"testing"
 	"time"
@@ -118,9 +119,14 @@ func TestFindIntersectFound(t *testing.T) {
 			wantPoint := chain.Points[1]
 			wantTip := chain.Tip()
 
+			// The callback runs on the server goroutine, where require's
+			// FailNow (runtime.Goexit) would only unwind the callback and
+			// hang the test. Capture the received points and assert them on
+			// the test goroutine instead.
+			gotPoints := make(chan []pcommon.Point, 1)
 			r := &responder{
 				findIntersect: func(points []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
-					require.NotEmpty(t, points)
+					gotPoints <- points
 					return wantPoint, wantTip, nil
 				},
 			}
@@ -139,6 +145,9 @@ func TestFindIntersectFound(t *testing.T) {
 			gotTip, ok := msg.Tip()
 			require.True(t, ok)
 			require.Equal(t, wantTip, gotTip)
+
+			// The server received exactly the points we drove it with.
+			require.Equal(t, chain.Points, <-gotPoints)
 		})
 	}
 }
@@ -179,6 +188,38 @@ func TestFindIntersectNotFound(t *testing.T) {
 			require.Equal(t, wantTip, gotTip)
 		})
 	}
+}
+
+// A FindIntersect whose encoded form exceeds a single muxer segment
+// (SegmentMaxPayloadLength) must be split across segments by the driver and
+// reassembled by the server, delivering every point to the callback.
+func TestFindIntersectOversizedPayload(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// ~40 bytes/point encoded; 3000 points is well over the 65535-byte limit.
+	const numPoints = 3000
+	points := make([]pcommon.Point, numPoints)
+	for i := range points {
+		hash := make([]byte, 32)
+		binary.BigEndian.PutUint64(hash, uint64(i))
+		points[i] = pcommon.NewPoint(uint64(i), hash)
+	}
+
+	gotCount := make(chan int, 1)
+	r := &responder{
+		findIntersect: func(p []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+			gotCount <- len(p)
+			return csmock.OriginPoint(), chainsync.Tip{}, nil
+		},
+	}
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+
+	require.NoError(t, h.FindIntersect(points))
+
+	msg := observe(t, h)
+	require.True(t, msg.IsIntersectFound(), "expected IntersectFound")
+	require.Equal(t, numPoints, <-gotCount)
 }
 
 // Drive RequestNext and distinguish the roll-forward path. In NtC the full

--- a/chainsync/helpers.go
+++ b/chainsync/helpers.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	gchainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+)
+
+// OriginPoint returns the point representing the origin of the chain, suitable
+// for a FindIntersect request that should always match.
+func OriginPoint() pcommon.Point {
+	return pcommon.NewPointOrigin()
+}
+
+// PointOf returns the chain-sync point (slot + block hash) for a block.
+func PointOf(block ledger.Block) pcommon.Point {
+	return pcommon.NewPoint(block.SlotNumber(), block.Hash().Bytes())
+}
+
+// TipOf returns the chain-sync tip (point + block number) for a block, as a
+// server callback would report when the block is the current chain tip.
+func TipOf(block ledger.Block) gchainsync.Tip {
+	return gchainsync.Tip{
+		Point:       PointOf(block),
+		BlockNumber: block.BlockNumber(),
+	}
+}
+
+// Chain is a generated sequence of connected blocks together with the
+// chain-sync points and tips derived from them. The three slices are parallel:
+// Points[i] and Tips[i] describe Blocks[i].
+type Chain struct {
+	Blocks []ledger.Block
+	Points []pcommon.Point
+	Tips   []gchainsync.Tip
+}
+
+// Tip returns the tip of the whole chain (the point and block number of the
+// last block). It returns a zero tip for an empty chain.
+func (c Chain) Tip() gchainsync.Tip {
+	if len(c.Tips) == 0 {
+		return gchainsync.Tip{}
+	}
+	return c.Tips[len(c.Tips)-1]
+}
+
+// Len returns the number of blocks in the chain.
+func (c Chain) Len() int {
+	return len(c.Blocks)
+}
+
+// BuildChain generates count connected Conway blocks and derives the matching
+// chain-sync points and tips. It composes
+// [github.com/blinklabs-io/ouroboros-mock/fixtures.GenerateConwayChain]; see
+// that function for the block layout (slots, block numbers, and prev-hash
+// linkage). A count of zero or less returns an empty, non-nil Chain.
+func BuildChain(
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	count int,
+) (Chain, error) {
+	blocks, err := fixtures.GenerateConwayChain(
+		startBlockNumber,
+		prevHash,
+		startSlot,
+		slotIncrement,
+		count,
+	)
+	if err != nil {
+		return Chain{}, err
+	}
+	chain := Chain{
+		Blocks: blocks,
+		Points: make([]pcommon.Point, len(blocks)),
+		Tips:   make([]gchainsync.Tip, len(blocks)),
+	}
+	for i, block := range blocks {
+		chain.Points[i] = PointOf(block)
+		chain.Tips[i] = TipOf(block)
+	}
+	return chain, nil
+}

--- a/chainsync/message.go
+++ b/chainsync/message.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"github.com/blinklabs-io/gouroboros/protocol"
+	gchainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// ServerMessage is a single outbound chain-sync message observed coming from
+// the server under test. It wraps the decoded gouroboros protocol message and
+// provides typed accessors for the values a test typically asserts on.
+type ServerMessage struct {
+	msg protocol.Message
+}
+
+// Type returns the chain-sync message type. Compare against the
+// gouroboros chainsync.MessageType* constants (e.g.
+// [github.com/blinklabs-io/gouroboros/protocol/chainsync.MessageTypeRollForward]).
+func (m ServerMessage) Type() uint {
+	if m.msg == nil {
+		return 0
+	}
+	return uint(m.msg.Type())
+}
+
+// Message returns the underlying decoded gouroboros protocol message. Callers
+// needing era-specific or wrapper detail can type-assert it to the concrete
+// chain-sync message type (e.g. *chainsync.MsgRollForwardNtC).
+func (m ServerMessage) Message() protocol.Message {
+	return m.msg
+}
+
+// IsRollForward reports whether the message is a RollForward (NtN or NtC).
+func (m ServerMessage) IsRollForward() bool {
+	return m.Type() == gchainsync.MessageTypeRollForward
+}
+
+// IsRollBackward reports whether the message is a RollBackward.
+func (m ServerMessage) IsRollBackward() bool {
+	return m.Type() == gchainsync.MessageTypeRollBackward
+}
+
+// IsAwaitReply reports whether the message is an AwaitReply.
+func (m ServerMessage) IsAwaitReply() bool {
+	return m.Type() == gchainsync.MessageTypeAwaitReply
+}
+
+// IsIntersectFound reports whether the message is an IntersectFound.
+func (m ServerMessage) IsIntersectFound() bool {
+	return m.Type() == gchainsync.MessageTypeIntersectFound
+}
+
+// IsIntersectNotFound reports whether the message is an IntersectNotFound.
+func (m ServerMessage) IsIntersectNotFound() bool {
+	return m.Type() == gchainsync.MessageTypeIntersectNotFound
+}
+
+// Tip returns the chain tip carried by the message and true, for the message
+// types that carry one (RollForward, RollBackward, IntersectFound,
+// IntersectNotFound). It returns a zero tip and false otherwise (e.g.
+// AwaitReply).
+func (m ServerMessage) Tip() (gchainsync.Tip, bool) {
+	switch msg := m.msg.(type) {
+	case *gchainsync.MsgRollForwardNtN:
+		return msg.Tip, true
+	case *gchainsync.MsgRollForwardNtC:
+		return msg.Tip, true
+	case *gchainsync.MsgRollBackward:
+		return msg.Tip, true
+	case *gchainsync.MsgIntersectFound:
+		return msg.Tip, true
+	case *gchainsync.MsgIntersectNotFound:
+		return msg.Tip, true
+	default:
+		return gchainsync.Tip{}, false
+	}
+}
+
+// Point returns the point carried by the message and true, for the message
+// types that carry one (RollBackward, IntersectFound). It returns a zero point
+// and false otherwise.
+func (m ServerMessage) Point() (pcommon.Point, bool) {
+	switch msg := m.msg.(type) {
+	case *gchainsync.MsgRollBackward:
+		return msg.Point, true
+	case *gchainsync.MsgIntersectFound:
+		return msg.Point, true
+	default:
+		return pcommon.Point{}, false
+	}
+}
+
+// RollForwardNtC returns the block type, block CBOR and tip of an NtC
+// RollForward message. The final return value is false if the message is not an
+// NtC RollForward.
+func (m ServerMessage) RollForwardNtC() (uint, []byte, gchainsync.Tip, bool) {
+	msg, ok := m.msg.(*gchainsync.MsgRollForwardNtC)
+	if !ok {
+		return 0, nil, gchainsync.Tip{}, false
+	}
+	return msg.BlockType(), msg.BlockCbor(), msg.Tip, true
+}
+
+// RollForwardNtN returns the wrapped header and tip of an NtN RollForward
+// message. The final return value is false if the message is not an NtN
+// RollForward.
+func (m ServerMessage) RollForwardNtN() (gchainsync.WrappedHeader, gchainsync.Tip, bool) {
+	msg, ok := m.msg.(*gchainsync.MsgRollForwardNtN)
+	if !ok {
+		return gchainsync.WrappedHeader{}, gchainsync.Tip{}, false
+	}
+	return msg.WrappedHeader, msg.Tip, true
+}


### PR DESCRIPTION
## Summary

Adds a reusable, observable chain-sync **server-callback** test harness under a new `chainsync/` package. It stands up a real gouroboros chain-sync server (the system under test), configured with the caller's own `chainsync.Config` callbacks, wired to a lightweight mock client driver over an in-memory `net.Pipe`. Tests drive the server and observe every decoded outbound message over a channel — no `time.Sleep`-based synchronization.

This replaces the brittle scripted-conversation pattern (real server + scripted `ouroboros_mock.Connection` with `ConversationEntrySleep`) that downstreams have duplicated.

## What it provides

- **Connected client/server** in both **NtN** and **NtC** modes (`Config.Mode`).
- **Drivers:** `FindIntersect(points)`, `RequestNext()`, `SendDone()`.
- **Observation:** `Observe(ctx)` / `Observed()` deliver decoded `RollForward`, `RollBackward`, `AwaitReply`, `IntersectFound`, and `IntersectNotFound` messages, with typed accessors (`Tip()`, `Point()`, `RollForwardNtC/NtN()`, `IsAwaitReply()`, …).
- **Deterministic controls:** `Disconnect()` (abrupt close → send failure), `Close()` (goleak-clean teardown), `ServerErrors()`, `Server()` for out-of-band pushes (e.g. a late RollForward after AwaitReply).
- **Helpers:** `OriginPoint`, `PointOf`, `TipOf`, and `BuildChain` composing the existing `fixtures.GenerateConwayChain` so points/tips line up with what a server callback reports.
- API uses only standard gouroboros types, so it composes with the message/conversation builders and block builders.

Internals: only the chain-sync server is started (`WithDelayProtocolStart`), so in NtN mode block-fetch/tx-submission never emit unsolicited traffic onto the observation stream. The driver is a raw muxer using a `ProtocolUnknown` catch-all, mirroring the existing mock `Connection`.

## Tests

- FindIntersect found/not-found (points + tips), NtN & NtC
- RequestNext distinguishing roll-forward vs rollback vs await-reply
- Deterministic send-failure via `Disconnect()` (callback held in a non-idle state so the error is never suppressed) and context cancellation
- `goleak.VerifyNone` on every test; green under `go test -race -count=50`
- External-consumer example test driving a full intersect → rollback → roll-forward → await-reply sequence

`go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` (0 issues), and `go mod tidy` (no dependency changes) all pass.

## Note

The package is named `chainsync`, which collides with gouroboros's `protocol/chainsync` (consumers alias one; tests use `csmock`). Happy to rename to something non-colliding (e.g. `chainsynctest`) if preferred.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an observable `chainsync` server-callback test harness that runs a real `gouroboros` chain-sync server (NtN/NtC), drives it with a mock client, and streams decoded server messages without sleeps. Also fixes oversized payload handling and concurrent multi-segment send interleaving; documents `SendDone` behavior.

- **New Features**
  - Real connected client/server for NtN and NtC.
  - Driver calls: FindIntersect, RequestNext, SendDone.
  - Observe decoded RollForward/RollBackward/AwaitReply/Intersect* via Observe(ctx) or Observed().
  - Deterministic controls: Disconnect, Close, ServerErrors, and Server() for out-of-band sends.
  - Helpers: OriginPoint, PointOf, TipOf, BuildChain (points/tips align with callbacks).
  - Only chain-sync server started; uses standard `gouroboros` types.

- **Bug Fixes**
  - Fragment oversized muxer payloads; added regression with a 3000-point FindIntersect.
  - Serialize multi-segment sends to prevent interleaving and CBOR corruption; added concurrent oversized-send test.
  - Safer tests: no require/assert inside server goroutines; verify on the test goroutine.
  - Document that SendDone is terminal for the current drive due to async server restart.

<sup>Written for commit e06bb02b1343c5ba03a5cad2df8e1caf68276f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chain-sync testing harness supporting NtC and NtN modes.
  * Added controls for intersections, next-block requests, completion, observation, errors, and lifecycle management.
  * Added helpers for building mock chains and deriving points and tips.
  * Added utilities for inspecting server messages, including roll forwards, rollbacks, intersections, and await responses.

* **Documentation**
  * Added package documentation and an end-to-end usage example.

* **Tests**
  * Added comprehensive coverage for chain-sync behavior, cancellation, shutdown, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->