### PR TITLE
fix(conformance): preserve reward account state

### DIFF
--- a/conformance/IMPLEMENTING_STATE_MANAGER.md
+++ b/conformance/IMPLEMENTING_STATE_MANAGER.md
@@ -69,7 +69,8 @@ Called once per vector, before any events are processed. Your job is to hydrate 
 |-------|------|-------------|
 | `CurrentEpoch` | `uint64` | Epoch number at vector start |
 | `Utxos` | `map[string]ParsedUtxo` | UTxO set, keyed by `"txHash#index"` |
-| `StakeRegistrations` | `map[Blake2b224]bool` | Registered stake credentials |
+| `StakeRegistrationsByCredential` | `map[ledger.RewardAccountKey]bool` | Registrations keyed by credential type and hash |
+| `StakeRegistrations` | `map[Blake2b224]bool` | Deprecated hash-only compatibility view |
 | `RewardAccountBalances` | `map[ledger.RewardAccountKey]uint64` | Reward balances keyed by credential type and hash |
 | `RewardAccounts` | `map[Blake2b224]uint64` | Deprecated hash-only compatibility view |
 | `PoolRegistrations` | `map[Blake2b224]bool` | Registered pools |

--- a/conformance/IMPLEMENTING_STATE_MANAGER.md
+++ b/conformance/IMPLEMENTING_STATE_MANAGER.md
@@ -70,7 +70,8 @@ Called once per vector, before any events are processed. Your job is to hydrate 
 | `CurrentEpoch` | `uint64` | Epoch number at vector start |
 | `Utxos` | `map[string]ParsedUtxo` | UTxO set, keyed by `"txHash#index"` |
 | `StakeRegistrations` | `map[Blake2b224]bool` | Registered stake credentials |
-| `RewardAccounts` | `map[Blake2b224]uint64` | Reward account balances |
+| `RewardAccountBalances` | `map[ledger.RewardAccountKey]uint64` | Reward balances keyed by credential type and hash |
+| `RewardAccounts` | `map[Blake2b224]uint64` | Deprecated hash-only compatibility view |
 | `PoolRegistrations` | `map[Blake2b224]bool` | Registered pools |
 | `CommitteeMembers` | `map[Blake2b224]uint64` | Cold key → expiry epoch |
 | `HotKeyAuthorizations` | `map[Blake2b224]Blake2b224` | Cold key → hot key |
@@ -147,15 +148,34 @@ Return a pointer to your current `conformance.GovernanceState`. The harness uses
 
 The simplest approach: maintain a `*GovernanceState` alongside your database and keep it in sync inside `ApplyTransaction` and `ProcessEpochBoundary`.
 
-### `SetRewardBalances(balances map[Blake2b224]uint64)`
+### Reward balance setters
 
-The harness calls this before each transaction with adjusted reward balances for that transaction's withdrawal validation. The adjustment accounts for future withdrawals within the same vector:
+The harness calls a reward balance setter before each transaction with the
+pre-transaction balances needed for withdrawal validation. The adjustment
+accounts for the current and future withdrawals within the same vector:
 
 ```
-adjusted[cred] = finalStateBalance[cred] + sum(withdrawals[cred] from tx+1 onward)
+adjusted[cred] = finalStateBalance[cred] + sum(withdrawals[cred] from tx onward)
 ```
 
-Write these values into your `GovernanceState.RewardAccounts` map (and your database if your withdrawal validation reads from there). Do not persist them permanently; they are replaced before every transaction.
+Implement the optional `conformance.RewardAccountBalanceSetter` interface to
+receive `map[ledger.RewardAccountKey]uint64`. `RewardAccountKey` preserves the
+credential type as well as its hash, so key and script credentials with the
+same hash remain distinct. Write these values into
+`GovernanceState.RewardAccountBalances` and into the backend used by
+`RewardAccountBalance`. Treat the map as balance updates for accounts that are
+already registered: ignore credentials that are not registered yet, and keep
+currently registered accounts unchanged when they are absent from the map.
+
+Existing state managers remain compatible through
+`SetRewardBalances(map[Blake2b224]uint64)`. The harness collapses the full map
+to that legacy view and deterministically prefers the key credential when both
+credential types carry the same hash. That fallback cannot represent a
+collision, so state managers that validate script withdrawals should adopt
+`RewardAccountBalanceSetter`.
+
+Do not use an inferred balance to create or remove a registration. Certificate
+processing remains the source of truth for reward-account registration.
 
 ### `GetProtocolParameters() common.ProtocolParameters`
 
@@ -209,7 +229,13 @@ Start with `ApplyTransaction` → UTxO changes → certificates → governance. 
 
 ## Key behaviors to match
 
-**Reward balance injection** — `SetRewardBalances` is called by the harness before every transaction. The values already account for future withdrawals. Your withdrawal validation must use these values, not your database's current reward balance, or multi-withdrawal vectors will fail.
+**Reward balance injection** — the credential-aware setter is preferred before
+every transaction, with `SetRewardBalances` retained as a compatibility
+fallback. The values represent the balance before the current transaction and
+already account for its withdrawal plus later withdrawals. Withdrawal
+validation must use these values rather than a post-transaction balance. Apply
+only updates for accounts already registered in your state; do not infer
+registration from the adjustment map.
 
 **Phase-2 invalid transactions** — `ApplyTransaction` is called even when `tx.IsValid() == false`. Apply only collateral effects; do not apply outputs or certificates.
 

--- a/conformance/IMPLEMENTING_STATE_MANAGER.md
+++ b/conformance/IMPLEMENTING_STATE_MANAGER.md
@@ -76,6 +76,8 @@ Called once per vector, before any events are processed. Your job is to hydrate 
 | `CommitteeMembers` | `map[Blake2b224]uint64` | Cold key → expiry epoch |
 | `HotKeyAuthorizations` | `map[Blake2b224]Blake2b224` | Cold key → hot key |
 | `DRepRegistrations` | `[]Blake2b224` | Registered DRep credential hashes |
+| `DRepDelegationsByCredential` | `map[ledger.RewardAccountKey]common.Drep` | Vote delegations keyed by full stake credential identity |
+| `DRepDelegations` | `map[Blake2b224]common.Drep` | Deprecated hash-only compatibility view |
 | `Proposals` | `map[string]GovActionInfo` | Active governance proposals |
 | `ProposalRoots` | `ProposalRoots` | Last-enacted root for each action type |
 | `Constitution` | `*ConstitutionInfo` | Current constitution (may be nil) |
@@ -154,7 +156,7 @@ The harness calls a reward balance setter before each transaction with the
 pre-transaction balances needed for withdrawal validation. The adjustment
 accounts for the current and future withdrawals within the same vector:
 
-```
+```text
 adjusted[cred] = finalStateBalance[cred] + sum(withdrawals[cred] from tx onward)
 ```
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -335,6 +335,14 @@ type StateManager interface {
 }
 ```
 
+Implementations that need credential-aware reward balances should also
+implement `RewardAccountBalanceSetter`. Its `SetRewardAccountBalances` method
+uses `ledger.RewardAccountKey`, which includes both the credential type and
+hash. The original `SetRewardBalances` method remains the compatibility path
+for existing state managers. Both setters update balances for accounts already
+registered by the state manager; the inferred balance map must not create or
+remove registrations.
+
 ---
 
 ## Implementation Notes

--- a/conformance/VECTOR_FORMAT.md
+++ b/conformance/VECTOR_FORMAT.md
@@ -127,7 +127,18 @@ utxo_state = [
 | Previous pparams hash | `initial_state[3][1][1][3][4]` |
 | DRep registrations | `initial_state[3][1][0][0][0]` |
 | Stake registrations | `initial_state[3][1][0][2][0]` |
-| Final reward balances | `final_state[3][1][1][3]` (reward accounts within gov state) |
+| Final reward balances | `final_state[3][1][0][2][0][0]` (reward accounts within delegation state) |
+
+---
+
+Reward-account keys are stake credentials encoded as `[type, hash]`. The type
+is part of the identity: type `0` (verification-key hash) and type `1` (script
+hash) remain distinct even when the 28-byte hashes are equal.
+
+Vendored UMap account values wrap `[reward, deposit]` in their first field, so
+the reward balance is the first value of that nested pair. Modern Conway
+AccountState values encode `[balance, deposit, poolDelegation,
+drepDelegation]`, with the balance directly in the first field.
 
 ---
 

--- a/conformance/VECTOR_FORMAT.md
+++ b/conformance/VECTOR_FORMAT.md
@@ -79,7 +79,7 @@ begin_epoch_state = [
 
 ```
 ledger_state = [
-    cert_state,  ; [0] array[5] — certificates, DReps, committee
+    cert_state,  ; [0] array[3] — certificates, DReps, stake and pool state
     utxo_state,  ; [1] array[4] — UTxOs, deposits, fees, governance
 ]
 ```
@@ -88,17 +88,27 @@ ledger_state = [
 
 ```
 cert_state = [
-    voting_state,  ; [0] [drep_state, committee_state, ...]
-    _deleg_state,  ; [1]
-    _pool_state,   ; [2] — pool registrations / stake distributions
-    _reward_state, ; [3] — deposit map (stake registrations, pool deposits)
-    _stake_state,  ; [4]
+    voting_state,     ; [0] [drep_state, committee_state, ...]
+    pool_state,       ; [1] pool registrations / retirements
+    delegation_state, ; [2] unified stake-credential state
+]
+
+delegation_state = [
+    unified_map_wrapper, ; [0]
+    _future_gen_delegs,  ; [1]
+    _gen_delegs,         ; [2]
+    _instantaneous,      ; [3]
+]
+
+unified_map_wrapper = [
+    reward_accounts, ; [0] map[Credential]AccountState
+    _pointer_map,    ; [1]
 ]
 ```
 
 The harness reads DRep registrations and stake registrations from this subtree:
 - DReps: `initial_state[3][1][0][0][0]`
-- Stake registrations: `initial_state[3][1][0][2][0]`
+- Stake registrations: `initial_state[3][1][0][2][0][0]`
 
 ### utxo\_state (index 3→1→1)
 
@@ -126,7 +136,7 @@ utxo_state = [
 | Current pparams hash | `initial_state[3][1][1][3][3]` |
 | Previous pparams hash | `initial_state[3][1][1][3][4]` |
 | DRep registrations | `initial_state[3][1][0][0][0]` |
-| Stake registrations | `initial_state[3][1][0][2][0]` |
+| Stake registrations | `initial_state[3][1][0][2][0][0]` |
 | Final reward balances | `final_state[3][1][0][2][0][0]` (reward accounts within delegation state) |
 
 ---

--- a/conformance/example_backend_test.go
+++ b/conformance/example_backend_test.go
@@ -273,6 +273,12 @@ func (m *customStateManager) SetRewardBalances(
 	m.inner.SetRewardBalances(balances)
 }
 
+func (m *customStateManager) SetRewardAccountBalances(
+	balances map[ledger.RewardAccountKey]uint64,
+) {
+	m.inner.SetRewardAccountBalances(balances)
+}
+
 func (m *customStateManager) GetProtocolParameters() common.ProtocolParameters {
 	return m.inner.GetProtocolParameters()
 }

--- a/conformance/harness.go
+++ b/conformance/harness.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
 )
 
 // Harness runs conformance test vectors against a StateManager implementation.
@@ -55,10 +56,10 @@ type Harness struct {
 
 	// futureWithdrawals contains cumulative withdrawals from each event to end.
 	// Used to compute accurate reward balance at each transaction.
-	futureWithdrawals []map[common.Blake2b224]uint64
+	futureWithdrawals []map[ledger.RewardAccountKey]uint64
 
 	// finalStateBalances contains reward balances from the final state.
-	finalStateBalances map[common.Blake2b224]uint64
+	finalStateBalances map[ledger.RewardAccountKey]uint64
 
 	// epochLength is the number of slots per epoch from the vector config.
 	epochLength uint64
@@ -697,37 +698,47 @@ func (h *Harness) adjustRewardBalances(eventIdx int, event VectorEvent) {
 	if event.Type != EventTypeTransaction {
 		return
 	}
-	if len(h.finalStateBalances) == 0 {
+	if eventIdx >= len(h.futureWithdrawals) {
 		return
 	}
-	if eventIdx+1 >= len(h.futureWithdrawals) {
+	future := h.futureWithdrawals[eventIdx]
+	if len(h.finalStateBalances) == 0 && len(future) == 0 {
 		return
 	}
-	future := h.futureWithdrawals[eventIdx+1]
-	adjusted := make(map[common.Blake2b224]uint64, len(h.finalStateBalances))
+	adjusted := make(
+		map[ledger.RewardAccountKey]uint64,
+		len(h.finalStateBalances)+len(future),
+	)
 	for cred, balance := range h.finalStateBalances {
-		adjusted[cred] = balance + future[cred]
+		adjusted[cred] = balance
 	}
-	h.stateManager.SetRewardBalances(adjusted)
+	for cred, balance := range future {
+		adjusted[cred] += balance
+	}
+	if setter, ok := h.stateManager.(RewardAccountBalanceSetter); ok {
+		setter.SetRewardAccountBalances(adjusted)
+		return
+	}
+	h.stateManager.SetRewardBalances(rewardBalancesByHash(adjusted))
 }
 
 // computeFutureWithdrawals computes cumulative withdrawals from each TX index to the end.
 // Returns a slice where futureWithdrawals[i] contains the sum of successful withdrawals
 // from events[i] to the end (inclusive). This allows computing balance at TX i as:
-// balance_at_i = final_state_balance + futureWithdrawals[i+1]
+// balance_at_i = final_state_balance + futureWithdrawals[i]
 func (h *Harness) computeFutureWithdrawals(
 	events []VectorEvent,
-) []map[common.Blake2b224]uint64 {
+) []map[ledger.RewardAccountKey]uint64 {
 	n := len(events)
-	result := make([]map[common.Blake2b224]uint64, n+1)
+	result := make([]map[ledger.RewardAccountKey]uint64, n+1)
 
 	// Initialize the last entry (after all events) to empty
-	result[n] = make(map[common.Blake2b224]uint64)
+	result[n] = make(map[ledger.RewardAccountKey]uint64)
 
 	// Work backwards from the end
 	for i := n - 1; i >= 0; i-- {
 		// Copy previous (next in order) cumulative
-		result[i] = make(map[common.Blake2b224]uint64)
+		result[i] = make(map[ledger.RewardAccountKey]uint64)
 		maps.Copy(result[i], result[i+1])
 
 		event := events[i]
@@ -747,15 +758,19 @@ func (h *Harness) computeFutureWithdrawals(
 		}
 
 		for addr, amount := range tx.Withdrawals() {
-			if amount == nil {
+			if addr == nil || amount == nil {
 				continue
 			}
 			withdrawAmount := amount.Uint64()
 			if withdrawAmount == 0 {
 				continue
 			}
-			credHash := addr.StakeKeyHash()
-			result[i][credHash] += withdrawAmount
+			credential, ok := addr.StakeCredential()
+			if !ok {
+				continue
+			}
+			accountKey := ledger.NewRewardAccountKey(credential)
+			result[i][accountKey] += withdrawAmount
 		}
 	}
 
@@ -767,8 +782,8 @@ func (h *Harness) computeFutureWithdrawals(
 // Structure: final_state[3][1][0][2][0][0] = stake credentials map
 func extractFinalStateBalances(
 	finalState cbor.RawMessage,
-) map[common.Blake2b224]uint64 {
-	result := make(map[common.Blake2b224]uint64)
+) map[ledger.RewardAccountKey]uint64 {
+	result := make(map[ledger.RewardAccountKey]uint64)
 
 	// Navigate: final_state[3] = begin_epoch_state
 	var stateArr []cbor.RawMessage
@@ -830,9 +845,29 @@ func extractFinalStateBalances(
 
 	for _, entry := range entries {
 		credHash := common.NewBlake2b224(entry.Hash)
-		result[credHash] = entry.Balance
+		result[ledger.RewardAccountKey{
+			CredType:   uint(entry.CredType),
+			Credential: credHash,
+		}] = entry.Balance
 	}
 
+	return result
+}
+
+// rewardBalancesByHash converts full reward-account identities for legacy
+// StateManager implementations. If both credential types carry the same hash,
+// the key-hash credential wins deterministically.
+func rewardBalancesByHash(
+	balances map[ledger.RewardAccountKey]uint64,
+) map[common.Blake2b224]uint64 {
+	result := make(map[common.Blake2b224]uint64, len(balances))
+	for credential, balance := range balances {
+		_, exists := result[credential.Credential]
+		if !exists ||
+			credential.CredType == common.CredentialTypeAddrKeyHash {
+			result[credential.Credential] = balance
+		}
+	}
 	return result
 }
 
@@ -922,64 +957,18 @@ func parseStakeCredEntry(data []byte, pos int) (*stakeCredEntry, int) {
 		return nil, pos
 	}
 
-	// Parse value (array: [rewards, deposit, drep_delegatee, pool_delegatee])
-	if pos >= len(data) {
+	// Decode the account value independently after manually parsing the
+	// non-hashable credential key. This supports both the vendored UMap layout
+	// and the modern Conway AccountState layout.
+	var accountValue cbor.Value
+	consumed, err := cbor.Decode(data[pos:], &accountValue)
+	if err != nil || consumed <= 0 {
+		return nil, skipCborItem(data, pos)
+	}
+	pos += consumed
+	balance, registered := extractRewardAccountBalance(accountValue.Value())
+	if !registered {
 		return nil, pos
-	}
-	if data[pos]&0xe0 != 0x80 {
-		pos = skipCborItem(data, pos)
-		return nil, pos
-	}
-	valArrayLen := int(data[pos] & 0x1f)
-	pos++
-	if valArrayLen < 1 {
-		return nil, pos
-	}
-
-	// First element is rewards: [[epoch, balance], ...]
-	if pos >= len(data) {
-		return nil, pos
-	}
-	if data[pos]&0xe0 != 0x80 {
-		for range valArrayLen {
-			pos = skipCborItem(data, pos)
-		}
-		return nil, pos
-	}
-	rewardsLen := int(data[pos] & 0x1f)
-	pos++
-
-	var balance uint64
-	if rewardsLen > 0 {
-		// Parse first reward entry [epoch, balance]
-		if pos >= len(data) {
-			return nil, pos
-		}
-		if data[pos]&0xe0 == 0x80 {
-			rewardEntryLen := int(data[pos] & 0x1f)
-			pos++
-			if rewardEntryLen >= 2 {
-				// Skip epoch
-				_, n := parseCborUint(data, pos)
-				pos += n
-				// Parse balance
-				balance, n = parseCborUint(data, pos)
-				pos += n
-				// Skip remaining elements
-				for k := 2; k < rewardEntryLen; k++ {
-					pos = skipCborItem(data, pos)
-				}
-			}
-		}
-		// Skip remaining reward entries
-		for j := 1; j < rewardsLen; j++ {
-			pos = skipCborItem(data, pos)
-		}
-	}
-
-	// Skip remaining value elements (deposit, drep_delegatee, pool_delegatee)
-	for j := 1; j < valArrayLen; j++ {
-		pos = skipCborItem(data, pos)
 	}
 
 	return &stakeCredEntry{

--- a/conformance/harness_test.go
+++ b/conformance/harness_test.go
@@ -746,7 +746,7 @@ func TestMockStateManagerRewardAdjustmentPreservesRegistrationState(
 	}
 	currentKey := ledger.NewRewardAccountKey(currentCredential)
 	futureKey := ledger.NewRewardAccountKey(futureCredential)
-	sm.stakeRegistrations[currentCredential.Credential] = 0
+	sm.stakeRegistrations[currentKey] = 0
 	sm.rewardAccounts[currentKey] = 0
 	sm.govState.RegisterStakeCredential(currentCredential)
 
@@ -818,6 +818,38 @@ func TestMockStateManagerScriptRegistrationPreservesIdentity(t *testing.T) {
 	state := sm.GetStateProvider()
 	assert.True(t, state.IsRewardAccountRegistered(scriptCredential))
 	assert.False(t, state.IsRewardAccountRegistered(keyCredential))
+	assert.True(t, state.IsStakeCredentialRegistered(scriptCredential))
+	assert.False(t, state.IsStakeCredentialRegistered(keyCredential))
+}
+
+func TestValidatorStakeRegistrationPreservesCredentialIdentity(t *testing.T) {
+	hash := common.NewBlake2b224(append(make([]byte, 27), byte(6)))
+	scriptCredential := common.Credential{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	keyCredential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	govState := NewGovernanceState()
+	govState.RegisterStakeCredential(scriptCredential)
+	validator := NewValidator()
+
+	require.NoError(t, validator.validateCertificate(
+		&common.StakeRegistrationCertificate{
+			StakeCredential: keyCredential,
+		},
+		govState,
+		map[ledger.RewardAccountKey]bool{},
+	))
+	require.Error(t, validator.validateCertificate(
+		&common.StakeRegistrationCertificate{
+			StakeCredential: scriptCredential,
+		},
+		govState,
+		map[ledger.RewardAccountKey]bool{},
+	))
 }
 
 func TestMockStateManagerDRepDelegationPreservesCredentialIdentity(
@@ -864,6 +896,8 @@ func TestMockStateManagerDRepDelegationPreservesCredentialIdentity(
 
 	sm.deregisterStakeCredential(keyCredential)
 	state = sm.buildLedgerState()
+	assert.False(t, state.IsStakeCredentialRegistered(keyCredential))
+	assert.True(t, state.IsStakeCredentialRegistered(scriptCredential))
 	keyDelegation, err = state.DRepDelegation(keyCredential)
 	require.NoError(t, err)
 	assert.Nil(t, keyDelegation)

--- a/conformance/harness_test.go
+++ b/conformance/harness_test.go
@@ -820,6 +820,59 @@ func TestMockStateManagerScriptRegistrationPreservesIdentity(t *testing.T) {
 	assert.False(t, state.IsRewardAccountRegistered(keyCredential))
 }
 
+func TestMockStateManagerDRepDelegationPreservesCredentialIdentity(
+	t *testing.T,
+) {
+	hash := common.NewBlake2b224(append(make([]byte, 27), byte(5)))
+	keyCredential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	scriptCredential := common.Credential{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	sm := NewMockStateManager()
+	for _, credential := range []common.Credential{
+		keyCredential,
+		scriptCredential,
+	} {
+		sm.processCertificate(&common.StakeRegistrationCertificate{
+			StakeCredential: credential,
+		})
+	}
+	sm.processCertificate(&common.VoteDelegationCertificate{
+		CertType:        uint(common.CertificateTypeVoteDelegation),
+		StakeCredential: keyCredential,
+		Drep:            common.Drep{Type: common.DrepTypeAbstain},
+	})
+	sm.processCertificate(&common.VoteDelegationCertificate{
+		CertType:        uint(common.CertificateTypeVoteDelegation),
+		StakeCredential: scriptCredential,
+		Drep:            common.Drep{Type: common.DrepTypeNoConfidence},
+	})
+
+	state := sm.buildLedgerState()
+	keyDelegation, err := state.DRepDelegation(keyCredential)
+	require.NoError(t, err)
+	require.NotNil(t, keyDelegation)
+	assert.Equal(t, common.DrepTypeAbstain, keyDelegation.Type)
+	scriptDelegation, err := state.DRepDelegation(scriptCredential)
+	require.NoError(t, err)
+	require.NotNil(t, scriptDelegation)
+	assert.Equal(t, common.DrepTypeNoConfidence, scriptDelegation.Type)
+
+	sm.deregisterStakeCredential(keyCredential)
+	state = sm.buildLedgerState()
+	keyDelegation, err = state.DRepDelegation(keyCredential)
+	require.NoError(t, err)
+	assert.Nil(t, keyDelegation)
+	scriptDelegation, err = state.DRepDelegation(scriptCredential)
+	require.NoError(t, err)
+	require.NotNil(t, scriptDelegation)
+	assert.Equal(t, common.DrepTypeNoConfidence, scriptDelegation.Type)
+}
+
 // TestHarnessRollbackCachePopulatedByBothPaths guards against the
 // runVector / runVectorWithResult parity bug: both vector-execution
 // entry points must populate the rollback cache (initialState and the

--- a/conformance/harness_test.go
+++ b/conformance/harness_test.go
@@ -18,10 +18,14 @@
 package conformance
 
 import (
+	"maps"
 	"path/filepath"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -578,7 +582,8 @@ func TestHarnessRollbackRequiresInitialState(t *testing.T) {
 // invocations so tests can assert on rollback-replay behavior.
 type recordingStateManager struct {
 	*MockStateManager
-	setRewardBalancesCalls []map[common.Blake2b224]uint64
+	setRewardBalancesCalls       []map[common.Blake2b224]uint64
+	setRewardAccountBalanceCalls []map[ledger.RewardAccountKey]uint64
 }
 
 func (r *recordingStateManager) SetRewardBalances(
@@ -590,6 +595,17 @@ func (r *recordingStateManager) SetRewardBalances(
 	}
 	r.setRewardBalancesCalls = append(r.setRewardBalancesCalls, snapshot)
 	r.MockStateManager.SetRewardBalances(b)
+}
+
+func (r *recordingStateManager) SetRewardAccountBalances(
+	balances map[ledger.RewardAccountKey]uint64,
+) {
+	snapshot := maps.Clone(balances)
+	r.setRewardAccountBalanceCalls = append(
+		r.setRewardAccountBalanceCalls,
+		snapshot,
+	)
+	r.MockStateManager.SetRewardAccountBalances(balances)
 }
 
 // TestHarnessRollbackReappliesRewardBalances guards against the
@@ -610,14 +626,17 @@ func TestHarnessRollbackReappliesRewardBalances(t *testing.T) {
 	h.initialEpoch = 0
 	h.currentEpoch = 0
 
-	cred := common.NewBlake2b224(make([]byte, 28))
-	h.finalStateBalances = map[common.Blake2b224]uint64{cred: 1000}
+	cred := ledger.RewardAccountKey{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: common.NewBlake2b224(make([]byte, 28)),
+	}
+	h.finalStateBalances = map[ledger.RewardAccountKey]uint64{cred: 1000}
 	// futureWithdrawals[i] is the cumulative withdrawal from event i to
-	// the end (inclusive of i). adjustRewardBalances looks up index i+1.
-	// Indices 2 and 3 hold distinct values so the assertion below
+	// the end (inclusive of i). adjustRewardBalances looks up index i.
+	// Indices 1 and 2 hold distinct values so the assertion below
 	// differentiates between the journaled originalIdx (correct) and the
 	// replay-loop index (buggy) being used to look up the adjustment.
-	h.futureWithdrawals = []map[common.Blake2b224]uint64{
+	h.futureWithdrawals = []map[ledger.RewardAccountKey]uint64{
 		{cred: 900},
 		{cred: 900},
 		{cred: 500},
@@ -660,21 +679,145 @@ func TestHarnessRollbackReappliesRewardBalances(t *testing.T) {
 		t.Fatalf("rollback failed: %v", err)
 	}
 
-	if len(sm.setRewardBalancesCalls) != 1 {
+	if len(sm.setRewardAccountBalanceCalls) != 1 {
 		t.Fatalf(
-			"expected 1 SetRewardBalances call during replay, got %d",
-			len(sm.setRewardBalancesCalls),
+			"expected 1 SetRewardAccountBalances call during replay, got %d",
+			len(sm.setRewardAccountBalanceCalls),
 		)
 	}
-	got := sm.setRewardBalancesCalls[0][cred]
-	// Correct path uses originalIdx=2 → futureWithdrawals[3]={cred:0}
-	// → adjusted balance = 1000 + 0 = 1000.
+	got := sm.setRewardAccountBalanceCalls[0][cred]
+	// Correct path uses originalIdx=2 → futureWithdrawals[2]={cred:500}
+	// → adjusted balance = 1000 + 500 = 1500.
 	// A bug that uses the replay-loop index i=1 would read
-	// futureWithdrawals[2]={cred:500} → 1500, failing this assertion.
-	const want uint64 = 1000
+	// futureWithdrawals[1]={cred:900} → 1900, failing this assertion.
+	const want uint64 = 1500
 	if got != want {
 		t.Errorf("replay adjusted balance: got %d, want %d", got, want)
 	}
+}
+
+func TestHarnessAdjustRewardBalancesPreservesCredentialIdentity(t *testing.T) {
+	sm := &recordingStateManager{MockStateManager: NewMockStateManager()}
+	h := NewHarness(sm, HarnessConfig{})
+	hash := common.NewBlake2b224(make([]byte, 28))
+	keyAccount := ledger.RewardAccountKey{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	scriptAccount := ledger.RewardAccountKey{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	h.finalStateBalances = map[ledger.RewardAccountKey]uint64{
+		scriptAccount: 2,
+	}
+	h.futureWithdrawals = []map[ledger.RewardAccountKey]uint64{
+		{keyAccount: 3},
+		{},
+	}
+
+	h.adjustRewardBalances(0, VectorEvent{Type: EventTypeTransaction})
+
+	require.Len(t, sm.setRewardAccountBalanceCalls, 1)
+	assert.Equal(t, uint64(3), sm.setRewardAccountBalanceCalls[0][keyAccount])
+	assert.Equal(
+		t,
+		uint64(2),
+		sm.setRewardAccountBalanceCalls[0][scriptAccount],
+	)
+	assert.Empty(t, sm.setRewardBalancesCalls)
+}
+
+func TestMockStateManagerRewardAdjustmentPreservesRegistrationState(
+	t *testing.T,
+) {
+	sm := NewMockStateManager()
+	currentCredential := common.Credential{
+		CredType: common.CredentialTypeAddrKeyHash,
+		Credential: common.NewBlake2b224(
+			append(make([]byte, 27), byte(1)),
+		),
+	}
+	futureCredential := common.Credential{
+		CredType: common.CredentialTypeAddrKeyHash,
+		Credential: common.NewBlake2b224(
+			append(make([]byte, 27), byte(2)),
+		),
+	}
+	currentKey := ledger.NewRewardAccountKey(currentCredential)
+	futureKey := ledger.NewRewardAccountKey(futureCredential)
+	sm.stakeRegistrations[currentCredential.Credential] = 0
+	sm.rewardAccounts[currentKey] = 0
+	sm.govState.RegisterStakeCredential(currentCredential)
+
+	sm.SetRewardAccountBalances(map[ledger.RewardAccountKey]uint64{
+		futureKey: 9,
+	})
+
+	state := sm.GetStateProvider()
+	assert.True(t, state.IsRewardAccountRegistered(currentCredential))
+	currentBalance, err := state.RewardAccountBalance(currentCredential)
+	require.NoError(t, err)
+	require.NotNil(t, currentBalance)
+	assert.Zero(t, *currentBalance)
+	assert.False(t, state.IsRewardAccountRegistered(futureCredential))
+	futureBalance, err := state.RewardAccountBalance(futureCredential)
+	require.NoError(t, err)
+	assert.Nil(t, futureBalance)
+
+	sm.SetRewardAccountBalances(map[ledger.RewardAccountKey]uint64{
+		currentKey: 3,
+		futureKey:  9,
+	})
+
+	state = sm.GetStateProvider()
+	currentBalance, err = state.RewardAccountBalance(currentCredential)
+	require.NoError(t, err)
+	require.NotNil(t, currentBalance)
+	assert.Equal(t, uint64(3), *currentBalance)
+	assert.False(t, state.IsRewardAccountRegistered(futureCredential))
+}
+
+func TestMockStateManagerLoadsLegacyStakeRegistrationAsRewardAccount(
+	t *testing.T,
+) {
+	hash := common.NewBlake2b224(append(make([]byte, 27), byte(3)))
+	sm := NewMockStateManager()
+	require.NoError(t, sm.LoadInitialState(&ParsedInitialState{
+		StakeRegistrations: map[common.Blake2b224]bool{hash: true},
+		RewardAccounts:     map[common.Blake2b224]uint64{hash: 7},
+	}, nil))
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+
+	state := sm.GetStateProvider()
+	assert.True(t, state.IsRewardAccountRegistered(credential))
+	balance, err := state.RewardAccountBalance(credential)
+	require.NoError(t, err)
+	require.NotNil(t, balance)
+	assert.Equal(t, uint64(7), *balance)
+}
+
+func TestMockStateManagerScriptRegistrationPreservesIdentity(t *testing.T) {
+	hash := common.NewBlake2b224(append(make([]byte, 27), byte(4)))
+	scriptCredential := common.Credential{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	keyCredential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	sm := NewMockStateManager()
+	sm.processCertificate(&common.StakeRegistrationCertificate{
+		StakeCredential: scriptCredential,
+	})
+
+	state := sm.GetStateProvider()
+	assert.True(t, state.IsRewardAccountRegistered(scriptCredential))
+	assert.False(t, state.IsRewardAccountRegistered(keyCredential))
 }
 
 // TestHarnessRollbackCachePopulatedByBothPaths guards against the

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -391,8 +391,9 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			m.stakeRegistrations[credential.Credential] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
-			m.govState.DRepDelegations[credential.Credential] = drepDelegation(
-				regCert.Drep,
+			m.govState.SetDRepDelegation(
+				credential,
+				drepDelegation(regCert.Drep),
 			)
 		}
 
@@ -403,8 +404,9 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 			m.stakeRegistrations[credential.Credential] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
-			m.govState.DRepDelegations[credential.Credential] = drepDelegation(
-				regCert.Drep,
+			m.govState.SetDRepDelegation(
+				credential,
+				drepDelegation(regCert.Drep),
 			)
 		}
 
@@ -415,17 +417,17 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 
 	case common.CertificateTypeVoteDelegation:
 		if voteCert, ok := cert.(*common.VoteDelegationCertificate); ok {
-			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] = drepDelegation(
-				voteCert.Drep,
+			m.govState.SetDRepDelegation(
+				voteCert.StakeCredential,
+				drepDelegation(voteCert.Drep),
 			)
 		}
 
 	case common.CertificateTypeStakeVoteDelegation:
 		if voteCert, ok := cert.(*common.StakeVoteDelegationCertificate); ok {
-			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] = drepDelegation(
-				voteCert.Drep,
+			m.govState.SetDRepDelegation(
+				voteCert.StakeCredential,
+				drepDelegation(voteCert.Drep),
 			)
 		}
 
@@ -496,7 +498,6 @@ func (m *MockStateManager) deregisterStakeCredential(
 		m.stakeRegistrations[credential.Credential] = balance
 	} else {
 		delete(m.stakeRegistrations, credential.Credential)
-		delete(m.govState.DRepDelegations, credential.Credential)
 	}
 	m.govState.DeregisterStakeCredential(credential)
 }
@@ -851,10 +852,14 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 			return nil, nil
 		},
 	)
-	drepDelegations := m.govState.DRepDelegations
+	drepDelegations := m.govState.DRepDelegationsByCredential
+	legacyDRepDelegations := m.govState.DRepDelegations
 	builder.WithDRepDelegation(
 		func(cred common.Credential) (*common.Drep, error) {
-			delegation, ok := drepDelegations[cred.Credential]
+			delegation, ok := drepDelegations[ledger.NewRewardAccountKey(cred)]
+			if !ok && len(drepDelegations) == 0 {
+				delegation, ok = legacyDRepDelegations[cred.Credential]
+			}
 			if !ok {
 				return nil, nil
 			}

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -43,7 +43,7 @@ type MockStateManager struct {
 	utxos map[string]common.Utxo
 
 	// stakeRegistrations tracks registered stake credentials and their balances
-	stakeRegistrations map[common.Blake2b224]uint64
+	stakeRegistrations map[ledger.RewardAccountKey]uint64
 
 	// rewardAccounts tracks balances by full credential identity.
 	rewardAccounts map[ledger.RewardAccountKey]uint64
@@ -66,7 +66,7 @@ func NewMockStateManager() *MockStateManager {
 	return &MockStateManager{
 		govState:             NewGovernanceState(),
 		utxos:                make(map[string]common.Utxo),
-		stakeRegistrations:   make(map[common.Blake2b224]uint64),
+		stakeRegistrations:   make(map[ledger.RewardAccountKey]uint64),
 		rewardAccounts:       make(map[ledger.RewardAccountKey]uint64),
 		poolRegistrations:    make(map[common.Blake2b224]bool),
 		drepRegistrations:    make(map[common.Blake2b224]bool),
@@ -85,18 +85,37 @@ func (m *MockStateManager) LoadInitialState(
 
 	// Clear existing state
 	m.utxos = make(map[string]common.Utxo)
-	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.stakeRegistrations = make(map[ledger.RewardAccountKey]uint64)
 	m.rewardAccounts = make(map[ledger.RewardAccountKey]uint64)
 	m.poolRegistrations = make(map[common.Blake2b224]bool)
 	m.drepRegistrations = make(map[common.Blake2b224]bool)
 	m.committeeMembers = make(map[common.Blake2b224]uint64)
 	m.hotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
 
-	// Load stake registrations with reward balances
-	for hash, registered := range state.StakeRegistrations {
-		if registered {
-			balance := state.RewardAccounts[hash]
-			m.stakeRegistrations[hash] = balance
+	// Load stake registrations with reward balances. Prefer full credential
+	// identity. Legacy hash-only registrations represent key credentials.
+	if len(state.StakeRegistrationsByCredential) > 0 {
+		for credential, registered := range state.StakeRegistrationsByCredential {
+			if !registered {
+				continue
+			}
+			balance, exists := state.RewardAccountBalances[credential]
+			if !exists {
+				balance = state.RewardAccounts[credential.Credential]
+			}
+			m.stakeRegistrations[credential] = balance
+		}
+	} else if len(state.RewardAccountBalances) > 0 {
+		maps.Copy(m.stakeRegistrations, state.RewardAccountBalances)
+	} else {
+		for hash, registered := range state.StakeRegistrations {
+			if !registered {
+				continue
+			}
+			m.stakeRegistrations[ledger.RewardAccountKey{
+				CredType:   common.CredentialTypeAddrKeyHash,
+				Credential: hash,
+			}] = state.RewardAccounts[hash]
 		}
 	}
 	if len(state.RewardAccountBalances) > 0 {
@@ -109,23 +128,11 @@ func (m *MockStateManager) LoadInitialState(
 			}] = balance
 		}
 	}
-	// Preserve compatibility for callers that provide only the legacy stake
-	// registration view. Parsed vector state normally supplies full account
-	// identities, so this defaults to a key credential only when no account
-	// with the registered hash is otherwise available.
-	for hash, balance := range m.stakeRegistrations {
-		accountExists := false
-		for account := range m.rewardAccounts {
-			if account.Credential == hash {
-				accountExists = true
-				break
-			}
-		}
-		if !accountExists {
-			m.rewardAccounts[ledger.RewardAccountKey{
-				CredType:   common.CredentialTypeAddrKeyHash,
-				Credential: hash,
-			}] = balance
+	// Preserve compatibility for callers that provide only a registration
+	// view. Every registered account has a balance entry, including zero.
+	for credential, balance := range m.stakeRegistrations {
+		if _, exists := m.rewardAccounts[credential]; !exists {
+			m.rewardAccounts[credential] = balance
 		}
 	}
 
@@ -362,7 +369,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	case common.CertificateTypeStakeRegistration:
 		if regCert, ok := cert.(*common.StakeRegistrationCertificate); ok {
 			credential := regCert.StakeCredential
-			m.stakeRegistrations[credential.Credential] = 0
+			m.stakeRegistrations[ledger.NewRewardAccountKey(credential)] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
 		}
@@ -370,7 +377,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	case common.CertificateTypeRegistration:
 		if regCert, ok := cert.(*common.RegistrationCertificate); ok {
 			credential := regCert.StakeCredential
-			m.stakeRegistrations[credential.Credential] = 0
+			m.stakeRegistrations[ledger.NewRewardAccountKey(credential)] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
 		}
@@ -379,7 +386,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 		// Combined registration + delegation (Conway)
 		if regCert, ok := cert.(*common.StakeRegistrationDelegationCertificate); ok {
 			credential := regCert.StakeCredential
-			m.stakeRegistrations[credential.Credential] = 0
+			m.stakeRegistrations[ledger.NewRewardAccountKey(credential)] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
 		}
@@ -388,7 +395,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 		// Combined registration + vote delegation (Conway)
 		if regCert, ok := cert.(*common.VoteRegistrationDelegationCertificate); ok {
 			credential := regCert.StakeCredential
-			m.stakeRegistrations[credential.Credential] = 0
+			m.stakeRegistrations[ledger.NewRewardAccountKey(credential)] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
 			m.govState.SetDRepDelegation(
@@ -401,7 +408,7 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 		// Combined registration + stake + vote delegation (Conway)
 		if regCert, ok := cert.(*common.StakeVoteRegistrationDelegationCertificate); ok {
 			credential := regCert.StakeCredential
-			m.stakeRegistrations[credential.Credential] = 0
+			m.stakeRegistrations[ledger.NewRewardAccountKey(credential)] = 0
 			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
 			m.govState.RegisterStakeCredential(credential)
 			m.govState.SetDRepDelegation(
@@ -492,13 +499,9 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 func (m *MockStateManager) deregisterStakeCredential(
 	credential common.Credential,
 ) {
-	delete(m.rewardAccounts, ledger.NewRewardAccountKey(credential))
-	remaining := rewardBalancesByHash(m.rewardAccounts)
-	if balance, exists := remaining[credential.Credential]; exists {
-		m.stakeRegistrations[credential.Credential] = balance
-	} else {
-		delete(m.stakeRegistrations, credential.Credential)
-	}
+	credentialKey := ledger.NewRewardAccountKey(credential)
+	delete(m.rewardAccounts, credentialKey)
+	delete(m.stakeRegistrations, credentialKey)
 	m.govState.DeregisterStakeCredential(credential)
 }
 
@@ -755,7 +758,7 @@ func (m *MockStateManager) SetRewardAccountBalances(
 func (m *MockStateManager) syncRewardBalanceMirrors() {
 	legacyBalances := rewardBalancesByHash(m.rewardAccounts)
 	for cred := range m.stakeRegistrations {
-		if balance, exists := legacyBalances[cred]; exists {
+		if balance, exists := m.rewardAccounts[cred]; exists {
 			m.stakeRegistrations[cred] = balance
 		}
 	}
@@ -775,7 +778,7 @@ func (m *MockStateManager) Reset() error {
 	m.protocolParams = nil
 	m.currentEpoch = 0
 	m.utxos = make(map[string]common.Utxo)
-	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.stakeRegistrations = make(map[ledger.RewardAccountKey]uint64)
 	m.rewardAccounts = make(map[ledger.RewardAccountKey]uint64)
 	m.poolRegistrations = make(map[common.Blake2b224]bool)
 	m.drepRegistrations = make(map[common.Blake2b224]bool)

--- a/conformance/mock_state_manager.go
+++ b/conformance/mock_state_manager.go
@@ -45,6 +45,9 @@ type MockStateManager struct {
 	// stakeRegistrations tracks registered stake credentials and their balances
 	stakeRegistrations map[common.Blake2b224]uint64
 
+	// rewardAccounts tracks balances by full credential identity.
+	rewardAccounts map[ledger.RewardAccountKey]uint64
+
 	// poolRegistrations tracks registered pools
 	poolRegistrations map[common.Blake2b224]bool
 
@@ -64,6 +67,7 @@ func NewMockStateManager() *MockStateManager {
 		govState:             NewGovernanceState(),
 		utxos:                make(map[string]common.Utxo),
 		stakeRegistrations:   make(map[common.Blake2b224]uint64),
+		rewardAccounts:       make(map[ledger.RewardAccountKey]uint64),
 		poolRegistrations:    make(map[common.Blake2b224]bool),
 		drepRegistrations:    make(map[common.Blake2b224]bool),
 		committeeMembers:     make(map[common.Blake2b224]uint64),
@@ -82,6 +86,7 @@ func (m *MockStateManager) LoadInitialState(
 	// Clear existing state
 	m.utxos = make(map[string]common.Utxo)
 	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.rewardAccounts = make(map[ledger.RewardAccountKey]uint64)
 	m.poolRegistrations = make(map[common.Blake2b224]bool)
 	m.drepRegistrations = make(map[common.Blake2b224]bool)
 	m.committeeMembers = make(map[common.Blake2b224]uint64)
@@ -92,6 +97,35 @@ func (m *MockStateManager) LoadInitialState(
 		if registered {
 			balance := state.RewardAccounts[hash]
 			m.stakeRegistrations[hash] = balance
+		}
+	}
+	if len(state.RewardAccountBalances) > 0 {
+		maps.Copy(m.rewardAccounts, state.RewardAccountBalances)
+	} else {
+		for hash, balance := range state.RewardAccounts {
+			m.rewardAccounts[ledger.RewardAccountKey{
+				CredType:   common.CredentialTypeAddrKeyHash,
+				Credential: hash,
+			}] = balance
+		}
+	}
+	// Preserve compatibility for callers that provide only the legacy stake
+	// registration view. Parsed vector state normally supplies full account
+	// identities, so this defaults to a key credential only when no account
+	// with the registered hash is otherwise available.
+	for hash, balance := range m.stakeRegistrations {
+		accountExists := false
+		for account := range m.rewardAccounts {
+			if account.Credential == hash {
+				accountExists = true
+				break
+			}
+		}
+		if !accountExists {
+			m.rewardAccounts[ledger.RewardAccountKey{
+				CredType:   common.CredentialTypeAddrKeyHash,
+				Credential: hash,
+			}] = balance
 		}
 	}
 
@@ -115,6 +149,7 @@ func (m *MockStateManager) LoadInitialState(
 	// Load governance state
 	m.govState = NewGovernanceState()
 	m.govState.LoadFromParsedState(state)
+	m.syncRewardBalanceMirrors()
 
 	// Populate UTxOs from parsed state using the fully decoded Output
 	for utxoId, parsedUtxo := range state.Utxos {
@@ -326,42 +361,51 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	switch certType {
 	case common.CertificateTypeStakeRegistration:
 		if regCert, ok := cert.(*common.StakeRegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			m.stakeRegistrations[credential] = 0
-			m.govState.RegisterStake(credential)
+			credential := regCert.StakeCredential
+			m.stakeRegistrations[credential.Credential] = 0
+			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
+			m.govState.RegisterStakeCredential(credential)
 		}
 
 	case common.CertificateTypeRegistration:
 		if regCert, ok := cert.(*common.RegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			m.stakeRegistrations[credential] = 0
-			m.govState.RegisterStake(credential)
+			credential := regCert.StakeCredential
+			m.stakeRegistrations[credential.Credential] = 0
+			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
+			m.govState.RegisterStakeCredential(credential)
 		}
 
 	case common.CertificateTypeStakeRegistrationDelegation:
 		// Combined registration + delegation (Conway)
 		if regCert, ok := cert.(*common.StakeRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			m.stakeRegistrations[credential] = 0
-			m.govState.RegisterStake(credential)
+			credential := regCert.StakeCredential
+			m.stakeRegistrations[credential.Credential] = 0
+			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
+			m.govState.RegisterStakeCredential(credential)
 		}
 
 	case common.CertificateTypeVoteRegistrationDelegation:
 		// Combined registration + vote delegation (Conway)
 		if regCert, ok := cert.(*common.VoteRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			m.stakeRegistrations[credential] = 0
-			m.govState.RegisterStake(credential)
-			m.govState.DRepDelegations[credential] = drepDelegation(regCert.Drep)
+			credential := regCert.StakeCredential
+			m.stakeRegistrations[credential.Credential] = 0
+			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
+			m.govState.RegisterStakeCredential(credential)
+			m.govState.DRepDelegations[credential.Credential] = drepDelegation(
+				regCert.Drep,
+			)
 		}
 
 	case common.CertificateTypeStakeVoteRegistrationDelegation:
 		// Combined registration + stake + vote delegation (Conway)
 		if regCert, ok := cert.(*common.StakeVoteRegistrationDelegationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			m.stakeRegistrations[credential] = 0
-			m.govState.RegisterStake(credential)
-			m.govState.DRepDelegations[credential] = drepDelegation(regCert.Drep)
+			credential := regCert.StakeCredential
+			m.stakeRegistrations[credential.Credential] = 0
+			m.rewardAccounts[ledger.NewRewardAccountKey(credential)] = 0
+			m.govState.RegisterStakeCredential(credential)
+			m.govState.DRepDelegations[credential.Credential] = drepDelegation(
+				regCert.Drep,
+			)
 		}
 
 	case common.CertificateTypeStakeDelegation:
@@ -372,29 +416,27 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	case common.CertificateTypeVoteDelegation:
 		if voteCert, ok := cert.(*common.VoteDelegationCertificate); ok {
 			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] = drepDelegation(voteCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(
+				voteCert.Drep,
+			)
 		}
 
 	case common.CertificateTypeStakeVoteDelegation:
 		if voteCert, ok := cert.(*common.StakeVoteDelegationCertificate); ok {
 			credential := voteCert.StakeCredential.Credential
-			m.govState.DRepDelegations[credential] = drepDelegation(voteCert.Drep)
+			m.govState.DRepDelegations[credential] = drepDelegation(
+				voteCert.Drep,
+			)
 		}
 
 	case common.CertificateTypeStakeDeregistration:
 		if deregCert, ok := cert.(*common.StakeDeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
-			delete(m.stakeRegistrations, credential)
-			delete(m.govState.DRepDelegations, credential)
-			m.govState.DeregisterStake(credential)
+			m.deregisterStakeCredential(deregCert.StakeCredential)
 		}
 
 	case common.CertificateTypeDeregistration:
 		if deregCert, ok := cert.(*common.DeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
-			delete(m.stakeRegistrations, credential)
-			delete(m.govState.DRepDelegations, credential)
-			m.govState.DeregisterStake(credential)
+			m.deregisterStakeCredential(deregCert.StakeCredential)
 		}
 
 	case common.CertificateTypePoolRegistration:
@@ -443,6 +485,20 @@ func (m *MockStateManager) processCertificate(cert common.Certificate) {
 	default:
 		// Other certificate types not relevant for state tracking
 	}
+}
+
+func (m *MockStateManager) deregisterStakeCredential(
+	credential common.Credential,
+) {
+	delete(m.rewardAccounts, ledger.NewRewardAccountKey(credential))
+	remaining := rewardBalancesByHash(m.rewardAccounts)
+	if balance, exists := remaining[credential.Credential]; exists {
+		m.stakeRegistrations[credential.Credential] = balance
+	} else {
+		delete(m.stakeRegistrations, credential.Credential)
+		delete(m.govState.DRepDelegations, credential.Credential)
+	}
+	m.govState.DeregisterStakeCredential(credential)
 }
 
 func drepDelegation(drep common.Drep) common.Drep {
@@ -674,18 +730,37 @@ func (m *MockStateManager) GetGovernanceState() *GovernanceState {
 func (m *MockStateManager) SetRewardBalances(
 	balances map[common.Blake2b224]uint64,
 ) {
-	// Update both the state manager's internal tracking and governance state
-	for cred, balance := range balances {
-		if _, exists := m.stakeRegistrations[cred]; exists {
+	for credential := range m.rewardAccounts {
+		if balance, exists := balances[credential.Credential]; exists {
+			m.rewardAccounts[credential] = balance
+		}
+	}
+	m.syncRewardBalanceMirrors()
+}
+
+// SetRewardAccountBalances updates currently registered reward balances by
+// full credential identity without changing registration state.
+func (m *MockStateManager) SetRewardAccountBalances(
+	balances map[ledger.RewardAccountKey]uint64,
+) {
+	for credential := range m.rewardAccounts {
+		if balance, exists := balances[credential]; exists {
+			m.rewardAccounts[credential] = balance
+		}
+	}
+	m.syncRewardBalanceMirrors()
+}
+
+func (m *MockStateManager) syncRewardBalanceMirrors() {
+	legacyBalances := rewardBalancesByHash(m.rewardAccounts)
+	for cred := range m.stakeRegistrations {
+		if balance, exists := legacyBalances[cred]; exists {
 			m.stakeRegistrations[cred] = balance
 		}
 	}
 	if m.govState != nil {
-		for cred, balance := range balances {
-			if m.govState.StakeRegistrations[cred] {
-				m.govState.RewardAccounts[cred] = balance
-			}
-		}
+		m.govState.RewardAccountBalances = maps.Clone(m.rewardAccounts)
+		m.govState.RewardAccounts = legacyBalances
 	}
 }
 
@@ -700,6 +775,7 @@ func (m *MockStateManager) Reset() error {
 	m.currentEpoch = 0
 	m.utxos = make(map[string]common.Utxo)
 	m.stakeRegistrations = make(map[common.Blake2b224]uint64)
+	m.rewardAccounts = make(map[ledger.RewardAccountKey]uint64)
 	m.poolRegistrations = make(map[common.Blake2b224]bool)
 	m.drepRegistrations = make(map[common.Blake2b224]bool)
 	m.committeeMembers = make(map[common.Blake2b224]uint64)
@@ -727,18 +803,11 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 		return common.Utxo{}, ledger.ErrNotFound
 	})
 
-	// Set up stake registrations
-	stakeRegs := m.stakeRegistrations // capture for closure
-	builder.WithStakeCredentials(func() map[common.Blake2b224]bool {
-		result := make(map[common.Blake2b224]bool)
-		for cred := range stakeRegs {
-			result[cred] = true
-		}
-		return result
-	}())
-
-	// Set up reward account balances
-	builder.WithRewardAccounts(stakeRegs)
+	// Reward-account entries carry both registration and balance. Every
+	// registration path above creates an entry, including registered-zero
+	// accounts, so using the credential-aware builder avoids fabricating a
+	// key credential for a registered script account.
+	builder.WithRewardAccountCredentialBalances(m.rewardAccounts)
 
 	// Set up pool lookup callback
 	// Pool is considered registered if:
@@ -789,7 +858,9 @@ func (m *MockStateManager) buildLedgerState() *ledger.MockLedgerState {
 			if !ok {
 				return nil, nil
 			}
-			delegation.Credential = append([]byte(nil), delegation.Credential...)
+			delegation.Credential = append(
+				[]byte(nil),
+				delegation.Credential...)
 			return &delegation, nil
 		},
 	)

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -88,7 +88,12 @@ type GovernanceState struct {
 
 	// DRepDelegations maps stake credentials to their delegated DRep, including
 	// the special always-abstain and always-no-confidence DReps.
+	// Deprecated: use DRepDelegationsByCredential when credential type matters.
 	DRepDelegations map[common.Blake2b224]common.Drep
+
+	// DRepDelegationsByCredential maps full stake credential identities to
+	// their delegated DRep.
+	DRepDelegationsByCredential map[ledger.RewardAccountKey]common.Drep
 
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
@@ -141,9 +146,12 @@ type ProposalState struct {
 // NewGovernanceState creates a new empty governance state.
 func NewGovernanceState() *GovernanceState {
 	return &GovernanceState{
-		CommitteeMembers:      make(map[common.Blake2b224]*CommitteeMemberInfo),
-		DRepRegistrations:     make(map[common.Blake2b224]bool),
-		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
+		CommitteeMembers:  make(map[common.Blake2b224]*CommitteeMemberInfo),
+		DRepRegistrations: make(map[common.Blake2b224]bool),
+		DRepDelegations:   make(map[common.Blake2b224]common.Drep),
+		DRepDelegationsByCredential: make(
+			map[ledger.RewardAccountKey]common.Drep,
+		),
 		HotKeyAuthorizations:  make(map[common.Blake2b224]common.Blake2b224),
 		StakeRegistrations:    make(map[common.Blake2b224]bool),
 		PoolRegistrations:     make(map[common.Blake2b224]bool),
@@ -164,6 +172,9 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	g.HotKeyAuthorizations = make(map[common.Blake2b224]common.Blake2b224)
 	g.DRepRegistrations = make(map[common.Blake2b224]bool)
 	g.DRepDelegations = make(map[common.Blake2b224]common.Drep)
+	g.DRepDelegationsByCredential = make(
+		map[ledger.RewardAccountKey]common.Drep,
+	)
 	g.StakeRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRetirements = make(map[common.Blake2b224]uint64)
@@ -195,7 +206,22 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	for _, drepHash := range state.DRepRegistrations {
 		g.DRepRegistrations[drepHash] = true
 	}
-	maps.Copy(g.DRepDelegations, state.DRepDelegations)
+	if len(state.DRepDelegationsByCredential) > 0 {
+		maps.Copy(
+			g.DRepDelegationsByCredential,
+			state.DRepDelegationsByCredential,
+		)
+	} else {
+		for credential, delegation := range state.DRepDelegations {
+			g.DRepDelegationsByCredential[ledger.RewardAccountKey{
+				CredType:   common.CredentialTypeAddrKeyHash,
+				Credential: credential,
+			}] = delegation
+		}
+	}
+	g.DRepDelegations = drepDelegationsByHash(
+		g.DRepDelegationsByCredential,
+	)
 
 	// Load stake registrations
 	maps.Copy(g.StakeRegistrations, state.StakeRegistrations)
@@ -317,6 +343,23 @@ func (g *GovernanceState) RegisterStakeCredential(
 	}
 }
 
+// SetDRepDelegation records a vote delegation for one full stake credential.
+func (g *GovernanceState) SetDRepDelegation(
+	credential common.Credential,
+	delegation common.Drep,
+) {
+	if g.DRepDelegationsByCredential == nil {
+		g.DRepDelegationsByCredential = make(
+			map[ledger.RewardAccountKey]common.Drep,
+		)
+	}
+	credentialKey := ledger.NewRewardAccountKey(credential)
+	g.DRepDelegationsByCredential[credentialKey] = delegation
+	g.DRepDelegations = drepDelegationsByHash(
+		g.DRepDelegationsByCredential,
+	)
+}
+
 // DeregisterStake deregisters a stake credential.
 func (g *GovernanceState) DeregisterStake(hash common.Blake2b224) {
 	delete(g.StakeRegistrations, hash)
@@ -326,6 +369,14 @@ func (g *GovernanceState) DeregisterStake(hash common.Blake2b224) {
 			delete(g.RewardAccountBalances, credential)
 		}
 	}
+	for credential := range g.DRepDelegationsByCredential {
+		if credential.Credential == hash {
+			delete(g.DRepDelegationsByCredential, credential)
+		}
+	}
+	g.DRepDelegations = drepDelegationsByHash(
+		g.DRepDelegationsByCredential,
+	)
 }
 
 // DeregisterStakeCredential deregisters one full stake credential without
@@ -334,6 +385,13 @@ func (g *GovernanceState) DeregisterStakeCredential(
 	credential common.Credential,
 ) {
 	delete(g.RewardAccountBalances, ledger.NewRewardAccountKey(credential))
+	delete(
+		g.DRepDelegationsByCredential,
+		ledger.NewRewardAccountKey(credential),
+	)
+	g.DRepDelegations = drepDelegationsByHash(
+		g.DRepDelegationsByCredential,
+	)
 	remaining := rewardBalancesByHash(g.RewardAccountBalances)
 	if balance, exists := remaining[credential.Credential]; exists {
 		g.RewardAccounts[credential.Credential] = balance
@@ -341,6 +399,19 @@ func (g *GovernanceState) DeregisterStakeCredential(
 	}
 	delete(g.StakeRegistrations, credential.Credential)
 	delete(g.RewardAccounts, credential.Credential)
+}
+
+func drepDelegationsByHash(
+	delegations map[ledger.RewardAccountKey]common.Drep,
+) map[common.Blake2b224]common.Drep {
+	result := make(map[common.Blake2b224]common.Drep, len(delegations))
+	for credential, delegation := range delegations {
+		_, exists := result[credential.Credential]
+		if !exists || credential.CredType == common.CredentialTypeAddrKeyHash {
+			result[credential.Credential] = delegation
+		}
+	}
+	return result
 }
 
 // RegisterDRep registers a DRep.

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -28,6 +28,16 @@ import (
 // unchanged. Implementors should refer to ledger.StateProvider directly.
 type StateProvider = ledger.StateProvider
 
+// RewardAccountBalanceSetter is an optional StateManager extension for
+// preserving the full reward-account credential identity. The harness falls
+// back to StateManager.SetRewardBalances for implementations that have not yet
+// adopted it.
+type RewardAccountBalanceSetter interface {
+	// SetRewardAccountBalances updates balances for accounts already registered
+	// by the state manager. It must not create or remove registrations.
+	SetRewardAccountBalances(balances map[ledger.RewardAccountKey]uint64)
+}
+
 // StateManager handles state mutations during test execution.
 // Implementations manage the full lifecycle of ledger state for a test vector.
 type StateManager interface {
@@ -93,7 +103,11 @@ type GovernanceState struct {
 	PoolRetirements map[common.Blake2b224]uint64
 
 	// RewardAccounts maps stake credentials to their reward balances.
+	// Deprecated: use RewardAccountBalances when credential type matters.
 	RewardAccounts map[common.Blake2b224]uint64
+
+	// RewardAccountBalances maps full credential identities to reward balances.
+	RewardAccountBalances map[ledger.RewardAccountKey]uint64
 
 	// Proposals maps GovActionId (as "txHash#index") to proposal info.
 	Proposals map[string]*ProposalState
@@ -127,16 +141,17 @@ type ProposalState struct {
 // NewGovernanceState creates a new empty governance state.
 func NewGovernanceState() *GovernanceState {
 	return &GovernanceState{
-		CommitteeMembers:     make(map[common.Blake2b224]*CommitteeMemberInfo),
-		DRepRegistrations:    make(map[common.Blake2b224]bool),
-		DRepDelegations:      make(map[common.Blake2b224]common.Drep),
-		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
-		StakeRegistrations:   make(map[common.Blake2b224]bool),
-		PoolRegistrations:    make(map[common.Blake2b224]bool),
-		PoolRetirements:      make(map[common.Blake2b224]uint64),
-		RewardAccounts:       make(map[common.Blake2b224]uint64),
-		Proposals:            make(map[string]*ProposalState),
-		EnactedProposals:     make(map[string]bool),
+		CommitteeMembers:      make(map[common.Blake2b224]*CommitteeMemberInfo),
+		DRepRegistrations:     make(map[common.Blake2b224]bool),
+		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
+		HotKeyAuthorizations:  make(map[common.Blake2b224]common.Blake2b224),
+		StakeRegistrations:    make(map[common.Blake2b224]bool),
+		PoolRegistrations:     make(map[common.Blake2b224]bool),
+		PoolRetirements:       make(map[common.Blake2b224]uint64),
+		RewardAccounts:        make(map[common.Blake2b224]uint64),
+		RewardAccountBalances: make(map[ledger.RewardAccountKey]uint64),
+		Proposals:             make(map[string]*ProposalState),
+		EnactedProposals:      make(map[string]bool),
 	}
 }
 
@@ -153,6 +168,7 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 	g.PoolRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRetirements = make(map[common.Blake2b224]uint64)
 	g.RewardAccounts = make(map[common.Blake2b224]uint64)
+	g.RewardAccountBalances = make(map[ledger.RewardAccountKey]uint64)
 	g.Proposals = make(map[string]*ProposalState)
 	g.EnactedProposals = make(map[string]bool)
 	g.Roots = ProposalRoots{}
@@ -189,6 +205,7 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 
 	// Load reward accounts
 	maps.Copy(g.RewardAccounts, state.RewardAccounts)
+	maps.Copy(g.RewardAccountBalances, state.RewardAccountBalances)
 
 	// Load proposals (preserve RatifiedEpoch from parsed state)
 	for id, info := range state.Proposals {
@@ -251,6 +268,18 @@ func (g *GovernanceState) GetRewardBalance(hash common.Blake2b224) uint64 {
 	return g.RewardAccounts[hash]
 }
 
+// GetRewardAccountBalance returns the reward balance for a full credential
+// identity. It falls back to the legacy key-hash map for state constructed by
+// older consumers.
+func (g *GovernanceState) GetRewardAccountBalance(
+	credential common.Credential,
+) uint64 {
+	if len(g.RewardAccountBalances) > 0 {
+		return g.RewardAccountBalances[ledger.NewRewardAccountKey(credential)]
+	}
+	return g.GetRewardBalance(credential.Credential)
+}
+
 // GetEnactedRoot returns the enacted root for a governance action type.
 func (g *GovernanceState) GetEnactedRoot(
 	actionType common.GovActionType,
@@ -275,10 +304,43 @@ func (g *GovernanceState) RegisterStake(hash common.Blake2b224) {
 	g.StakeRegistrations[hash] = true
 }
 
+// RegisterStakeCredential registers a full stake credential and initializes
+// its reward account without aliasing another credential type.
+func (g *GovernanceState) RegisterStakeCredential(
+	credential common.Credential,
+) {
+	g.RegisterStake(credential.Credential)
+	g.RewardAccountBalances[ledger.NewRewardAccountKey(credential)] = 0
+	if _, exists := g.RewardAccounts[credential.Credential]; !exists ||
+		credential.CredType == common.CredentialTypeAddrKeyHash {
+		g.RewardAccounts[credential.Credential] = 0
+	}
+}
+
 // DeregisterStake deregisters a stake credential.
 func (g *GovernanceState) DeregisterStake(hash common.Blake2b224) {
 	delete(g.StakeRegistrations, hash)
 	delete(g.RewardAccounts, hash)
+	for credential := range g.RewardAccountBalances {
+		if credential.Credential == hash {
+			delete(g.RewardAccountBalances, credential)
+		}
+	}
+}
+
+// DeregisterStakeCredential deregisters one full stake credential without
+// deleting a different credential type that carries the same hash.
+func (g *GovernanceState) DeregisterStakeCredential(
+	credential common.Credential,
+) {
+	delete(g.RewardAccountBalances, ledger.NewRewardAccountKey(credential))
+	remaining := rewardBalancesByHash(g.RewardAccountBalances)
+	if balance, exists := remaining[credential.Credential]; exists {
+		g.RewardAccounts[credential.Credential] = balance
+		return
+	}
+	delete(g.StakeRegistrations, credential.Credential)
+	delete(g.RewardAccounts, credential.Credential)
 }
 
 // RegisterDRep registers a DRep.

--- a/conformance/state.go
+++ b/conformance/state.go
@@ -99,7 +99,13 @@ type GovernanceState struct {
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
 
 	// StakeRegistrations tracks which stake credentials are registered.
+	// Deprecated: use StakeRegistrationsByCredential when credential type
+	// matters.
 	StakeRegistrations map[common.Blake2b224]bool
+
+	// StakeRegistrationsByCredential tracks registrations by full stake
+	// credential identity.
+	StakeRegistrationsByCredential map[ledger.RewardAccountKey]bool
 
 	// PoolRegistrations tracks which pools are registered.
 	PoolRegistrations map[common.Blake2b224]bool
@@ -152,8 +158,11 @@ func NewGovernanceState() *GovernanceState {
 		DRepDelegationsByCredential: make(
 			map[ledger.RewardAccountKey]common.Drep,
 		),
-		HotKeyAuthorizations:  make(map[common.Blake2b224]common.Blake2b224),
-		StakeRegistrations:    make(map[common.Blake2b224]bool),
+		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+		StakeRegistrations:   make(map[common.Blake2b224]bool),
+		StakeRegistrationsByCredential: make(
+			map[ledger.RewardAccountKey]bool,
+		),
 		PoolRegistrations:     make(map[common.Blake2b224]bool),
 		PoolRetirements:       make(map[common.Blake2b224]uint64),
 		RewardAccounts:        make(map[common.Blake2b224]uint64),
@@ -176,6 +185,9 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 		map[ledger.RewardAccountKey]common.Drep,
 	)
 	g.StakeRegistrations = make(map[common.Blake2b224]bool)
+	g.StakeRegistrationsByCredential = make(
+		map[ledger.RewardAccountKey]bool,
+	)
 	g.PoolRegistrations = make(map[common.Blake2b224]bool)
 	g.PoolRetirements = make(map[common.Blake2b224]uint64)
 	g.RewardAccounts = make(map[common.Blake2b224]uint64)
@@ -225,6 +237,26 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 
 	// Load stake registrations
 	maps.Copy(g.StakeRegistrations, state.StakeRegistrations)
+	if len(state.StakeRegistrationsByCredential) > 0 {
+		maps.Copy(
+			g.StakeRegistrationsByCredential,
+			state.StakeRegistrationsByCredential,
+		)
+	} else if len(state.RewardAccountBalances) > 0 {
+		for credential := range state.RewardAccountBalances {
+			g.StakeRegistrationsByCredential[credential] = true
+		}
+	} else {
+		for hash, registered := range state.StakeRegistrations {
+			if !registered {
+				continue
+			}
+			g.StakeRegistrationsByCredential[ledger.RewardAccountKey{
+				CredType:   common.CredentialTypeAddrKeyHash,
+				Credential: hash,
+			}] = true
+		}
+	}
 
 	// Load pool registrations
 	maps.Copy(g.PoolRegistrations, state.PoolRegistrations)
@@ -251,6 +283,16 @@ func (g *GovernanceState) LoadFromParsedState(state *ParsedInitialState) {
 // IsStakeRegistered checks if a stake credential is registered.
 func (g *GovernanceState) IsStakeRegistered(hash common.Blake2b224) bool {
 	return g.StakeRegistrations[hash]
+}
+
+// IsStakeCredentialRegistered checks registration by full credential identity.
+func (g *GovernanceState) IsStakeCredentialRegistered(
+	credential common.Credential,
+) bool {
+	if len(g.StakeRegistrationsByCredential) > 0 {
+		return g.StakeRegistrationsByCredential[ledger.NewRewardAccountKey(credential)]
+	}
+	return g.IsStakeRegistered(credential.Credential)
 }
 
 // IsDRepRegistered checks if a DRep is registered.
@@ -328,6 +370,10 @@ func (g *GovernanceState) GetEnactedRoot(
 // RegisterStake registers a stake credential.
 func (g *GovernanceState) RegisterStake(hash common.Blake2b224) {
 	g.StakeRegistrations[hash] = true
+	g.StakeRegistrationsByCredential[ledger.RewardAccountKey{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}] = true
 }
 
 // RegisterStakeCredential registers a full stake credential and initializes
@@ -335,7 +381,8 @@ func (g *GovernanceState) RegisterStake(hash common.Blake2b224) {
 func (g *GovernanceState) RegisterStakeCredential(
 	credential common.Credential,
 ) {
-	g.RegisterStake(credential.Credential)
+	g.StakeRegistrations[credential.Credential] = true
+	g.StakeRegistrationsByCredential[ledger.NewRewardAccountKey(credential)] = true
 	g.RewardAccountBalances[ledger.NewRewardAccountKey(credential)] = 0
 	if _, exists := g.RewardAccounts[credential.Credential]; !exists ||
 		credential.CredType == common.CredentialTypeAddrKeyHash {
@@ -363,6 +410,11 @@ func (g *GovernanceState) SetDRepDelegation(
 // DeregisterStake deregisters a stake credential.
 func (g *GovernanceState) DeregisterStake(hash common.Blake2b224) {
 	delete(g.StakeRegistrations, hash)
+	for credential := range g.StakeRegistrationsByCredential {
+		if credential.Credential == hash {
+			delete(g.StakeRegistrationsByCredential, credential)
+		}
+	}
 	delete(g.RewardAccounts, hash)
 	for credential := range g.RewardAccountBalances {
 		if credential.Credential == hash {
@@ -384,6 +436,10 @@ func (g *GovernanceState) DeregisterStake(hash common.Blake2b224) {
 func (g *GovernanceState) DeregisterStakeCredential(
 	credential common.Credential,
 ) {
+	delete(
+		g.StakeRegistrationsByCredential,
+		ledger.NewRewardAccountKey(credential),
+	)
 	delete(g.RewardAccountBalances, ledger.NewRewardAccountKey(credential))
 	delete(
 		g.DRepDelegationsByCredential,
@@ -392,10 +448,17 @@ func (g *GovernanceState) DeregisterStakeCredential(
 	g.DRepDelegations = drepDelegationsByHash(
 		g.DRepDelegationsByCredential,
 	)
-	remaining := rewardBalancesByHash(g.RewardAccountBalances)
-	if balance, exists := remaining[credential.Credential]; exists {
-		g.RewardAccounts[credential.Credential] = balance
-		return
+	for registration, registered := range g.StakeRegistrationsByCredential {
+		if registered && registration.Credential == credential.Credential {
+			g.StakeRegistrations[credential.Credential] = true
+			remainingBalances := rewardBalancesByHash(g.RewardAccountBalances)
+			if balance, exists := remainingBalances[credential.Credential]; exists {
+				g.RewardAccounts[credential.Credential] = balance
+			} else {
+				g.RewardAccounts[credential.Credential] = 0
+			}
+			return
+		}
 	}
 	delete(g.StakeRegistrations, credential.Credential)
 	delete(g.RewardAccounts, credential.Credential)

--- a/conformance/state_parser.go
+++ b/conformance/state_parser.go
@@ -69,7 +69,12 @@ type ParsedInitialState struct {
 
 	// DRepDelegations maps stake credentials to their delegated DRep, including
 	// the special always-abstain and always-no-confidence DReps.
+	// Deprecated: use DRepDelegationsByCredential when credential type matters.
 	DRepDelegations map[common.Blake2b224]common.Drep
+
+	// DRepDelegationsByCredential maps full stake credential identities to
+	// their delegated DRep.
+	DRepDelegationsByCredential map[mockledger.RewardAccountKey]common.Drep
 
 	// HotKeyAuthorizations maps cold keys to hot keys for committee members.
 	HotKeyAuthorizations map[common.Blake2b224]common.Blake2b224
@@ -152,9 +157,12 @@ func ParseInitialState(raw cbor.RawMessage) (*ParsedInitialState, error) {
 		PoolRegistrations:     make(map[common.Blake2b224]bool),
 		CommitteeMembers:      make(map[common.Blake2b224]uint64),
 		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
-		HotKeyAuthorizations:  make(map[common.Blake2b224]common.Blake2b224),
-		Proposals:             make(map[string]GovActionInfo),
-		CostModels:            make(map[uint][]int64),
+		DRepDelegationsByCredential: make(
+			map[mockledger.RewardAccountKey]common.Drep,
+		),
+		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
+		Proposals:            make(map[string]GovActionInfo),
+		CostModels:           make(map[uint][]int64),
 	}
 
 	// Extract current epoch from stateArr[0]
@@ -594,6 +602,7 @@ func parseDelegationState(
 				continue
 			}
 			state.StakeRegistrations[cred.Credential] = true
+			accountKey := mockledger.NewRewardAccountKey(*cred)
 
 			// Current AccountState values place the DRep delegation fourth.
 			// Retain the older third-position fallback for existing fixtures.
@@ -603,13 +612,21 @@ func parseDelegationState(
 						continue
 					}
 					if drep := extractDRepDelegation(vArr[idx]); drep != nil {
-						state.DRepDelegations[cred.Credential] = *drep
+						if state.DRepDelegationsByCredential == nil {
+							state.DRepDelegationsByCredential = make(
+								map[mockledger.RewardAccountKey]common.Drep,
+							)
+						}
+						state.DRepDelegationsByCredential[accountKey] = *drep
+						if _, exists := state.DRepDelegations[cred.Credential]; !exists ||
+							cred.CredType == common.CredentialTypeAddrKeyHash {
+							state.DRepDelegations[cred.Credential] = *drep
+						}
 						break
 					}
 				}
 			}
 
-			accountKey := mockledger.NewRewardAccountKey(*cred)
 			state.RewardAccountBalances[accountKey] = balance
 			// Keep the legacy hash-only view deterministic: prefer a key-hash
 			// credential if both credential types carry the same hash.
@@ -676,6 +693,12 @@ func extractDRepDelegation(raw any) *common.Drep {
 	}
 	items, ok := raw.([]any)
 	if !ok || len(items) != 1 {
+		return nil
+	}
+	if wrapped, ok := items[0].([]any); ok {
+		items = wrapped
+	}
+	if len(items) != 1 {
 		return nil
 	}
 	drepType, ok := items[0].(uint64)

--- a/conformance/state_parser.go
+++ b/conformance/state_parser.go
@@ -49,7 +49,13 @@ type ParsedInitialState struct {
 	Utxos map[string]ParsedUtxo
 
 	// StakeRegistrations tracks which stake credentials are registered.
+	// Deprecated: use StakeRegistrationsByCredential when credential type
+	// matters.
 	StakeRegistrations map[common.Blake2b224]bool
+
+	// StakeRegistrationsByCredential tracks registrations by full stake
+	// credential identity.
+	StakeRegistrationsByCredential map[mockledger.RewardAccountKey]bool
 
 	// RewardAccounts maps stake credentials to their reward balances.
 	// Deprecated: use RewardAccountBalances when credential type matters.
@@ -150,8 +156,11 @@ func ParseInitialState(raw cbor.RawMessage) (*ParsedInitialState, error) {
 	}
 
 	state := &ParsedInitialState{
-		Utxos:                 make(map[string]ParsedUtxo),
-		StakeRegistrations:    make(map[common.Blake2b224]bool),
+		Utxos:              make(map[string]ParsedUtxo),
+		StakeRegistrations: make(map[common.Blake2b224]bool),
+		StakeRegistrationsByCredential: make(
+			map[mockledger.RewardAccountKey]bool,
+		),
 		RewardAccounts:        make(map[common.Blake2b224]uint64),
 		RewardAccountBalances: make(map[mockledger.RewardAccountKey]uint64),
 		PoolRegistrations:     make(map[common.Blake2b224]bool),
@@ -603,6 +612,12 @@ func parseDelegationState(
 			}
 			state.StakeRegistrations[cred.Credential] = true
 			accountKey := mockledger.NewRewardAccountKey(*cred)
+			if state.StakeRegistrationsByCredential == nil {
+				state.StakeRegistrationsByCredential = make(
+					map[mockledger.RewardAccountKey]bool,
+				)
+			}
+			state.StakeRegistrationsByCredential[accountKey] = true
 
 			// Current AccountState values place the DRep delegation fourth.
 			// Retain the older third-position fallback for existing fixtures.

--- a/conformance/state_parser.go
+++ b/conformance/state_parser.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
-	"github.com/blinklabs-io/gouroboros/ledger"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 )
 
 // ParsedUtxo contains a UTxO parsed from test vectors.
@@ -51,7 +52,11 @@ type ParsedInitialState struct {
 	StakeRegistrations map[common.Blake2b224]bool
 
 	// RewardAccounts maps stake credentials to their reward balances.
+	// Deprecated: use RewardAccountBalances when credential type matters.
 	RewardAccounts map[common.Blake2b224]uint64
+
+	// RewardAccountBalances maps full credential identities to reward balances.
+	RewardAccountBalances map[mockledger.RewardAccountKey]uint64
 
 	// PoolRegistrations tracks which pools are registered (by pool key hash).
 	PoolRegistrations map[common.Blake2b224]bool
@@ -140,15 +145,16 @@ func ParseInitialState(raw cbor.RawMessage) (*ParsedInitialState, error) {
 	}
 
 	state := &ParsedInitialState{
-		Utxos:                make(map[string]ParsedUtxo),
-		StakeRegistrations:   make(map[common.Blake2b224]bool),
-		RewardAccounts:       make(map[common.Blake2b224]uint64),
-		PoolRegistrations:    make(map[common.Blake2b224]bool),
-		CommitteeMembers:     make(map[common.Blake2b224]uint64),
-		DRepDelegations:      make(map[common.Blake2b224]common.Drep),
-		HotKeyAuthorizations: make(map[common.Blake2b224]common.Blake2b224),
-		Proposals:            make(map[string]GovActionInfo),
-		CostModels:           make(map[uint][]int64),
+		Utxos:                 make(map[string]ParsedUtxo),
+		StakeRegistrations:    make(map[common.Blake2b224]bool),
+		RewardAccounts:        make(map[common.Blake2b224]uint64),
+		RewardAccountBalances: make(map[mockledger.RewardAccountKey]uint64),
+		PoolRegistrations:     make(map[common.Blake2b224]bool),
+		CommitteeMembers:      make(map[common.Blake2b224]uint64),
+		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
+		HotKeyAuthorizations:  make(map[common.Blake2b224]common.Blake2b224),
+		Proposals:             make(map[string]GovActionInfo),
+		CostModels:            make(map[uint][]int64),
 	}
 
 	// Extract current epoch from stateArr[0]
@@ -415,7 +421,7 @@ func parseUtxosFromRawCBOR(raw cbor.RawMessage) (map[string]ParsedUtxo, error) {
 					}
 
 					// Extract hash and index from key
-					var hash ledger.Blake2b256
+					var hash gledger.Blake2b256
 					var index uint32
 					keyOk := false
 
@@ -570,40 +576,95 @@ func parseDelegationState(
 		return nil
 	}
 
-	// unified_map at delegationState[0] contains stake credentials
-	if unifiedMap, ok := delegationState[0].(map[any]any); ok {
+	// The vendored vectors wrap the unified credential map together with a
+	// pointer map. Some synthetic fixtures provide the credential map directly.
+	unifiedMapRaw := delegationState[0]
+	if wrapper, ok := unifiedMapRaw.([]any); ok && len(wrapper) > 0 {
+		unifiedMapRaw = wrapper[0]
+	}
+
+	if unifiedMap, ok := unifiedMapRaw.(map[any]any); ok {
 		for k, v := range unifiedMap {
-			cred := extractCredentialHash(k)
+			cred := extractCredentialHash(unwrapPointer(k))
 			if cred == nil {
+				continue
+			}
+			balance, registered := extractRewardAccountBalance(v)
+			if !registered {
 				continue
 			}
 			state.StakeRegistrations[cred.Credential] = true
 
-			// Extract reward balance if present in value
-			// Value structure: [rewards_map, deposit, drep_delegatee, pool_delegatee]
-			if vArr, ok := v.([]any); ok && len(vArr) >= 1 {
-				// rewards_map contains [[epoch, balance], ...]
-				if rewardsMap, ok := vArr[0].(map[any]any); ok {
-					for _, reward := range rewardsMap {
-						if rewardPair, ok := reward.([]any); ok &&
-							len(rewardPair) >= 2 {
-							if balance, ok := rewardPair[1].(uint64); ok {
-								state.RewardAccounts[cred.Credential] = balance
-								break
-							}
-						}
+			// Current AccountState values place the DRep delegation fourth.
+			// Retain the older third-position fallback for existing fixtures.
+			if vArr, ok := v.([]any); ok {
+				for _, idx := range []int{3, 2} {
+					if len(vArr) <= idx {
+						continue
 					}
-				}
-				if len(vArr) >= 3 {
-					if drep := extractDRepDelegation(vArr[2]); drep != nil {
+					if drep := extractDRepDelegation(vArr[idx]); drep != nil {
 						state.DRepDelegations[cred.Credential] = *drep
+						break
 					}
 				}
+			}
+
+			accountKey := mockledger.NewRewardAccountKey(*cred)
+			state.RewardAccountBalances[accountKey] = balance
+			// Keep the legacy hash-only view deterministic: prefer a key-hash
+			// credential if both credential types carry the same hash.
+			if _, exists := state.RewardAccounts[cred.Credential]; !exists ||
+				cred.CredType == common.CredentialTypeAddrKeyHash {
+				state.RewardAccounts[cred.Credential] = balance
 			}
 		}
 	}
 
 	return nil
+}
+
+// extractRewardAccountBalance reads reward balances from the account layouts
+// used by conformance vectors. Vendored UMap values wrap [reward, deposit] in
+// an optional account state, while modern Conway AccountState values expose
+// balance and deposit directly. The historical rewards-map form remains
+// supported for synthetic and downstream fixtures.
+func extractRewardAccountBalance(raw any) (uint64, bool) {
+	account, ok := raw.([]any)
+	if !ok || len(account) == 0 {
+		return 0, false
+	}
+
+	switch balanceState := account[0].(type) {
+	case uint64:
+		return balanceState, true
+	case []any:
+		if len(balanceState) == 0 {
+			return 0, false
+		}
+		legacyAccount, ok := balanceState[0].([]any)
+		if !ok || len(legacyAccount) == 0 {
+			return 0, false
+		}
+		balance, ok := legacyAccount[0].(uint64)
+		return balance, ok
+	case map[any]any:
+		if len(balanceState) == 0 {
+			return 0, true
+		}
+		for _, reward := range balanceState {
+			rewardPair, ok := reward.([]any)
+			if !ok || len(rewardPair) < 2 {
+				continue
+			}
+			balance, ok := rewardPair[1].(uint64)
+			if ok {
+				return balance, true
+			}
+		}
+		return 0, true
+	}
+
+	return 0, false
 }
 
 func extractDRepDelegation(raw any) *common.Drep {

--- a/conformance/state_parser_test.go
+++ b/conformance/state_parser_test.go
@@ -36,20 +36,34 @@ func TestParseDelegationStatePreservesRewardCredentialIdentity(t *testing.T) {
 		Hash: hash,
 	}
 	state := &ParsedInitialState{
-		StakeRegistrations:    make(map[common.Blake2b224]bool),
-		RewardAccounts:        make(map[common.Blake2b224]uint64),
-		RewardAccountBalances: make(map[ledger.RewardAccountKey]uint64),
-		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
+		StakeRegistrations: make(map[common.Blake2b224]bool),
+		RewardAccounts:     make(map[common.Blake2b224]uint64),
+		RewardAccountBalances: make(
+			map[ledger.RewardAccountKey]uint64,
+		),
+		DRepDelegations: make(map[common.Blake2b224]common.Drep),
+		DRepDelegationsByCredential: make(
+			map[ledger.RewardAccountKey]common.Drep,
+		),
 	}
-	rewardValue := func(balance uint64) []any {
+	rewardValue := func(balance uint64, drepType int) []any {
 		return []any{
 			[]any{[]any{balance, uint64(2)}},
+			[]any{},
+			[]any{},
+			[]any{[]any{uint64(drepType)}},
 		}
 	}
 	delegationState := []any{
 		map[any]any{
-			keyCredential:    rewardValue(11),
-			scriptCredential: rewardValue(22),
+			keyCredential: rewardValue(
+				11,
+				common.DrepTypeAbstain,
+			),
+			scriptCredential: rewardValue(
+				22,
+				common.DrepTypeNoConfidence,
+			),
 		},
 	}
 
@@ -72,6 +86,27 @@ func TestParseDelegationStatePreservesRewardCredentialIdentity(t *testing.T) {
 		}],
 	)
 	require.Equal(t, uint64(11), state.RewardAccounts[hash])
+	require.Equal(
+		t,
+		common.DrepTypeAbstain,
+		state.DRepDelegationsByCredential[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: hash,
+		}].Type,
+	)
+	require.Equal(
+		t,
+		common.DrepTypeNoConfidence,
+		state.DRepDelegationsByCredential[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeScriptHash,
+			Credential: hash,
+		}].Type,
+	)
+	require.Equal(
+		t,
+		common.DrepTypeAbstain,
+		state.DRepDelegations[hash].Type,
+	)
 }
 
 func TestParseStakeCredentialMapRewardAccountLayouts(t *testing.T) {
@@ -133,6 +168,13 @@ func TestExtractDRepDelegationPreservesType(t *testing.T) {
 			name:     "always no confidence",
 			raw:      []any{uint64(common.DrepTypeNoConfidence)},
 			expected: common.DrepTypeNoConfidence,
+		},
+		{
+			name: "wrapped always abstain",
+			raw: []any{
+				[]any{uint64(common.DrepTypeAbstain)},
+			},
+			expected: common.DrepTypeAbstain,
 		},
 	}
 

--- a/conformance/state_parser_test.go
+++ b/conformance/state_parser_test.go
@@ -85,6 +85,20 @@ func TestParseDelegationStatePreservesRewardCredentialIdentity(t *testing.T) {
 			Credential: hash,
 		}],
 	)
+	require.True(
+		t,
+		state.StakeRegistrationsByCredential[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: hash,
+		}],
+	)
+	require.True(
+		t,
+		state.StakeRegistrationsByCredential[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeScriptHash,
+			Credential: hash,
+		}],
+	)
 	require.Equal(t, uint64(11), state.RewardAccounts[hash])
 	require.Equal(
 		t,

--- a/conformance/state_parser_test.go
+++ b/conformance/state_parser_test.go
@@ -18,10 +18,105 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
+
+func TestParseDelegationStatePreservesRewardCredentialIdentity(t *testing.T) {
+	hash := common.NewBlake2b224(make([]byte, 28))
+	keyCredential := stakeCredential{
+		Type: common.CredentialTypeAddrKeyHash,
+		Hash: hash,
+	}
+	scriptCredential := stakeCredential{
+		Type: common.CredentialTypeScriptHash,
+		Hash: hash,
+	}
+	state := &ParsedInitialState{
+		StakeRegistrations:    make(map[common.Blake2b224]bool),
+		RewardAccounts:        make(map[common.Blake2b224]uint64),
+		RewardAccountBalances: make(map[ledger.RewardAccountKey]uint64),
+		DRepDelegations:       make(map[common.Blake2b224]common.Drep),
+	}
+	rewardValue := func(balance uint64) []any {
+		return []any{
+			[]any{[]any{balance, uint64(2)}},
+		}
+	}
+	delegationState := []any{
+		map[any]any{
+			keyCredential:    rewardValue(11),
+			scriptCredential: rewardValue(22),
+		},
+	}
+
+	require.NoError(t, parseDelegationState(state, delegationState))
+	require.Len(t, state.RewardAccountBalances, 2)
+	require.Equal(
+		t,
+		uint64(11),
+		state.RewardAccountBalances[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeAddrKeyHash,
+			Credential: hash,
+		}],
+	)
+	require.Equal(
+		t,
+		uint64(22),
+		state.RewardAccountBalances[ledger.RewardAccountKey{
+			CredType:   common.CredentialTypeScriptHash,
+			Credential: hash,
+		}],
+	)
+	require.Equal(t, uint64(11), state.RewardAccounts[hash])
+}
+
+func TestParseStakeCredentialMapRewardAccountLayouts(t *testing.T) {
+	hash := common.NewBlake2b224(make([]byte, 28))
+	tests := []struct {
+		name    string
+		account []any
+	}{
+		{
+			name: "vendored legacy UMap",
+			account: []any{
+				[]any{[]any{uint64(11), uint64(2)}},
+				[]any{},
+				[]any{},
+				[]any{},
+			},
+		},
+		{
+			name: "modern Conway account state",
+			account: []any{
+				uint64(11),
+				uint64(2),
+				[]any{},
+				[]any{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encodedAccount, err := cbor.Encode(test.account)
+			require.NoError(t, err)
+			encodedMap := []byte{0xa1, 0x82, 0x00, 0x58, 0x1c}
+			encodedMap = append(encodedMap, hash.Bytes()...)
+			encodedMap = append(encodedMap, encodedAccount...)
+
+			entries := parseStakeCredentialMap(encodedMap)
+
+			require.Len(t, entries, 1)
+			require.Equal(t, uint64(11), entries[0].Balance)
+			require.Equal(t, uint64(0), entries[0].CredType)
+			require.Equal(t, hash.Bytes(), entries[0].Hash)
+		})
+	}
+}
 
 func TestExtractDRepDelegationPreservesType(t *testing.T) {
 	tests := []struct {

--- a/conformance/validation.go
+++ b/conformance/validation.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/ouroboros-mock/ledger"
 )
 
 // Validator performs pre-validation checks on transactions.
@@ -213,9 +214,8 @@ func (v *Validator) validateWithdrawals(
 		if addr == nil {
 			continue
 		}
-		// Extract stake credential from reward address
-		stakeHash := extractStakeHashFromAddress(*addr)
-		if stakeHash == nil {
+		credential, ok := addr.StakeCredential()
+		if !ok {
 			addrBytes, _ := addr.Bytes()
 			return fmt.Errorf(
 				"invalid withdrawal address: cannot extract stake credential from %x",
@@ -224,12 +224,12 @@ func (v *Validator) validateWithdrawals(
 		}
 
 		// Check withdrawal amount matches reward balance exactly
-		balance := govState.GetRewardBalance(*stakeHash)
+		balance := govState.GetRewardAccountBalance(credential)
 		withdrawalAmount := amount.Uint64()
 		if withdrawalAmount != balance {
 			return fmt.Errorf(
 				"withdrawal amount %d does not match balance %d for %x",
-				withdrawalAmount, balance, *stakeHash,
+				withdrawalAmount, balance, credential.Credential,
 			)
 		}
 	}
@@ -248,14 +248,14 @@ func (v *Validator) validateCertificates(
 	}
 
 	// Build a set of credentials being withdrawn in this transaction
-	withdrawnCreds := make(map[common.Blake2b224]bool)
+	withdrawnCreds := make(map[ledger.RewardAccountKey]bool)
 	for addr := range tx.Withdrawals() {
 		if addr == nil {
 			continue
 		}
-		stakeHash := extractStakeHashFromAddress(*addr)
-		if stakeHash != nil {
-			withdrawnCreds[*stakeHash] = true
+		credential, ok := addr.StakeCredential()
+		if ok {
+			withdrawnCreds[ledger.NewRewardAccountKey(credential)] = true
 		}
 	}
 
@@ -273,7 +273,7 @@ func (v *Validator) validateCertificates(
 func (v *Validator) validateCertificate(
 	cert common.Certificate,
 	govState *GovernanceState,
-	withdrawnCreds map[common.Blake2b224]bool,
+	withdrawnCreds map[ledger.RewardAccountKey]bool,
 ) error {
 	certType := common.CertificateType(cert.Type())
 
@@ -281,32 +281,33 @@ func (v *Validator) validateCertificate(
 	switch certType {
 	case common.CertificateTypeStakeRegistration:
 		if regCert, ok := cert.(*common.StakeRegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			if govState.IsStakeRegistered(credential) {
+			credential := regCert.StakeCredential
+			if govState.IsStakeCredentialRegistered(credential) {
 				return fmt.Errorf(
 					"stake credential %x already registered",
-					credential,
+					credential.Credential,
 				)
 			}
 		}
 
 	case common.CertificateTypeRegistration:
 		if regCert, ok := cert.(*common.RegistrationCertificate); ok {
-			credential := regCert.StakeCredential.Credential
-			if govState.IsStakeRegistered(credential) {
+			credential := regCert.StakeCredential
+			if govState.IsStakeCredentialRegistered(credential) {
 				return fmt.Errorf(
 					"stake credential %x already registered",
-					credential,
+					credential.Credential,
 				)
 			}
 		}
 
 	case common.CertificateTypeStakeDeregistration:
 		if deregCert, ok := cert.(*common.StakeDeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
-			balance := govState.GetRewardBalance(credential)
+			credential := deregCert.StakeCredential
+			balance := govState.GetRewardAccountBalance(credential)
 			// Allow deregistration if balance is being withdrawn in same transaction
-			if balance > 0 && !withdrawnCreds[credential] {
+			if balance > 0 &&
+				!withdrawnCreds[ledger.NewRewardAccountKey(credential)] {
 				return fmt.Errorf(
 					"cannot deregister stake with balance %d",
 					balance,
@@ -316,10 +317,11 @@ func (v *Validator) validateCertificate(
 
 	case common.CertificateTypeDeregistration:
 		if deregCert, ok := cert.(*common.DeregistrationCertificate); ok {
-			credential := deregCert.StakeCredential.Credential
-			balance := govState.GetRewardBalance(credential)
+			credential := deregCert.StakeCredential
+			balance := govState.GetRewardAccountBalance(credential)
 			// Allow deregistration if balance is being withdrawn in same transaction
-			if balance > 0 && !withdrawnCreds[credential] {
+			if balance > 0 &&
+				!withdrawnCreds[ledger.NewRewardAccountKey(credential)] {
 				return fmt.Errorf(
 					"cannot deregister stake with balance %d",
 					balance,
@@ -403,18 +405,18 @@ func (v *Validator) validateProposal(
 ) error {
 	// Check reward account address is valid and registered
 	rewardAddr := proposal.RewardAccount()
-	stakeHash := extractStakeHashFromAddress(rewardAddr)
-	if stakeHash == nil {
+	credential, ok := rewardAddr.StakeCredential()
+	if !ok {
 		addrBytes, _ := rewardAddr.Bytes()
 		return fmt.Errorf(
 			"invalid proposal reward address: cannot extract stake credential from %x",
 			addrBytes,
 		)
 	}
-	if !govState.IsStakeRegistered(*stakeHash) {
+	if !govState.IsStakeCredentialRegistered(credential) {
 		return fmt.Errorf(
 			"proposal reward address %x not registered",
-			*stakeHash,
+			credential.Credential,
 		)
 	}
 
@@ -655,18 +657,18 @@ func (v *Validator) validateTreasuryWithdrawal(
 		if rewardAddr == nil {
 			continue
 		}
-		stakeHash := extractStakeHashFromAddress(*rewardAddr)
-		if stakeHash == nil {
+		credential, ok := rewardAddr.StakeCredential()
+		if !ok {
 			addrBytes, _ := rewardAddr.Bytes()
 			return fmt.Errorf(
 				"invalid treasury withdrawal: cannot extract stake credential from %x",
 				addrBytes,
 			)
 		}
-		if !govState.IsStakeRegistered(*stakeHash) {
+		if !govState.IsStakeCredentialRegistered(credential) {
 			return fmt.Errorf(
 				"treasury withdrawal: return address %x not registered",
-				*stakeHash,
+				credential.Credential,
 			)
 		}
 	}
@@ -787,43 +789,4 @@ func formatGovActionIdFromPtr(id *common.GovActionId) string {
 		hex.EncodeToString(id.TransactionId[:]),
 		id.GovActionIdx,
 	)
-}
-
-// extractStakeHashFromAddress extracts the stake credential hash from an address.
-// Per CIP-19, address types and lengths:
-//   - Reward addresses (types 0xE, 0xF): 29 bytes (1 header + 28 credential)
-//   - Base addresses (types 0-3): 57 bytes (1 header + 28 payment + 28 stake)
-func extractStakeHashFromAddress(addr common.Address) *common.Blake2b224 {
-	// Get address bytes
-	addrBytes, err := addr.Bytes()
-	if err != nil || len(addrBytes) == 0 {
-		return nil
-	}
-
-	header := addrBytes[0]
-	addrType := (header & 0xF0) >> 4
-
-	// Check for stake/reward address types (0xE or 0xF)
-	// Per CIP-19, reward addresses are exactly 29 bytes
-	if addrType == 0xE || addrType == 0xF {
-		if len(addrBytes) != 29 {
-			return nil
-		}
-		var hash common.Blake2b224
-		copy(hash[:], addrBytes[1:29])
-		return &hash
-	}
-
-	// For base addresses (types 0-3), extract the staking part (last 28 bytes)
-	// Per CIP-19, base addresses are exactly 57 bytes
-	if addrType <= 0x3 {
-		if len(addrBytes) != 57 {
-			return nil
-		}
-		var hash common.Blake2b224
-		copy(hash[:], addrBytes[29:57])
-		return &hash
-	}
-
-	return nil
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2117,6 +2117,27 @@ func TestLedgerStateBuilder_RewardAccountRegistrationCredentialIdentity(
 	assert.False(t, ls.IsRewardAccountRegistered(scriptCredential))
 }
 
+func TestLedgerStateBuilder_StakeRegistrationPreservesCredentialType(
+	t *testing.T,
+) {
+	hash := lcommon.NewBlake2b224(bytes.Repeat([]byte{0x23}, 28))
+	scriptCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	keyCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+
+	ls := ledger.NewLedgerStateBuilder().
+		WithRewardAccountCredentialBalance(scriptCredential, 100).
+		Build()
+
+	assert.True(t, ls.IsStakeCredentialRegistered(scriptCredential))
+	assert.False(t, ls.IsStakeCredentialRegistered(keyCredential))
+}
+
 func TestLedgerStateBuilder_LegacyStakeRegistrationCreatesRewardAccount(
 	t *testing.T,
 ) {

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2065,6 +2065,128 @@ func TestLedgerStateBuilder_WithRewardSnapshot(t *testing.T) {
 	assert.Equal(t, uint64(1000000), result.TotalActiveStake)
 }
 
+func TestLedgerStateBuilder_RewardAccountCredentialIdentity(t *testing.T) {
+	hash := lcommon.NewBlake2b224(bytes.Repeat([]byte{0x42}, 28))
+	keyCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	scriptCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+
+	ls := ledger.NewLedgerStateBuilder().
+		WithRewardAccountCredentialBalances(
+			map[ledger.RewardAccountKey]uint64{
+				ledger.NewRewardAccountKey(keyCredential):    11,
+				ledger.NewRewardAccountKey(scriptCredential): 22,
+			},
+		).
+		Build()
+
+	keyBalance, err := ls.RewardAccountBalance(keyCredential)
+	require.NoError(t, err)
+	require.NotNil(t, keyBalance)
+	assert.Equal(t, uint64(11), *keyBalance)
+
+	scriptBalance, err := ls.RewardAccountBalance(scriptCredential)
+	require.NoError(t, err)
+	require.NotNil(t, scriptBalance)
+	assert.Equal(t, uint64(22), *scriptBalance)
+}
+
+func TestLedgerStateBuilder_RewardAccountRegistrationCredentialIdentity(
+	t *testing.T,
+) {
+	hash := lcommon.NewBlake2b224(bytes.Repeat([]byte{0x24}, 28))
+	keyCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	scriptCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+
+	ls := ledger.NewLedgerStateBuilder().
+		WithRewardAccountCredentialBalance(keyCredential, 0).
+		Build()
+
+	assert.True(t, ls.IsRewardAccountRegistered(keyCredential))
+	assert.False(t, ls.IsRewardAccountRegistered(scriptCredential))
+}
+
+func TestLedgerStateBuilder_LegacyStakeRegistrationCreatesRewardAccount(
+	t *testing.T,
+) {
+	hash := lcommon.NewBlake2b224(bytes.Repeat([]byte{0x25}, 28))
+	credential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	tests := []struct {
+		name  string
+		build func() *ledger.MockLedgerState
+	}{
+		{
+			name: "single registration",
+			build: func() *ledger.MockLedgerState {
+				return ledger.NewLedgerStateBuilder().
+					WithStakeCredentialRegistered(hash, true).
+					Build()
+			},
+		},
+		{
+			name: "registration map",
+			build: func() *ledger.MockLedgerState {
+				return ledger.NewLedgerStateBuilder().
+					WithStakeCredentials(map[lcommon.Blake2b224]bool{
+						hash: true,
+					}).
+					Build()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ls := test.build()
+			assert.True(t, ls.IsRewardAccountRegistered(credential))
+			balance, err := ls.RewardAccountBalance(credential)
+			require.NoError(t, err)
+			require.NotNil(t, balance)
+			assert.Zero(t, *balance)
+		})
+	}
+}
+
+func TestLedgerStateBuilder_StakeRegistrationCertificatePreservesIdentity(
+	t *testing.T,
+) {
+	hash := lcommon.NewBlake2b224(bytes.Repeat([]byte{0x26}, 28))
+	scriptCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeScriptHash,
+		Credential: hash,
+	}
+	keyCredential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	ls := ledger.NewLedgerStateBuilder().
+		WithStakeRegistrations([]lcommon.StakeRegistrationCertificate{
+			{StakeCredential: scriptCredential},
+		}).
+		Build()
+
+	assert.True(t, ls.IsRewardAccountRegistered(scriptCredential))
+	assert.False(t, ls.IsRewardAccountRegistered(keyCredential))
+	balance, err := ls.RewardAccountBalance(scriptCredential)
+	require.NoError(t, err)
+	require.NotNil(t, balance)
+	assert.Zero(t, *balance)
+}
+
 // =============================================================================
 // WithConstitutionValue Tests
 // =============================================================================

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"maps"
 	"time"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -38,6 +37,33 @@ type (
 	DRepRegistration = lcommon.DRepRegistration
 	GovActionState   = lcommon.GovActionState
 )
+
+// RewardAccountKey is the comparable identity of a reward account. The
+// credential type is part of the key: a verification-key credential and a
+// script credential may carry the same hash without identifying the same
+// account.
+type RewardAccountKey struct {
+	CredType   uint
+	Credential lcommon.Blake2b224
+}
+
+// NewRewardAccountKey converts a ledger credential to its comparable reward
+// account identity.
+func NewRewardAccountKey(credential lcommon.Credential) RewardAccountKey {
+	return RewardAccountKey{
+		CredType:   credential.CredType,
+		Credential: credential.Credential,
+	}
+}
+
+// AsCredential converts a reward account identity back to a ledger
+// credential.
+func (k RewardAccountKey) AsCredential() lcommon.Credential {
+	return lcommon.Credential{
+		CredType:   k.CredType,
+		Credential: k.Credential,
+	}
+}
 
 // Plutus language version constants
 const (
@@ -114,8 +140,8 @@ type MockLedgerState struct {
 	// RewardState callbacks and state
 	CalculateRewardsCallback  CalculateRewardsFunc
 	GetRewardSnapshotCallback GetRewardSnapshotFunc
-	rewardAccounts            map[lcommon.Blake2b224]uint64 // credential -> balance
-	rewardSnapshot            lcommon.RewardSnapshot        // static snapshot value
+	rewardAccounts            map[RewardAccountKey]uint64 // credential -> balance
+	rewardSnapshot            lcommon.RewardSnapshot      // static snapshot value
 
 	// GovState callbacks and state
 	CommitteeMemberCallback  CommitteeMemberFunc
@@ -275,8 +301,8 @@ func (ls *MockLedgerState) GetRewardSnapshot(
 func (ls *MockLedgerState) IsRewardAccountRegistered(
 	cred lcommon.Credential,
 ) bool {
-	// Reward account registration is tied to stake credential registration
-	return ls.IsStakeCredentialRegistered(cred)
+	_, exists := ls.rewardAccounts[NewRewardAccountKey(cred)]
+	return exists
 }
 
 // RewardAccountBalance returns the current reward balance for a stake credential
@@ -286,7 +312,7 @@ func (ls *MockLedgerState) RewardAccountBalance(
 	if ls.rewardAccounts == nil {
 		return nil, nil
 	}
-	balance, exists := ls.rewardAccounts[cred.Credential]
+	balance, exists := ls.rewardAccounts[NewRewardAccountKey(cred)]
 	if !exists {
 		return nil, nil
 	}
@@ -438,7 +464,7 @@ func NewLedgerStateBuilder() *LedgerStateBuilder {
 	return &LedgerStateBuilder{
 		state: &MockLedgerState{
 			stakeRegistrations:       make(map[lcommon.Blake2b224]bool),
-			rewardAccounts:           make(map[lcommon.Blake2b224]uint64),
+			rewardAccounts:           make(map[RewardAccountKey]uint64),
 			govActions:               make(map[string]*lcommon.GovActionState),
 			proposedCommitteeMembers: make(map[lcommon.Blake2b224]uint64),
 		},
@@ -479,6 +505,13 @@ func (b *LedgerStateBuilder) WithStakeCredentialRegistered(
 	registered bool,
 ) *LedgerStateBuilder {
 	b.state.stakeRegistrations[cred] = registered
+	b.withRewardAccountRegistration(
+		lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: cred,
+		},
+		registered,
+	)
 	return b
 }
 
@@ -486,8 +519,24 @@ func (b *LedgerStateBuilder) WithStakeCredentialRegistered(
 func (b *LedgerStateBuilder) WithStakeCredentials(
 	creds map[lcommon.Blake2b224]bool,
 ) *LedgerStateBuilder {
-	maps.Copy(b.state.stakeRegistrations, creds)
+	for cred, registered := range creds {
+		b.WithStakeCredentialRegistered(cred, registered)
+	}
 	return b
+}
+
+func (b *LedgerStateBuilder) withRewardAccountRegistration(
+	credential lcommon.Credential,
+	registered bool,
+) {
+	key := NewRewardAccountKey(credential)
+	if !registered {
+		delete(b.state.rewardAccounts, key)
+		return
+	}
+	if _, exists := b.state.rewardAccounts[key]; !exists {
+		b.state.rewardAccounts[key] = 0
+	}
 }
 
 // WithSlotToTime sets the slot to time conversion callback
@@ -559,9 +608,24 @@ func (b *LedgerStateBuilder) WithRewardAccountBalance(
 	cred lcommon.Blake2b224,
 	balance uint64,
 ) *LedgerStateBuilder {
-	b.state.rewardAccounts[cred] = balance
+	return b.WithRewardAccountCredentialBalance(
+		lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: cred,
+		},
+		balance,
+	)
+}
+
+// WithRewardAccountCredentialBalance sets the balance for a reward account
+// while preserving the credential type.
+func (b *LedgerStateBuilder) WithRewardAccountCredentialBalance(
+	cred lcommon.Credential,
+	balance uint64,
+) *LedgerStateBuilder {
+	b.state.rewardAccounts[NewRewardAccountKey(cred)] = balance
 	// Also mark the stake credential as registered
-	b.state.stakeRegistrations[cred] = true
+	b.state.stakeRegistrations[cred.Credential] = true
 	return b
 }
 
@@ -570,8 +634,18 @@ func (b *LedgerStateBuilder) WithRewardAccounts(
 	accounts map[lcommon.Blake2b224]uint64,
 ) *LedgerStateBuilder {
 	for cred, balance := range accounts {
-		b.state.rewardAccounts[cred] = balance
-		b.state.stakeRegistrations[cred] = true
+		b.WithRewardAccountBalance(cred, balance)
+	}
+	return b
+}
+
+// WithRewardAccountCredentialBalances sets reward account balances while
+// preserving each credential's type.
+func (b *LedgerStateBuilder) WithRewardAccountCredentialBalances(
+	accounts map[RewardAccountKey]uint64,
+) *LedgerStateBuilder {
+	for cred, balance := range accounts {
+		b.WithRewardAccountCredentialBalance(cred.AsCredential(), balance)
 	}
 	return b
 }
@@ -773,6 +847,7 @@ func (b *LedgerStateBuilder) WithStakeRegistrations(
 	// Also mark credentials as registered for IsStakeCredentialRegistered
 	for _, cert := range certs {
 		b.state.stakeRegistrations[cert.StakeCredential.Credential] = true
+		b.withRewardAccountRegistration(cert.StakeCredential, true)
 	}
 	return b
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -126,7 +126,7 @@ type MockLedgerState struct {
 
 	// CertState callbacks and state
 	StakeRegistrationCallback StakeRegistrationFunc
-	stakeRegistrations        map[lcommon.Blake2b224]bool // credential -> registered
+	stakeRegistrations        map[RewardAccountKey]bool // credential -> registered
 
 	// SlotState callbacks
 	SlotToTimeCallback SlotToTimeFunc
@@ -200,7 +200,7 @@ func (ls *MockLedgerState) IsStakeCredentialRegistered(
 	if ls.stakeRegistrations == nil {
 		return false
 	}
-	return ls.stakeRegistrations[cred.Credential]
+	return ls.stakeRegistrations[NewRewardAccountKey(cred)]
 }
 
 // SlotToTime converts a slot number to a time
@@ -463,7 +463,7 @@ type LedgerStateBuilder struct {
 func NewLedgerStateBuilder() *LedgerStateBuilder {
 	return &LedgerStateBuilder{
 		state: &MockLedgerState{
-			stakeRegistrations:       make(map[lcommon.Blake2b224]bool),
+			stakeRegistrations:       make(map[RewardAccountKey]bool),
 			rewardAccounts:           make(map[RewardAccountKey]uint64),
 			govActions:               make(map[string]*lcommon.GovActionState),
 			proposedCommitteeMembers: make(map[lcommon.Blake2b224]uint64),
@@ -504,14 +504,12 @@ func (b *LedgerStateBuilder) WithStakeCredentialRegistered(
 	cred lcommon.Blake2b224,
 	registered bool,
 ) *LedgerStateBuilder {
-	b.state.stakeRegistrations[cred] = registered
-	b.withRewardAccountRegistration(
-		lcommon.Credential{
-			CredType:   lcommon.CredentialTypeAddrKeyHash,
-			Credential: cred,
-		},
-		registered,
-	)
+	credential := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: cred,
+	}
+	b.state.stakeRegistrations[NewRewardAccountKey(credential)] = registered
+	b.withRewardAccountRegistration(credential, registered)
 	return b
 }
 
@@ -625,7 +623,7 @@ func (b *LedgerStateBuilder) WithRewardAccountCredentialBalance(
 ) *LedgerStateBuilder {
 	b.state.rewardAccounts[NewRewardAccountKey(cred)] = balance
 	// Also mark the stake credential as registered
-	b.state.stakeRegistrations[cred.Credential] = true
+	b.state.stakeRegistrations[NewRewardAccountKey(cred)] = true
 	return b
 }
 
@@ -846,7 +844,7 @@ func (b *LedgerStateBuilder) WithStakeRegistrations(
 	}
 	// Also mark credentials as registered for IsStakeCredentialRegistered
 	for _, cert := range certs {
-		b.state.stakeRegistrations[cert.StakeCredential.Credential] = true
+		b.state.stakeRegistrations[NewRewardAccountKey(cert.StakeCredential)] = true
 		b.withRewardAccountRegistration(cert.StakeCredential, true)
 	}
 	return b


### PR DESCRIPTION
- preserve reward-account and stake-registration identity by credential type and hash
- parse legacy and current account-state layouts without collapsing key and script credentials
- keep registration, reward-balance, and DRep-delegation state distinct through replay

Fixes #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reward accounts now preserve credential type and hash identity, preventing collisions between key and script credentials.
  * Stake registrations, DRep delegations, balances, withdrawals, and validation now support credential-aware tracking.
  * Added support for modern, legacy, and wrapped state layouts.

* **Bug Fixes**
  * Deregistration and delegation updates now affect only the matching credential.
  * Improved compatibility with legacy hash-based state managers and data formats.

* **Documentation**
  * Updated implementation guidance and vector format documentation for credential-aware state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->