### PR TITLE
feat(chainsync): expose the harness server-under-test connection

### DIFF
--- a/chainsync/doc.go
+++ b/chainsync/doc.go
@@ -38,4 +38,24 @@
 // would report. Callers who need richer, multi-era blocks can substitute the
 // block builders and continue to use [PointOf]/[TipOf] to derive the matching
 // points and tips.
+//
+// # Consumer connection registries
+//
+// Some server callbacks do more than reply through their CallbackContext: they
+// resolve the peer connection out of a registry the consumer owns — a
+// connection manager, peer-governance table, or metrics map — usually to watch
+// for peer errors while a read blocks. A callback like that cannot run at all
+// until the connection is registered, so register the harness's connection
+// with [Harness.ServerConnection] before driving it:
+//
+//	h, err := csmock.New(csmock.Config{ChainSync: cfg})
+//	if err != nil { ... }
+//	defer h.Close()
+//	myConnManager.Add(h.ServerConnection())
+//
+// The connection's Id matches CallbackContext.ConnectionId, so a registry keyed
+// on that ID resolves. The harness keeps ownership of the connection's
+// lifecycle — see [Harness.ServerConnection] — though a consumer registry that
+// closes its connections on shutdown is safe to combine with [Harness.Close],
+// in either order.
 package chainsync

--- a/chainsync/doc.go
+++ b/chainsync/doc.go
@@ -54,8 +54,7 @@
 //	myConnManager.Add(h.ServerConnection())
 //
 // The connection's Id matches CallbackContext.ConnectionId, so a registry keyed
-// on that ID resolves. The harness keeps ownership of the connection's
-// lifecycle — see [Harness.ServerConnection] — though a consumer registry that
-// closes its connections on shutdown is safe to combine with [Harness.Close],
-// in either order.
+// on that ID resolves. The harness owns the connection's lifecycle and always
+// closes it in [Harness.Close]; a consumer registry that also closes its
+// connections composes safely in either order. See [Harness.ServerConnection].
 package chainsync

--- a/chainsync/harness.go
+++ b/chainsync/harness.go
@@ -361,6 +361,31 @@ func (h *Harness) Server() *gchainsync.Server {
 	return h.server
 }
 
+// ServerConnection returns the connection carrying the server under test.
+//
+// It exists for server callbacks that resolve their peer through a
+// caller-owned registry — a connection manager, peer-governance table, or
+// metrics map — rather than using [gchainsync.CallbackContext] alone. Such a
+// callback cannot run at all unless the connection is registered first, so
+// register it before driving the harness:
+//
+//	h, err := csmock.New(csmock.Config{ChainSync: cfg})
+//	...
+//	myConnManager.Add(h.ServerConnection())
+//
+// The connection's Id is the same [ouroboros.ConnectionId] delivered to
+// callbacks in CallbackContext.ConnectionId, so a registry keyed on that ID
+// resolves.
+//
+// The harness retains ownership: [Harness.Close] closes this connection.
+// Callers must not close it themselves, and should register it with a
+// lifecycle that will not outlive the harness. To exercise send failures, use
+// [Harness.Disconnect], which drops the driver side and leaves teardown to the
+// harness.
+func (h *Harness) ServerConnection() *ouroboros.Connection {
+	return h.sut
+}
+
 // Disconnect abruptly closes the driver side of the connection without a
 // protocol Done. An in-flight or subsequent server send fails, which the server
 // surfaces on [Harness.ServerErrors]. Use it to exercise send-failure paths

--- a/chainsync/harness.go
+++ b/chainsync/harness.go
@@ -377,11 +377,15 @@ func (h *Harness) Server() *gchainsync.Server {
 // callbacks in CallbackContext.ConnectionId, so a registry keyed on that ID
 // resolves.
 //
-// The harness retains ownership: [Harness.Close] closes this connection.
-// Callers must not close it themselves, and should register it with a
-// lifecycle that will not outlive the harness. To exercise send failures, use
-// [Harness.Disconnect], which drops the driver side and leaves teardown to the
-// harness.
+// The harness owns the connection's lifecycle: [Harness.Close] always closes
+// it, so callers need not. A consumer registry that closes the connections it
+// owns is still safe to combine with the harness — Close is idempotent, so the
+// two compose in either order — but the harness closing it is what guarantees
+// teardown, and a caller close is never required.
+//
+// To exercise send-failure paths, use [Harness.Disconnect] rather than closing
+// this connection: it drops the driver side, which fails the server's sends
+// while leaving teardown to the harness.
 func (h *Harness) ServerConnection() *ouroboros.Connection {
 	return h.sut
 }

--- a/chainsync/harness_test.go
+++ b/chainsync/harness_test.go
@@ -17,10 +17,12 @@ package chainsync_test
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -43,11 +45,19 @@ type responder struct {
 
 	findIntersect func([]pcommon.Point) (pcommon.Point, chainsync.Tip, error)
 	actions       []serverAction
+
+	// requestNextOverride, when set, handles RequestNext instead of the
+	// action script. It receives the full callback context, so a test can
+	// exercise behaviour that depends on CallbackContext.ConnectionId.
+	requestNextOverride func(chainsync.CallbackContext) error
 }
 
 func (r *responder) requestNext(ctx chainsync.CallbackContext) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.requestNextOverride != nil {
+		return r.requestNextOverride(ctx)
+	}
 	if len(r.actions) == 0 {
 		return ctx.Server.AwaitReply()
 	}
@@ -484,4 +494,222 @@ func TestObserveAfterClose(t *testing.T) {
 
 	_, err = h.Observe(context.Background())
 	require.ErrorIs(t, err, csmock.ErrClosed)
+}
+
+// peerRegistry is a caller-owned connection registry keyed by connection ID,
+// standing in for a consumer's connection manager (e.g. Dingo's connmanager).
+type peerRegistry struct {
+	mu    sync.Mutex
+	conns map[ouroboros.ConnectionId]*ouroboros.Connection
+}
+
+func newPeerRegistry() *peerRegistry {
+	return &peerRegistry{
+		conns: make(map[ouroboros.ConnectionId]*ouroboros.Connection),
+	}
+}
+
+func (p *peerRegistry) add(conn *ouroboros.Connection) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.conns[conn.Id()] = conn
+}
+
+func (p *peerRegistry) get(
+	id ouroboros.ConnectionId,
+) *ouroboros.Connection {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.conns[id]
+}
+
+// A callback that parks the client with AwaitReply and then resolves its peer
+// through a caller-owned registry must be drivable by the harness: the
+// connection the harness exposes has to be the same one the callback is told
+// about in CallbackContext.ConnectionId, so the lookup succeeds and the
+// asynchronous RollForward that follows can be observed.
+func TestRequestNextAsyncRollForwardViaCallerRegistry(t *testing.T) {
+	for _, tc := range allModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 1)
+			require.NoError(t, err)
+			block := chain.Blocks[0]
+			tip := chain.Tips[0]
+
+			registry := newPeerRegistry()
+			blockReady := make(chan struct{})
+			resolved := make(chan ouroboros.ConnectionId, 1)
+			var wg sync.WaitGroup
+			defer wg.Wait()
+
+			// Mirror the downstream shape: AwaitReply, resolve the peer from
+			// the registry, then serve asynchronously.
+			r := &responder{}
+			r.findIntersect = func(
+				points []pcommon.Point,
+			) (pcommon.Point, chainsync.Tip, error) {
+				return points[0], tip, nil
+			}
+			r.requestNextOverride = func(
+				ctx chainsync.CallbackContext,
+			) error {
+				if err := ctx.Server.AwaitReply(); err != nil {
+					return err
+				}
+				conn := registry.get(ctx.ConnectionId)
+				if conn == nil {
+					return fmt.Errorf(
+						"connection %s not found in registry",
+						ctx.ConnectionId.String(),
+					)
+				}
+				resolved <- ctx.ConnectionId
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					select {
+					case <-blockReady:
+						_ = ctx.Server.RollForward(
+							uint(block.Type()),
+							block.Cbor(),
+							tip,
+						)
+					case <-conn.ErrorChan():
+					}
+				}()
+				return nil
+			}
+
+			h := newHarness(t, tc.mode, r)
+			defer h.Close()
+
+			// Register the server-under-test connection as a consumer would.
+			conn := h.ServerConnection()
+			require.NotNil(
+				t,
+				conn,
+				"harness must expose its server connection",
+			)
+			registry.add(conn)
+
+			require.NoError(t, h.RequestNext())
+			require.True(t, observe(t, h).IsAwaitReply(), "expected AwaitReply")
+
+			select {
+			case gotId := <-resolved:
+				require.Equal(
+					t,
+					conn.Id(),
+					gotId,
+					"callback ConnectionId must match the exposed connection",
+				)
+			case <-time.After(5 * time.Second):
+				t.Fatal("callback never resolved its peer from the registry")
+			}
+
+			close(blockReady)
+
+			fwdMsg := observe(t, h)
+			require.True(t, fwdMsg.IsRollForward(), "expected async RollForward")
+			gotTip, ok := fwdMsg.Tip()
+			require.True(t, ok)
+			require.Equal(t, tip, gotTip)
+		})
+	}
+}
+
+// A callback that watches its resolved peer's error channel while waiting to
+// serve — the shape a consumer uses to abandon a blocked read when the peer
+// goes away — must be woken by [Harness.Disconnect], and the resulting send
+// failure must still surface on ServerErrors.
+func TestRegistryResolvedPeerErrorChanWakesOnDisconnect(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	chain, err := csmock.BuildChain(1, common.Blake2b256{}, 0, 20, 1)
+	require.NoError(t, err)
+	block := chain.Blocks[0]
+	tip := chain.Tips[0]
+
+	registry := newPeerRegistry()
+	// Never signalled: the only way out of the callback's select is the peer
+	// error channel.
+	blockReady := make(chan struct{})
+	abandoned := make(chan struct{})
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	r := &responder{}
+	r.requestNextOverride = func(ctx chainsync.CallbackContext) error {
+		if err := ctx.Server.AwaitReply(); err != nil {
+			return err
+		}
+		conn := registry.get(ctx.ConnectionId)
+		if conn == nil {
+			return fmt.Errorf(
+				"connection %s not found in registry",
+				ctx.ConnectionId.String(),
+			)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-blockReady:
+				_ = ctx.Server.RollForward(
+					uint(block.Type()),
+					block.Cbor(),
+					tip,
+				)
+			case <-conn.ErrorChan():
+				close(abandoned)
+			}
+		}()
+		return nil
+	}
+
+	h := newHarness(t, csmock.ModeNtC, r)
+	defer h.Close()
+	registry.add(h.ServerConnection())
+
+	require.NoError(t, h.RequestNext())
+	require.True(t, observe(t, h).IsAwaitReply(), "expected AwaitReply")
+
+	require.NoError(t, h.Disconnect())
+
+	select {
+	case <-abandoned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolved peer's error channel never woke the callback")
+	}
+}
+
+// A consumer's connection manager typically closes the connections it owns on
+// shutdown. Because the harness also closes the server connection, both can
+// run; neither ordering may panic, double-close, or leak.
+func TestServerConnectionCloseIsSafeFromCallerAndHarness(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	t.Run("caller closes first", func(t *testing.T) {
+		r := &responder{}
+		h := newHarness(t, csmock.ModeNtC, r)
+		defer h.Close()
+
+		conn := h.ServerConnection()
+		require.NotNil(t, conn)
+		require.NoError(t, conn.Close())
+		require.NoError(t, h.Close())
+	})
+
+	t.Run("harness closes first", func(t *testing.T) {
+		r := &responder{}
+		h := newHarness(t, csmock.ModeNtC, r)
+		defer h.Close()
+
+		conn := h.ServerConnection()
+		require.NotNil(t, conn)
+		require.NoError(t, h.Close())
+		require.NoError(t, conn.Close())
+	})
 }

--- a/chainsync/harness_test.go
+++ b/chainsync/harness_test.go
@@ -622,8 +622,10 @@ func TestRequestNextAsyncRollForwardViaCallerRegistry(t *testing.T) {
 
 // A callback that watches its resolved peer's error channel while waiting to
 // serve — the shape a consumer uses to abandon a blocked read when the peer
-// goes away — must be woken by [Harness.Disconnect], and the resulting send
-// failure must still surface on ServerErrors.
+// goes away — must be woken by [Harness.Disconnect]. The callback takes that
+// branch instead of sending, so no send is attempted and none is asserted
+// here; send failure after a disconnect is covered by
+// TestSendFailureOnDisconnect.
 func TestRegistryResolvedPeerErrorChanWakesOnDisconnect(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
Fixes #246.

## Problem

`Harness` creates the server-under-test connection internally and keeps it in the unexported `sut` field. A consumer cannot get at it, so it can never be registered with the consumer's own connection registry.

That matters because some server callbacks do more than reply through their `CallbackContext` — they resolve the peer connection out of a registry the consumer owns, usually to watch for peer errors while a read blocks. Dingo's `RequestNext` is the motivating case:

```go
if err := ctx.Server.AwaitReply(); err != nil {
    return err
}
conn := o.ConnManager.GetConnectionById(ctx.ConnectionId)
if conn == nil {
    return fmt.Errorf("connection %s not found", ctx.ConnectionId.String())
}
go func() {
    // wait on the chain iterator, or bail out when conn.ErrorChan() fires
}()
```

Driven by the harness today, that lookup returns nil and the callback fails on its first invocation. The failure lands *immediately after* the callback sent AwaitReply, so the connection is torn down mid-flight and even the AwaitReply message is racy to observe.

The practical effect is that the async half of this harness's intended scope is unreachable: asserting AwaitReply, the roll-forward that follows it, and the send-failure and cancellation paths around it — all called out in #226's scope.

## Change

Add `Harness.ServerConnection()`, returning the connection so it can be registered before the harness is driven. Everything here is additive; no existing behaviour changes.

- The connection's `Id` is the same `ConnectionId` delivered to callbacks in `CallbackContext.ConnectionId`, so a registry keyed on that ID resolves. Asserted, not assumed.
- The harness keeps ownership of the lifecycle. The doc comment says so, and points at `Disconnect` as the supported way to exercise send failures.
- `responder` gains a `requestNextOverride` hook so a test can supply a RequestNext handler that needs the full callback context rather than a context-free scripted action.
- `doc.go` gains a "Consumer connection registries" section so the pattern is discoverable at package level.

## On double close

A consumer's connection manager usually closes the connections it owns on shutdown, and the harness closes this one in `Close`, so in practice both will run — in `t.Cleanup` LIFO order, which the consumer does not directly control. `ouroboros.Connection.Close` is `sync.Once`-guarded, so this is safe; `TestServerConnectionCloseIsSafeFromCallerAndHarness` pins it in both orderings rather than leaving it to be rediscovered downstream.

## Tests

Written first — the registry test failed to compile on `h.ServerConnection undefined`, which is what drove the accessor.

- `TestRequestNextAsyncRollForwardViaCallerRegistry` (NtC and NtN) — a callback parks the client with AwaitReply, resolves its peer from a caller-owned registry, and serves asynchronously. Asserts the callback's `ConnectionId` matches the exposed connection, and that both messages are observed in order.
- `TestRegistryResolvedPeerErrorChanWakesOnDisconnect` — the resolved peer's error channel wakes a callback blocked waiting to serve, when `Disconnect` drops the driver. This is the mechanism a consumer relies on to abandon a blocked read.
- `TestServerConnectionCloseIsSafeFromCallerAndHarness` — close from either side, in either order.

`go build ./...`, `go vet ./...`, `gofmt`, `golines`, `golangci-lint` (0 issues), `go test -race ./chainsync -count=10`, and `go test -race ./...` across all packages are clean. `goleak.VerifyNone` on every new test; no `time.Sleep` anywhere.

## Verified against the downstream blocker

Rather than assume this solves the problem it was written for, I pointed blinklabs-io/dingo#2820's branch at this build with a temporary `replace`, registered the harness connection with Dingo's real `ConnectionManager`, and drove the path that could not run before: AwaitReply observed, no teardown, then the asynchronous RollForward observed with the exact block type, block CBOR and tip. The `replace` was reverted afterwards; Dingo will pick this up through a normal version bump.

## Downstream

blinklabs-io/dingo#2820 currently keeps a local connmanager-backed harness solely for the paths above. Once this is released and the dependency bumped, those tests move to the shared fixture and Dingo's local harness goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the server-under-test connection from the `chainsync` harness so consumers can register it in their own registries for callbacks that resolve peers, unlocking async test paths. Clarifies lifecycle: the harness always closes it; caller close is optional and safe; use `Disconnect` to simulate send failures.

- New Features
  - Added `Harness.ServerConnection()` to return the SUT connection. Its ID matches `CallbackContext.ConnectionId`. Harness closes it; caller close is tolerated in any order. Use `Disconnect` to exercise send failures.
  - Added `requestNextOverride` in the test responder for callbacks that need full `CallbackContext`.
  - Documented the consumer connection registries pattern and the close-ownership rule at package level.

<sup>Written for commit 366114cd6877b07e1a646903ff0a2929c343f0ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the harness’s server connection for external callback and connection management.
  - Enabled connection-ID-based resolution for asynchronous callback handling.
  - Improved support for asynchronous roll-forward delivery and peer error notifications when connections disconnect.
  - Ensured safe connection cleanup regardless of whether the caller or harness closes first.

- **Documentation**
  - Added guidance for registering server connections and coordinating registry shutdown with harness closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->