### PR TITLE
test(ledger): add validity interval fixtures

### DIFF
--- a/ledger/validity.go
+++ b/ledger/validity.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+)
+
+// ValidityIntervalFixture describes whether each transaction validity bound
+// is present and, when present, its slot value. A non-nil pointer to zero
+// represents an explicitly encoded zero bound.
+type ValidityIntervalFixture struct {
+	Name      string
+	StartSlot *uint64
+	EndSlot   *uint64
+}
+
+// ValidityIntervalFixtures returns the complete set of transaction validity
+// bound-presence combinations, including explicit zero bounds.
+func ValidityIntervalFixtures() []ValidityIntervalFixture {
+	slot := func(value uint64) *uint64 {
+		return &value
+	}
+	return []ValidityIntervalFixture{
+		{Name: "unbounded"},
+		{Name: "upper only", EndSlot: slot(10)},
+		{Name: "lower only", StartSlot: slot(5)},
+		{
+			Name:      "both bounds",
+			StartSlot: slot(5),
+			EndSlot:   slot(10),
+		},
+		{
+			Name:      "explicit zero lower",
+			StartSlot: slot(0),
+			EndSlot:   slot(10),
+		},
+		{Name: "explicit zero upper", EndSlot: slot(0)},
+		{
+			Name:      "both explicit zero",
+			StartSlot: slot(0),
+			EndSlot:   slot(0),
+		},
+	}
+}
+
+// AlonzoTransaction returns the fixture decoded as an Alonzo transaction.
+func (f ValidityIntervalFixture) AlonzoTransaction() (
+	*alonzo.AlonzoTransaction,
+	error,
+) {
+	txCbor, err := f.transactionCbor()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := alonzo.NewAlonzoTransactionFromCbor(txCbor)
+	if err != nil {
+		return nil, fmt.Errorf("decode Alonzo transaction: %w", err)
+	}
+	return tx, nil
+}
+
+// BabbageTransaction returns the fixture decoded as a Babbage transaction.
+func (f ValidityIntervalFixture) BabbageTransaction() (
+	*babbage.BabbageTransaction,
+	error,
+) {
+	txCbor, err := f.transactionCbor()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := babbage.NewBabbageTransactionFromCbor(txCbor)
+	if err != nil {
+		return nil, fmt.Errorf("decode Babbage transaction: %w", err)
+	}
+	return tx, nil
+}
+
+func (f ValidityIntervalFixture) transactionCbor() ([]byte, error) {
+	body := make(map[uint]uint64, 2)
+	if f.StartSlot != nil {
+		body[8] = *f.StartSlot
+	}
+	if f.EndSlot != nil {
+		body[3] = *f.EndSlot
+	}
+	bodyCbor, err := cbor.Encode(body)
+	if err != nil {
+		return nil, fmt.Errorf("encode transaction body: %w", err)
+	}
+	witnessCbor, err := cbor.Encode(map[uint]any{})
+	if err != nil {
+		return nil, fmt.Errorf("encode transaction witnesses: %w", err)
+	}
+	txCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		cbor.RawMessage(witnessCbor),
+		true,
+		nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode transaction: %w", err)
+	}
+	return txCbor, nil
+}

--- a/ledger/validity_test.go
+++ b/ledger/validity_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidityIntervalFixtures(t *testing.T) {
+	testCases := ledger.ValidityIntervalFixtures()
+	require.Len(t, testCases, 7)
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			for _, decoder := range []struct {
+				name string
+				run  func() (lcommon.Transaction, error)
+			}{
+				{
+					name: "Alonzo",
+					run: func() (lcommon.Transaction, error) {
+						return testCase.AlonzoTransaction()
+					},
+				},
+				{
+					name: "Babbage",
+					run: func() (lcommon.Transaction, error) {
+						return testCase.BabbageTransaction()
+					},
+				},
+			} {
+				t.Run(decoder.name, func(t *testing.T) {
+					tx, err := decoder.run()
+					require.NoError(t, err)
+					requireBound(
+						t,
+						tx,
+						8,
+						testCase.StartSlot,
+					)
+					requireBound(
+						t,
+						tx,
+						3,
+						testCase.EndSlot,
+					)
+				})
+			}
+		})
+	}
+}
+
+func requireBound(
+	t *testing.T,
+	tx lcommon.Transaction,
+	key uint,
+	expected *uint64,
+) {
+	t.Helper()
+	var txFields []cbor.RawMessage
+	_, err := cbor.Decode(tx.Cbor(), &txFields)
+	require.NoError(t, err)
+	require.NotEmpty(t, txFields)
+	var bodyFields map[uint]cbor.RawMessage
+	_, err = cbor.Decode(txFields[0], &bodyFields)
+	require.NoError(t, err)
+	raw, present := bodyFields[key]
+	require.Equal(t, expected != nil, present)
+	if expected == nil {
+		return
+	}
+	var actual uint64
+	_, err = cbor.Decode(raw, &actual)
+	require.NoError(t, err)
+	require.Equal(t, *expected, actual)
+	if key == 8 {
+		require.Equal(t, *expected, tx.ValidityIntervalStart())
+	} else {
+		require.Equal(t, *expected, tx.TTL())
+	}
+}

--- a/ledger/validity_test.go
+++ b/ledger/validity_test.go
@@ -53,12 +53,18 @@ func TestValidityIntervalFixtures(t *testing.T) {
 						tx,
 						8,
 						testCase.StartSlot,
+						func(tx lcommon.Transaction) uint64 {
+							return tx.ValidityIntervalStart()
+						},
 					)
 					requireBound(
 						t,
 						tx,
 						3,
 						testCase.EndSlot,
+						func(tx lcommon.Transaction) uint64 {
+							return tx.TTL()
+						},
 					)
 				})
 			}
@@ -71,6 +77,7 @@ func requireBound(
 	tx lcommon.Transaction,
 	key uint,
 	expected *uint64,
+	accessor func(lcommon.Transaction) uint64,
 ) {
 	t.Helper()
 	var txFields []cbor.RawMessage
@@ -89,9 +96,5 @@ func requireBound(
 	_, err = cbor.Decode(raw, &actual)
 	require.NoError(t, err)
 	require.Equal(t, *expected, actual)
-	if key == 8 {
-		require.Equal(t, *expected, tx.ValidityIntervalStart())
-	} else {
-		require.Equal(t, *expected, tx.TTL())
-	}
+	require.Equal(t, *expected, accessor(tx))
 }


### PR DESCRIPTION
## Summary

- add reusable Alonzo and Babbage transaction fixtures for every validity-bound presence combination
- preserve absent bounds distinctly from explicit zero bounds
- verify raw CBOR key presence and era decoder accessors

This fixture surface replaces inline transaction CBOR construction in [gouroboros #1964](https://github.com/blinklabs-io/gouroboros/pull/1964), which fixes the Plutus interval mismatch identified by [Dingo #3123](https://github.com/blinklabs-io/dingo/issues/3123).

## Test plan

- `go test -v -race -run '^TestValidityIntervalFixtures$' ./ledger`
- `make test`
- `golangci-lint run ./...`
- `nilaway -include-pkgs=github.com/blinklabs-io/ouroboros-mock ./...`
- `GOFLAGS=-buildvcs=false make build` (linked-worktree VCS stamping workaround)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added reusable validity-interval fixtures for Alonzo and Babbage transactions to validate encoding/decoding. Replaces ad‑hoc CBOR in `gouroboros` tests and addresses the Plutus interval mismatch noted in Dingo #3123.

- **New Features**
  - Adds `ValidityIntervalFixture` and `ValidityIntervalFixtures()` with seven cases, plus helpers to build decoded `alonzo`/`babbage` transactions from CBOR.
  - Tests assert CBOR key presence (8 start, 3 end) and use explicit `ValidityIntervalStart()`/`TTL()` accessors to validate values, distinguishing absent bounds from explicit zero.

<sup>Written for commit 214640bc3733ea6d2b712bc9879feaba61a1b75b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for transaction validity intervals across Alonzo and Babbage formats.
  * Verified handling of missing, present, and explicitly zero start and end slot values.
  * Added checks ensuring decoded transaction data matches exposed validity accessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->