### PR TITLE
feat: drep delegation

### DIFF
--- a/conformance/example_backend_test.go
+++ b/conformance/example_backend_test.go
@@ -132,7 +132,9 @@ func (s *stubBackend) UpdateAdaPots(p common.AdaPots) error {
 	return s.getInner().UpdateAdaPots(p)
 }
 
-func (s *stubBackend) GetRewardSnapshot(epoch uint64) (common.RewardSnapshot, error) {
+func (s *stubBackend) GetRewardSnapshot(
+	epoch uint64,
+) (common.RewardSnapshot, error) {
 	return s.getInner().GetRewardSnapshot(epoch)
 }
 

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -106,7 +106,6 @@ func (m *MockStateManager) LoadInitialState(
 	for _, hash := range state.DRepRegistrations {
 		m.drepRegistrations[hash] = true
 	}
-
 	// Load committee members
 	maps.Copy(m.committeeMembers, state.CommitteeMembers)
 
@@ -353,6 +352,8 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			credential := regCert.StakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			m.govState.DRepDelegations[credential] =
+				drepDelegation(regCert.Drep)
 		}
 
 	case common.CertificateTypeStakeVoteRegistrationDelegation:
@@ -361,6 +362,8 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			credential := regCert.StakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
+			m.govState.DRepDelegations[credential] =
+				drepDelegation(regCert.Drep)
 		}
 
 	case common.CertificateTypeStakeDelegation:
@@ -369,18 +372,24 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 		// No state change needed - delegation is tracked elsewhere in full implementation
 
 	case common.CertificateTypeVoteDelegation:
-		// Standalone vote delegation (without registration)
-		// Used for changing DRep delegation
-		// No state change needed - delegation is tracked elsewhere in full implementation
+		if voteCert, ok := cert.(*common.VoteDelegationCertificate); ok {
+			credential := voteCert.StakeCredential.Credential
+			m.govState.DRepDelegations[credential] =
+				drepDelegation(voteCert.Drep)
+		}
 
 	case common.CertificateTypeStakeVoteDelegation:
-		// Combined stake + vote delegation (without registration)
-		// No state change needed - delegation is tracked elsewhere in full implementation
+		if voteCert, ok := cert.(*common.StakeVoteDelegationCertificate); ok {
+			credential := voteCert.StakeCredential.Credential
+			m.govState.DRepDelegations[credential] =
+				drepDelegation(voteCert.Drep)
+		}
 
 	case common.CertificateTypeStakeDeregistration:
 		if deregCert, ok := cert.(*common.StakeDeregistrationCertificate); ok {
 			credential := deregCert.StakeCredential.Credential
 			delete(m.stakeRegistrations, credential)
+			delete(m.govState.DRepDelegations, credential)
 			m.govState.DeregisterStake(credential)
 		}
 
@@ -388,6 +397,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 		if deregCert, ok := cert.(*common.DeregistrationCertificate); ok {
 			credential := deregCert.StakeCredential.Credential
 			delete(m.stakeRegistrations, credential)
+			delete(m.govState.DRepDelegations, credential)
 			m.govState.DeregisterStake(credential)
 		}
 
@@ -436,6 +446,15 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 
 	default:
 		// Other certificate types not relevant for state tracking
+	}
+}
+
+func drepDelegation(drep common.Drep) common.DRepDelegation {
+	if len(drep.Credential) != common.AddressHashSize {
+		return common.DRepDelegation{}
+	}
+	return common.DRepDelegation{
+		DRep: common.NewBlake2b224(drep.Credential),
 	}
 }
 
@@ -770,6 +789,16 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 				}, nil
 			}
 			return nil, nil
+		},
+	)
+	drepDelegations := m.govState.DRepDelegations
+	builder.WithDRepDelegation(
+		func(cred common.Credential) (*common.DRepDelegation, error) {
+			delegation, ok := drepDelegations[cred.Credential]
+			if !ok {
+				return nil, nil
+			}
+			return &delegation, nil
 		},
 	)
 

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -784,14 +784,13 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 	)
 	drepDelegations := m.govState.DRepDelegations
 	builder.WithDRepDelegation(
-		func(cred common.Credential) (*common.DRepDelegation, error) {
+		func(cred common.Credential) (*common.Drep, error) {
 			delegation, ok := drepDelegations[cred.Credential]
 			if !ok {
 				return nil, nil
 			}
-			return &common.DRepDelegation{
-				DRep: common.NewBlake2b224(delegation.Credential),
-			}, nil
+			delegation.Credential = append([]byte(nil), delegation.Credential...)
+			return &delegation, nil
 		},
 	)
 

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -352,8 +352,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			credential := regCert.StakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
-			m.govState.DRepDelegations[credential] =
-				drepDelegation(regCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(regCert.Drep)
 		}
 
 	case common.CertificateTypeStakeVoteRegistrationDelegation:
@@ -362,8 +361,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			credential := regCert.StakeCredential.Credential
 			m.stakeRegistrations[credential] = 0
 			m.govState.RegisterStake(credential)
-			m.govState.DRepDelegations[credential] =
-				drepDelegation(regCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(regCert.Drep)
 		}
 
 	case common.CertificateTypeStakeDelegation:
@@ -374,15 +372,13 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	case common.CertificateTypeVoteDelegation:
 		if voteCert, ok := cert.(*common.VoteDelegationCertificate); ok {
 			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] =
-				drepDelegation(voteCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(voteCert.Drep)
 		}
 
 	case common.CertificateTypeStakeVoteDelegation:
 		if voteCert, ok := cert.(*common.StakeVoteDelegationCertificate); ok {
 			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] =
-				drepDelegation(voteCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(voteCert.Drep)
 		}
 
 	case common.CertificateTypeStakeDeregistration:
@@ -449,13 +445,8 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	}
 }
 
-func drepDelegation(drep common.Drep) common.DRepDelegation {
-	if len(drep.Credential) != common.AddressHashSize {
-		return common.DRepDelegation{}
-	}
-	return common.DRepDelegation{
-		DRep: common.NewBlake2b224(drep.Credential),
-	}
+func drepDelegation(drep common.Drep) common.Drep {
+	return drep
 }
 
 // ProcessEpochBoundary implements StateManager.ProcessEpochBoundary.
@@ -798,7 +789,9 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 			if !ok {
 				return nil, nil
 			}
-			return &delegation, nil
+			return &common.DRepDelegation{
+				DRep: common.NewBlake2b224(delegation.Credential),
+			}, nil
 		},
 	)
 

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -76,6 +76,9 @@ type GovernanceState struct {
 	// DRepRegistrations tracks registered DReps.
 	DRepRegistrations map[common.Blake2b224]bool
 
+	// DRepDelegations maps stake credentials to their delegated DRep.
+	DRepDelegations map[common.Blake2b224]common.DRepDelegation
+
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
 
@@ -125,6 +128,7 @@ func NewGovernanceState() *GovernanceState {
 	return &GovernanceState{
 		CommitteeMembers:     make(map[common.Blake2b224]*CommitteeMemberInfo),
 		DRepRegistrations:    make(map[common.Blake2b224]bool),
+		DRepDelegations:      make(map[common.Blake2b224]common.DRepDelegation),
 		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
 		StakeRegistrations:   make(map[common.Blake2b224]bool),
 		PoolRegistrations:    make(map[common.Blake2b224]bool),
@@ -143,6 +147,7 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	g.CommitteeMembers = make(map[common.Blake2b224]*CommitteeMemberInfo)
 	g.HotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
 	g.DRepRegistrations = make(map[common.Blake2b224]bool)
+	g.DRepDelegations = make(map[common.Blake2b224]common.DRepDelegation)
 	g.StakeRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRetirements = make(map[common.Blake2b224]uint64)
@@ -173,6 +178,7 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	for _, drepHash := range state.DRepRegistrations {
 		g.DRepRegistrations[drepHash] = true
 	}
+	maps.Copy(g.DRepDelegations, state.DRepDelegations)
 
 	// Load stake registrations
 	maps.Copy(g.StakeRegistrations, state.StakeRegistrations)

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -76,8 +76,9 @@ type GovernanceState struct {
 	// DRepRegistrations tracks registered DReps.
 	DRepRegistrations map[common.Blake2b224]bool
 
-	// DRepDelegations maps stake credentials to their delegated DRep.
-	DRepDelegations map[common.Blake2b224]common.DRepDelegation
+	// DRepDelegations maps stake credentials to their delegated DRep, including
+	// the special always-abstain and always-no-confidence DReps.
+	DRepDelegations map[common.Blake2b224]common.Drep
 
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
@@ -128,7 +129,7 @@ func NewGovernanceState() *GovernanceState {
 	return &GovernanceState{
 		CommitteeMembers:     make(map[common.Blake2b224]*CommitteeMemberInfo),
 		DRepRegistrations:    make(map[common.Blake2b224]bool),
-		DRepDelegations:      make(map[common.Blake2b224]common.DRepDelegation),
+		DRepDelegations:      make(map[common.Blake2b224]common.Drep),
 		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
 		StakeRegistrations:   make(map[common.Blake2b224]bool),
 		PoolRegistrations:    make(map[common.Blake2b224]bool),
@@ -147,7 +148,7 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	g.CommitteeMembers = make(map[common.Blake2b224]*CommitteeMemberInfo)
 	g.HotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
 	g.DRepRegistrations = make(map[common.Blake2b224]bool)
-	g.DRepDelegations = make(map[common.Blake2b224]common.DRepDelegation)
+	g.DRepDelegations = make(map[common.Blake2b224]common.Drep)
 	g.StakeRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRetirements = make(map[common.Blake2b224]uint64)

--- a/conformance/state_parser.go
+++ b/conformance/state_parser.go
@@ -62,6 +62,9 @@ type ParsedInitialState struct {
 	// DRepRegistrations contains registered DReps (credential hash).
 	DRepRegistrations []common.Blake2b224
 
+	// DRepDelegations maps stake credentials to their delegated DRep.
+	DRepDelegations map[common.Blake2b224]common.DRepDelegation
+
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
 
@@ -141,6 +144,7 @@ func ParseInitialState(raw cbor.RawMessage) (*ParsedInitialState, error) {
 		RewardAccounts:       make(map[common.Blake2b224]uint64),
 		PoolRegistrations:    make(map[common.Blake2b224]bool),
 		CommitteeMembers:     make(map[common.Blake2b224]uint64),
+		DRepDelegations:      make(map[common.Blake2b224]common.DRepDelegation),
 		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
 		Proposals:            make(map[string]GovActionInfo),
 		CostModels:           make(map[uint][]int64),
@@ -589,11 +593,32 @@ func parseDelegationState(
 						}
 					}
 				}
+				if len(vArr) >= 3 {
+					if drep := extractDRepDelegation(vArr[2]); drep != nil {
+						state.DRepDelegations[cred.Credential] = *drep
+					}
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+func extractDRepDelegation(raw any) *common.DRepDelegation {
+	if credential := extractCredentialHash(raw); credential != nil {
+		return &common.DRepDelegation{DRep: credential.Credential}
+	}
+	items, ok := raw.([]any)
+	if !ok || len(items) != 1 {
+		return nil
+	}
+	drepType, ok := items[0].(uint64)
+	if !ok || (drepType != common.DrepTypeAbstain &&
+		drepType != common.DrepTypeNoConfidence) {
+		return nil
+	}
+	return &common.DRepDelegation{}
 }
 
 // parseUtxoState extracts UTxOs, governance state, and cost models.

--- a/conformance/state_parser.go
+++ b/conformance/state_parser.go
@@ -62,8 +62,9 @@ type ParsedInitialState struct {
 	// DRepRegistrations contains registered DReps (credential hash).
 	DRepRegistrations []common.Blake2b224
 
-	// DRepDelegations maps stake credentials to their delegated DRep.
-	DRepDelegations map[common.Blake2b224]common.DRepDelegation
+	// DRepDelegations maps stake credentials to their delegated DRep, including
+	// the special always-abstain and always-no-confidence DReps.
+	DRepDelegations map[common.Blake2b224]common.Drep
 
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
@@ -144,7 +145,7 @@ func ParseInitialState(raw cbor.RawMessage) (*ParsedInitialState, error) {
 		RewardAccounts:       make(map[common.Blake2b224]uint64),
 		PoolRegistrations:    make(map[common.Blake2b224]bool),
 		CommitteeMembers:     make(map[common.Blake2b224]uint64),
-		DRepDelegations:      make(map[common.Blake2b224]common.DRepDelegation),
+		DRepDelegations:      make(map[common.Blake2b224]common.Drep),
 		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
 		Proposals:            make(map[string]GovActionInfo),
 		CostModels:           make(map[uint][]int64),
@@ -605,9 +606,12 @@ func parseDelegationState(
 	return nil
 }
 
-func extractDRepDelegation(raw any) *common.DRepDelegation {
+func extractDRepDelegation(raw any) *common.Drep {
 	if credential := extractCredentialHash(raw); credential != nil {
-		return &common.DRepDelegation{DRep: credential.Credential}
+		return &common.Drep{
+			Type:       int(credential.CredType),
+			Credential: append([]byte(nil), credential.Credential[:]...),
+		}
 	}
 	items, ok := raw.([]any)
 	if !ok || len(items) != 1 {
@@ -618,7 +622,7 @@ func extractDRepDelegation(raw any) *common.DRepDelegation {
 		drepType != common.DrepTypeNoConfidence) {
 		return nil
 	}
-	return &common.DRepDelegation{}
+	return &common.Drep{Type: int(drepType)}
 }
 
 // parseUtxoState extracts UTxOs, governance state, and cost models.

--- a/conformance/state_parser_test.go
+++ b/conformance/state_parser_test.go
@@ -18,8 +18,38 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
+
+func TestExtractDRepDelegationPreservesType(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      any
+		expected int
+	}{
+		{
+			name:     "always abstain",
+			raw:      []any{uint64(common.DrepTypeAbstain)},
+			expected: common.DrepTypeAbstain,
+		},
+		{
+			name:     "always no confidence",
+			raw:      []any{uint64(common.DrepTypeNoConfidence)},
+			expected: common.DrepTypeNoConfidence,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			delegation := extractDRepDelegation(test.raw)
+			require.NotNil(t, delegation)
+			require.Equal(t, test.expected, delegation.Type)
+			require.Empty(t, delegation.Credential)
+		})
+	}
+}
 
 func TestParseInitialState(t *testing.T) {
 	defer goleak.VerifyNone(t)

--- a/consensus/cmd/capture-sidecar/main.go
+++ b/consensus/cmd/capture-sidecar/main.go
@@ -34,14 +34,46 @@ import (
 
 func main() {
 	var (
-		address          = flag.String("address", "", "cardano-node NtN TCP endpoint (host:port)")
-		networkMagic     = flag.Uint64("network-magic", 0, "Cardano network magic (uint32)")
-		conversationPath = flag.String("conversation", "", "path to capture-conversation.json")
-		outPath          = flag.String("out", "", "destination path for the produced JSON vector")
-		peerID           = flag.Uint64("peer-id", 0, "peer id stamped on the resulting PeerInput")
-		title            = flag.String("title", "", "vector title (defaults to the conversation's name)")
-		runTimeout       = flag.Duration("timeout", 90*time.Second, "overall capture deadline")
-		dialTimeout      = flag.Duration("dial-timeout", 10*time.Second, "TCP dial timeout")
+		address = flag.String(
+			"address",
+			"",
+			"cardano-node NtN TCP endpoint (host:port)",
+		)
+		networkMagic = flag.Uint64(
+			"network-magic",
+			0,
+			"Cardano network magic (uint32)",
+		)
+		conversationPath = flag.String(
+			"conversation",
+			"",
+			"path to capture-conversation.json",
+		)
+		outPath = flag.String(
+			"out",
+			"",
+			"destination path for the produced JSON vector",
+		)
+		peerID = flag.Uint64(
+			"peer-id",
+			0,
+			"peer id stamped on the resulting PeerInput",
+		)
+		title = flag.String(
+			"title",
+			"",
+			"vector title (defaults to the conversation's name)",
+		)
+		runTimeout = flag.Duration(
+			"timeout",
+			90*time.Second,
+			"overall capture deadline",
+		)
+		dialTimeout = flag.Duration(
+			"dial-timeout",
+			10*time.Second,
+			"TCP dial timeout",
+		)
 	)
 	flag.Parse()
 

--- a/consensus/cmd/check-consensus-vector/main.go
+++ b/consensus/cmd/check-consensus-vector/main.go
@@ -57,7 +57,11 @@ func chainOf(served []format.ServedMessage) ([]blk, error) {
 			}
 			h, err := gledger.NewBlockHeaderFromCbor(*m.Era, m.HeaderCbor)
 			if err != nil {
-				return nil, fmt.Errorf("decode header (era %d): %w", *m.Era, err)
+				return nil, fmt.Errorf(
+					"decode header (era %d): %w",
+					*m.Era,
+					err,
+				)
 			}
 			out = append(out, blk{
 				h.BlockNumber(), h.SlotNumber(),
@@ -86,7 +90,8 @@ func chainOf(served []format.ServedMessage) ([]blk, error) {
 				// than silently truncating to origin and mis-judging the shape.
 				return nil, fmt.Errorf(
 					"roll_backward to point %s is not in the reconstructed chain",
-					ph)
+					ph,
+				)
 			}
 			out = out[:cut]
 		}
@@ -198,7 +203,10 @@ func checkShape(
 		ftPeer = 1
 	}
 	if ftPeer < 0 {
-		return fmt.Errorf("final_tip (block %d) matches no peer tip", ft.BlockNumber)
+		return fmt.Errorf(
+			"final_tip (block %d) matches no peer tip",
+			ft.BlockNumber,
+		)
 	}
 	hasRB := c.ExpectedOutput.ExpectedRollback != nil
 	hasLocal := c.LocalTip != nil
@@ -236,7 +244,10 @@ func checkShape(
 		if lead > ml {
 			return fmt.Errorf(
 				"winner leads by %d > %d — beyond the SUT's local_tip catch-up "+
-					"(2k); not replayable as a switch", lead, ml)
+					"(2k); not replayable as a switch",
+				lead,
+				ml,
+			)
 		}
 		if minLead > 0 && lead < minLead {
 			return fmt.Errorf("winner leads by %d, below required min %d",
@@ -261,7 +272,8 @@ func checkShape(
 		if ftPeer != 0 {
 			return fmt.Errorf(
 				"final_tip must be peer_id 0 (incumbent fed first); it is peer %d",
-				ftPeer)
+				ftPeer,
+			)
 		}
 		if t1.num <= t0.num {
 			return fmt.Errorf(
@@ -273,7 +285,10 @@ func checkShape(
 		if rollback <= k {
 			return fmt.Errorf(
 				"rollback to the longer peer is %d <= k=%d — a conformant node "+
-					"would switch; this is not an exceeds-k no-switch", rollback, k)
+					"would switch; this is not an exceeds-k no-switch",
+				rollback,
+				k,
+			)
 		}
 		// lead > k is a SEPARATE, SUT-reachability requirement, not a Praos
 		// rule: the SUT (dingo) refuses the longer peer via its tip-
@@ -289,12 +304,15 @@ func checkShape(
 					"guard would not reject its tip, so it would switch", lead, k)
 		}
 		if hasRB {
-			return errors.New("a no-switch vector must not carry expected_rollback")
+			return errors.New(
+				"a no-switch vector must not carry expected_rollback",
+			)
 		}
 		if hasLocal {
 			return errors.New(
 				"a no-switch vector must not carry local_tip (it would arm the " +
-					"catch-up and let the SUT accept the longer peer)")
+					"catch-up and let the SUT accept the longer peer)",
+			)
 		}
 		return nil
 
@@ -302,7 +320,8 @@ func checkShape(
 		if ftPeer != 1 {
 			return fmt.Errorf(
 				"final_tip must be peer_id 1 (VRF winner fed last); it is peer %d",
-				ftPeer)
+				ftPeer,
+			)
 		}
 		if t0.num != t1.num {
 			return fmt.Errorf(

--- a/consensus/corpus_rollback_conformance_test.go
+++ b/consensus/corpus_rollback_conformance_test.go
@@ -112,7 +112,10 @@ func TestCorpusFinalTipIsRollbackConformant(t *testing.T) {
 				}
 			}
 			if ftChain == nil {
-				t.Fatalf("final_tip block %d matches no peer chain", ft.BlockNumber)
+				t.Fatalf(
+					"final_tip block %d matches no peer chain",
+					ft.BlockNumber,
+				)
 			}
 			for _, p := range capt.Peers {
 				ch := chains[p.PeerID]

--- a/consensus/harness.go
+++ b/consensus/harness.go
@@ -43,7 +43,12 @@ type Replayer interface {
 	// peerID, in trace order: era is the captured block era (== the
 	// SUT handler's blockType), headerCbor the raw header bytes, tip
 	// the peer's announced chain tip. A non-nil error fails the vector.
-	RollForward(peerID uint64, era uint, headerCbor []byte, tip format.Tip) error
+	RollForward(
+		peerID uint64,
+		era uint,
+		headerCbor []byte,
+		tip format.Tip,
+	) error
 
 	// RollBackward delivers one captured chainsync roll_backward for
 	// peerID: point is the rollback target, tip the peer's announced

--- a/consensus/sidecar_internal_test.go
+++ b/consensus/sidecar_internal_test.go
@@ -147,7 +147,11 @@ func TestAssertObservationKeptShorterPeerExceedsK(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := assertObservationPickedLongestPeer(tc.peers, tc.finalTip, tc.k)
+			err := assertObservationPickedLongestPeer(
+				tc.peers,
+				tc.finalTip,
+				tc.k,
+			)
 			if tc.wantErr && err == nil {
 				t.Fatalf("want reject, got accept")
 			}

--- a/consensus/sidecar_test.go
+++ b/consensus/sidecar_test.go
@@ -204,7 +204,11 @@ func TestScenarioConversationsParse(t *testing.T) {
 		if !e.IsDir() {
 			continue
 		}
-		path := filepath.Join("scenarios", e.Name(), "capture-conversation.json")
+		path := filepath.Join(
+			"scenarios",
+			e.Name(),
+			"capture-conversation.json",
+		)
 		t.Run(e.Name(), func(t *testing.T) {
 			if _, err := os.Stat(path); err != nil {
 				t.Skipf("no capture-conversation.json at %s", path)

--- a/fixtures/chain_test.go
+++ b/fixtures/chain_test.go
@@ -99,7 +99,13 @@ func TestGenerateConwayChainHonorsPrevHash(t *testing.T) {
 // A non-positive count returns an empty, non-nil slice and no error.
 func TestGenerateConwayChainEmpty(t *testing.T) {
 	for _, count := range []int{0, -1} {
-		gen, err := fixtures.GenerateConwayChain(1, common.Blake2b256{}, 0, 1, count)
+		gen, err := fixtures.GenerateConwayChain(
+			1,
+			common.Blake2b256{},
+			0,
+			1,
+			count,
+		)
 		if err != nil {
 			t.Fatalf("count %d: unexpected error %s", count, err)
 		}

--- a/fixtures/decode.go
+++ b/fixtures/decode.go
@@ -357,7 +357,11 @@ func (f Fixture) ConsensusEnvelope() (*ConsensusEnvelope, error) {
 // consensus transaction fixture.
 func (f Fixture) ConsensusTransactionBytes() ([]byte, error) {
 	if f.Kind != KindTransaction {
-		return nil, fmt.Errorf("%w: fixture %s", ErrNotTransactionFixture, f.RelPath)
+		return nil, fmt.Errorf(
+			"%w: fixture %s",
+			ErrNotTransactionFixture,
+			f.RelPath,
+		)
 	}
 
 	envelope, err := f.ConsensusEnvelope()

--- a/fixtures/decode_test.go
+++ b/fixtures/decode_test.go
@@ -280,8 +280,12 @@ func TestValidateReferenceValidatesOptionalReferenceHash(t *testing.T) {
 				HashDigest: strings.Repeat("00", 32),
 			},
 		}, false)
-		if err == nil || !strings.Contains(err.Error(), "referenceHash.hashAlgorithm") {
-			t.Fatalf("expected optional reference hash to require algorithm, got %v", err)
+		if err == nil ||
+			!strings.Contains(err.Error(), "referenceHash.hashAlgorithm") {
+			t.Fatalf(
+				"expected optional reference hash to require algorithm, got %v",
+				err,
+			)
 		}
 	})
 
@@ -295,8 +299,12 @@ func TestValidateReferenceValidatesOptionalReferenceHash(t *testing.T) {
 				HashDigest:    "zz",
 			},
 		}, false)
-		if err == nil || !strings.Contains(err.Error(), "referenceHash.hashDigest") {
-			t.Fatalf("expected optional reference hash digest validation, got %v", err)
+		if err == nil ||
+			!strings.Contains(err.Error(), "referenceHash.hashDigest") {
+			t.Fatalf(
+				"expected optional reference hash digest validation, got %v",
+				err,
+			)
 		}
 	})
 }

--- a/fixtures/harness_test.go
+++ b/fixtures/harness_test.go
@@ -34,11 +34,14 @@ func TestHarnessIntegration(t *testing.T) {
 	expectedFixtures := expectedFixturesFromManifest(t, harness)
 	expectedFixtureCount := len(expectedFixtures)
 	expectedCounts := repoCounts(expectedFixtures)
-	expectedConsensusBlockCount := countMatchingFixtures(expectedFixtures, fixtures.Filter{
-		Repo:   fixtures.RepoOuroborosConsensus,
-		Kind:   fixtures.KindBlock,
-		Format: fixtures.FormatCBOR,
-	})
+	expectedConsensusBlockCount := countMatchingFixtures(
+		expectedFixtures,
+		fixtures.Filter{
+			Repo:   fixtures.RepoOuroborosConsensus,
+			Kind:   fixtures.KindBlock,
+			Format: fixtures.FormatCBOR,
+		},
+	)
 
 	t.Run("CollectFixtures", func(t *testing.T) {
 		collected, err := harness.Collect()
@@ -365,7 +368,11 @@ func expectedFixturesFromManifest(
 			filepath.Join(root, filepath.FromSlash(relPath)),
 		)
 		if err != nil {
-			t.Fatalf("NewFixture failed for manifest entry %q: %v", relPath, err)
+			t.Fatalf(
+				"NewFixture failed for manifest entry %q: %v",
+				relPath,
+				err,
+			)
 		}
 		expected = append(expected, fixture)
 	}
@@ -422,7 +429,10 @@ func walkFixtureFiles(root string) ([]string, error) {
 	return paths, nil
 }
 
-func firstSliceDifference(expected []string, actual []string) (int, string, string) {
+func firstSliceDifference(
+	expected []string,
+	actual []string,
+) (int, string, string) {
 	maxIndex := len(expected)
 	if len(actual) < maxIndex {
 		maxIndex = len(actual)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -215,6 +215,26 @@ func TestNewLedgerStateBuilder(t *testing.T) {
 	}
 }
 
+func TestLedgerStateBuilder_DRepDelegationPreservesVariant(t *testing.T) {
+	credential := lcommon.Credential{
+		Credential: lcommon.NewBlake2b224(bytes.Repeat([]byte{0xab}, 28)),
+	}
+	want := lcommon.Drep{Type: lcommon.DrepTypeNoConfidence}
+	state := ledger.NewLedgerStateBuilder().
+		WithDRepDelegation(
+			func(lcommon.Credential) (*lcommon.Drep, error) {
+				return &want, nil
+			},
+		).
+		Build()
+
+	got, err := state.DRepDelegation(credential)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, lcommon.DrepTypeNoConfidence, got.Type)
+	assert.Empty(t, got.Credential)
+}
+
 func TestLedgerStateBuilder_WithNetworkId(t *testing.T) {
 	networkId := uint(1) // mainnet
 	state := ledger.NewLedgerStateBuilder().

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -75,8 +75,10 @@ type CommitteeMemberFunc func(lcommon.Blake2b224) (*lcommon.CommitteeMember, err
 // DRepRegistrationFunc is a callback for DRep registration lookups
 type DRepRegistrationFunc func(lcommon.Blake2b224) (*lcommon.DRepRegistration, error)
 
-// DRepDelegationFunc is a callback for DRep delegation lookups.
-type DRepDelegationFunc func(lcommon.Credential) (*lcommon.DRepDelegation, error)
+// DRepDelegationFunc is a callback for DRep delegation lookups. It returns the
+// full DRep sum type so predefined DReps remain distinguishable from credential
+// based DReps.
+type DRepDelegationFunc func(lcommon.Credential) (*lcommon.Drep, error)
 
 // ConstitutionFunc is a callback for constitution lookups
 type ConstitutionFunc func() (*lcommon.Constitution, error)
@@ -349,7 +351,7 @@ func (ls *MockLedgerState) DRepRegistrations() ([]lcommon.DRepRegistration, erro
 // DRepDelegation looks up the vote delegation for a stake credential.
 func (ls *MockLedgerState) DRepDelegation(
 	credential lcommon.Credential,
-) (*lcommon.DRepDelegation, error) {
+) (*lcommon.Drep, error) {
 	if ls.DRepDelegationCallback != nil {
 		return ls.DRepDelegationCallback(credential)
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -75,6 +75,9 @@ type CommitteeMemberFunc func(lcommon.Blake2b224) (*lcommon.CommitteeMember, err
 // DRepRegistrationFunc is a callback for DRep registration lookups
 type DRepRegistrationFunc func(lcommon.Blake2b224) (*lcommon.DRepRegistration, error)
 
+// DRepDelegationFunc is a callback for DRep delegation lookups.
+type DRepDelegationFunc func(lcommon.Credential) (*lcommon.DRepDelegation, error)
+
 // ConstitutionFunc is a callback for constitution lookups
 type ConstitutionFunc func() (*lcommon.Constitution, error)
 
@@ -115,6 +118,7 @@ type MockLedgerState struct {
 	// GovState callbacks and state
 	CommitteeMemberCallback  CommitteeMemberFunc
 	DRepRegistrationCallback DRepRegistrationFunc
+	DRepDelegationCallback   DRepDelegationFunc
 	ConstitutionCallback     ConstitutionFunc
 	TreasuryValueCallback    TreasuryValueFunc
 	GovActionByIdCallback    GovActionByIdFunc
@@ -340,6 +344,16 @@ func (ls *MockLedgerState) DRepRegistration(
 // DRepRegistrations returns all DRep registrations
 func (ls *MockLedgerState) DRepRegistrations() ([]lcommon.DRepRegistration, error) {
 	return ls.drepRegistrations, nil
+}
+
+// DRepDelegation looks up the vote delegation for a stake credential.
+func (ls *MockLedgerState) DRepDelegation(
+	credential lcommon.Credential,
+) (*lcommon.DRepDelegation, error) {
+	if ls.DRepDelegationCallback != nil {
+		return ls.DRepDelegationCallback(credential)
+	}
+	return nil, nil
 }
 
 // Constitution returns the current constitution
@@ -593,6 +607,14 @@ func (b *LedgerStateBuilder) WithDRepRegistration(
 	fn DRepRegistrationFunc,
 ) *LedgerStateBuilder {
 	b.state.DRepRegistrationCallback = fn
+	return b
+}
+
+// WithDRepDelegation sets the DRep delegation lookup callback.
+func (b *LedgerStateBuilder) WithDRepDelegation(
+	fn DRepDelegationFunc,
+) *LedgerStateBuilder {
+	b.state.DRepDelegationCallback = fn
 	return b
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DRep delegation support across governance and ledger state, including parsing from initial state and certificate-driven updates. Preserves abstain/no-confidence variants and returns the full DRep sum type via the ledger lookup (no zero-hash credentials).

- **New Features**
  - Track DRep delegations in `conformance` governance state and load them from `ParsedInitialState`.
  - Parse delegations (including abstain/no-confidence) via `extractDRepDelegation`.
  - Apply delegation changes from registration, vote delegation, and stake-vote delegation certificates.
  - Add ledger lookup (`DRepDelegationFunc`, `MockLedgerState.DRepDelegation`, `WithDRepDelegation`) and wire it in `MockStateManager.buildLedgerState`.

- **Bug Fixes**
  - Clear DRep delegation on stake deregistration and deregistration to prevent stale mappings.
  - Represent "always" DReps without credential bytes to avoid zero-hash leakage (with test coverage).

<sup>Written for commit ee6674a29c8ccfe33f77f648188a83b0e7ccb690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking DRep delegation state throughout governance and ledger state.
  * Initial state loading now preserves DRep delegations.
  * Delegation and deregistration actions now correctly add or remove DRep delegation records.
  * Ledger state can now provide DRep delegation information for credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->