### PR TITLE
feat(fixtures): add valid era block chains

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -106,3 +106,11 @@ Current upstream exceptions are encoded in the harness rather than ignored:
 - Dijkstra `GenTx_*` fixtures currently validate through payload/body-hash
   semantics because the imported fixture shape is ahead of full
   `gouroboros` transaction decoding support
+
+## Generated block chains
+
+`GenerateShelleyChain`, `GenerateBabbageChain`, and `GenerateConwayChain`
+return connected empty blocks whose CBOR round-trips through `gouroboros`.
+Use `GenerateBabbageChainWithProtocolVersion` when a test needs valid Babbage
+bytes with a specific header protocol version, including an unknown version for
+fail-closed classification coverage.

--- a/fixtures/chain.go
+++ b/fixtures/chain.go
@@ -69,6 +69,12 @@ func GenerateConwayChain(
 	bodyHash := ComputeBlockBodyHash(
 		emptyTxsCbor, emptyWitsCbor, emptyAuxCbor, emptyInvalidCbor,
 	)
+	bodySize := computeBlockBodySize(
+		emptyTxsCbor,
+		emptyWitsCbor,
+		emptyAuxCbor,
+		emptyInvalidCbor,
+	)
 	blocks := make([]ledger.Block, 0, count)
 	currentPrev := prevHash
 	for i := range count {
@@ -82,7 +88,7 @@ func GenerateConwayChain(
 				Output: make([]byte, 64),
 				Proof:  make([]byte, 80),
 			},
-			BlockBodySize: 0,
+			BlockBodySize: bodySize,
 			BlockBodyHash: bodyHash,
 			OpCert: babbage.BabbageOpCert{
 				HotVkey:   make([]byte, 32),
@@ -132,4 +138,12 @@ func ComputeBlockBodyHash(parts ...[]byte) common.Blake2b256 {
 	}
 	h := blake2b.Sum256(combined)
 	return common.NewBlake2b256(h[:])
+}
+
+func computeBlockBodySize(parts ...[]byte) uint64 {
+	var size uint64
+	for _, part := range parts {
+		size += uint64(len(part))
+	}
+	return size
 }

--- a/fixtures/era_chain.go
+++ b/fixtures/era_chain.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// GenerateBabbageChain builds a connected chain of empty Babbage blocks using
+// the first Babbage protocol version.
+func GenerateBabbageChain(
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	count int,
+) ([]ledger.Block, error) {
+	return GenerateBabbageChainWithProtocolVersion(
+		startBlockNumber,
+		prevHash,
+		startSlot,
+		slotIncrement,
+		babbage.MinProtocolVersionBabbage,
+		0,
+		count,
+	)
+}
+
+// GenerateBabbageChainWithProtocolVersion builds a connected chain of empty
+// Babbage blocks with the requested header protocol version. The explicit
+// version is useful for exercising header classification at hard-fork and
+// unknown-version boundaries while retaining structurally valid block bytes.
+func GenerateBabbageChainWithProtocolVersion(
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	protocolMajor, protocolMinor uint64,
+	count int,
+) ([]ledger.Block, error) {
+	if count <= 0 {
+		return []ledger.Block{}, nil
+	}
+	emptyTxsCbor, err := cbor.Encode([]babbage.BabbageTransactionBody{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Babbage tx bodies: %w", err)
+	}
+	emptyWitsCbor, err := cbor.Encode([]babbage.BabbageTransactionWitnessSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Babbage witnesses: %w", err)
+	}
+	emptyAuxCbor, err := cbor.Encode(common.TransactionMetadataSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Babbage metadata set: %w", err)
+	}
+	emptyInvalidCbor, err := cbor.Encode([]uint{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty invalid txs: %w", err)
+	}
+	bodyHash := ComputeBlockBodyHash(
+		emptyTxsCbor,
+		emptyWitsCbor,
+		emptyAuxCbor,
+		emptyInvalidCbor,
+	)
+	bodySize := computeBlockBodySize(
+		emptyTxsCbor,
+		emptyWitsCbor,
+		emptyAuxCbor,
+		emptyInvalidCbor,
+	)
+	blocks := make([]ledger.Block, 0, count)
+	currentPrev := prevHash
+	for i := range count {
+		block := &babbage.BabbageBlock{
+			BlockHeader: &babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: startBlockNumber + uint64(i),
+					Slot:        startSlot + uint64(i)*slotIncrement,
+					PrevHash:    currentPrev,
+					IssuerVkey:  common.IssuerVkey{},
+					VrfKey:      make([]byte, 32),
+					VrfResult: common.VrfResult{
+						Output: make([]byte, 64),
+						Proof:  make([]byte, 80),
+					},
+					BlockBodySize: bodySize,
+					BlockBodyHash: bodyHash,
+					OpCert: babbage.BabbageOpCert{
+						HotVkey:   make([]byte, 32),
+						Signature: make([]byte, 64),
+					},
+					ProtoVersion: babbage.BabbageProtoVersion{
+						Major: protocolMajor,
+						Minor: protocolMinor,
+					},
+				},
+				Signature: make([]byte, 64),
+			},
+		}
+		blockCbor, err := cbor.Encode(block)
+		if err != nil {
+			return nil, fmt.Errorf("encode Babbage block %d: %w", i, err)
+		}
+		decoded, err := babbage.NewBabbageBlockFromCbor(blockCbor)
+		if err != nil {
+			return nil, fmt.Errorf("decode generated Babbage block %d: %w", i, err)
+		}
+		if !bytes.Equal(decoded.Cbor(), blockCbor) {
+			return nil, fmt.Errorf(
+				"Babbage block %d Cbor mismatch after round-trip",
+				i,
+			)
+		}
+		blocks = append(blocks, decoded)
+		currentPrev = decoded.Hash()
+	}
+	return blocks, nil
+}
+
+// GenerateShelleyChain builds a connected chain of empty Shelley blocks using
+// the first Shelley protocol version.
+func GenerateShelleyChain(
+	startBlockNumber uint64,
+	prevHash common.Blake2b256,
+	startSlot, slotIncrement uint64,
+	count int,
+) ([]ledger.Block, error) {
+	if count <= 0 {
+		return []ledger.Block{}, nil
+	}
+	emptyTxsCbor, err := cbor.Encode([]shelley.ShelleyTransactionBody{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Shelley tx bodies: %w", err)
+	}
+	emptyWitsCbor, err := cbor.Encode([]shelley.ShelleyTransactionWitnessSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Shelley witnesses: %w", err)
+	}
+	emptyAuxCbor, err := cbor.Encode(common.TransactionMetadataSet{})
+	if err != nil {
+		return nil, fmt.Errorf("encode empty Shelley metadata set: %w", err)
+	}
+	bodyHash := ComputeBlockBodyHash(
+		emptyTxsCbor,
+		emptyWitsCbor,
+		emptyAuxCbor,
+	)
+	bodySize := computeBlockBodySize(
+		emptyTxsCbor,
+		emptyWitsCbor,
+		emptyAuxCbor,
+	)
+	blocks := make([]ledger.Block, 0, count)
+	currentPrev := prevHash
+	for i := range count {
+		block := &shelley.ShelleyBlock{
+			BlockHeader: &shelley.ShelleyBlockHeader{
+				Body: shelley.ShelleyBlockHeaderBody{
+					BlockNumber: startBlockNumber + uint64(i),
+					Slot:        startSlot + uint64(i)*slotIncrement,
+					PrevHash:    currentPrev,
+					IssuerVkey:  common.IssuerVkey{},
+					VrfKey:      make([]byte, 32),
+					NonceVrf: common.VrfResult{
+						Output: make([]byte, 64),
+						Proof:  make([]byte, 80),
+					},
+					LeaderVrf: common.VrfResult{
+						Output: make([]byte, 64),
+						Proof:  make([]byte, 80),
+					},
+					BlockBodySize:     bodySize,
+					BlockBodyHash:     bodyHash,
+					OpCertHotVkey:     make([]byte, 32),
+					OpCertSignature:   make([]byte, 64),
+					ProtoMajorVersion: shelley.MinProtocolVersionShelley,
+					ProtoMinorVersion: 0,
+				},
+				Signature: make([]byte, 64),
+			},
+		}
+		blockCbor, err := cbor.Encode(block)
+		if err != nil {
+			return nil, fmt.Errorf("encode Shelley block %d: %w", i, err)
+		}
+		decoded, err := shelley.NewShelleyBlockFromCbor(blockCbor)
+		if err != nil {
+			return nil, fmt.Errorf("decode generated Shelley block %d: %w", i, err)
+		}
+		if !bytes.Equal(decoded.Cbor(), blockCbor) {
+			return nil, fmt.Errorf(
+				"Shelley block %d Cbor mismatch after round-trip",
+				i,
+			)
+		}
+		blocks = append(blocks, decoded)
+		currentPrev = decoded.Hash()
+	}
+	return blocks, nil
+}

--- a/fixtures/era_chain_test.go
+++ b/fixtures/era_chain_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+)
+
+func TestGenerateBabbageChainRoundTrip(t *testing.T) {
+	assertGeneratedChain(
+		t,
+		fixtures.GenerateBabbageChain,
+		ledger.BlockTypeBabbage,
+		babbage.MinProtocolVersionBabbage,
+	)
+}
+
+func TestGenerateShelleyChainRoundTrip(t *testing.T) {
+	assertGeneratedChain(
+		t,
+		fixtures.GenerateShelleyChain,
+		ledger.BlockTypeShelley,
+		shelley.MinProtocolVersionShelley,
+	)
+}
+
+func TestGeneratedBlocksDecodeAcrossAdjacentEras(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		generate    chainGenerator
+		decodeAsEra uint
+	}{
+		{
+			name:        "Shelley as Mary",
+			generate:    fixtures.GenerateShelleyChain,
+			decodeAsEra: ledger.BlockTypeMary,
+		},
+		{
+			name:        "Babbage as Conway",
+			generate:    fixtures.GenerateBabbageChain,
+			decodeAsEra: ledger.BlockTypeConway,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			blocks, err := test.generate(1, common.Blake2b256{}, 2, 1, 1)
+			if err != nil {
+				t.Fatalf("generate chain: %s", err)
+			}
+			if _, err := ledger.NewBlockFromCbor(
+				test.decodeAsEra,
+				blocks[0].Cbor(),
+			); err != nil {
+				t.Fatalf("cross-era decode: %s", err)
+			}
+		})
+	}
+}
+
+func TestGeneratedBlockBodySizes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		generate chainGenerator
+		wantSize uint64
+	}{
+		{
+			name:     "Shelley",
+			generate: fixtures.GenerateShelleyChain,
+			wantSize: 3,
+		},
+		{
+			name:     "Babbage",
+			generate: fixtures.GenerateBabbageChain,
+			wantSize: 4,
+		},
+		{
+			name:     "Conway",
+			generate: fixtures.GenerateConwayChain,
+			wantSize: 4,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			blocks, err := test.generate(1, common.Blake2b256{}, 2, 1, 1)
+			if err != nil {
+				t.Fatalf("generate chain: %s", err)
+			}
+			if got := blocks[0].BlockBodySize(); got != test.wantSize {
+				t.Fatalf("block body size = %d, want %d", got, test.wantSize)
+			}
+		})
+	}
+}
+
+func TestGenerateBabbageChainWithUnknownProtocolVersion(t *testing.T) {
+	blocks, err := fixtures.GenerateBabbageChainWithProtocolVersion(
+		1,
+		common.Blake2b256{},
+		2,
+		1,
+		99,
+		3,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("GenerateBabbageChainWithProtocolVersion: %s", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	decoded, err := ledger.NewBlockFromCbor(
+		ledger.BlockTypeBabbage,
+		blocks[0].Cbor(),
+	)
+	if err != nil {
+		t.Fatalf("decode Babbage block: %s", err)
+	}
+	if _, err := ledger.DetermineBlockType(decoded.Header().Cbor()); err == nil {
+		t.Fatal("expected unknown protocol major to be unclassifiable")
+	}
+}
+
+type chainGenerator func(
+	uint64,
+	common.Blake2b256,
+	uint64,
+	uint64,
+	int,
+) ([]ledger.Block, error)
+
+func assertGeneratedChain(
+	t *testing.T,
+	generate chainGenerator,
+	wantType uint,
+	wantProtocolMajor uint64,
+) {
+	t.Helper()
+	var origin common.Blake2b256
+	blocks, err := generate(4, origin, 20, 3, 3)
+	if err != nil {
+		t.Fatalf("generate chain: %s", err)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(blocks))
+	}
+	for i, block := range blocks {
+		decoded, err := ledger.NewBlockFromCbor(wantType, block.Cbor())
+		if err != nil {
+			t.Fatalf("block %d decode failed: %s", i, err)
+		}
+		if decoded.Hash() != block.Hash() {
+			t.Fatalf("block %d hash changed after round-trip", i)
+		}
+		if decoded.BlockNumber() != uint64(i+4) {
+			t.Fatalf(
+				"block %d number = %d, want %d",
+				i,
+				decoded.BlockNumber(),
+				i+4,
+			)
+		}
+		if decoded.SlotNumber() != uint64(20+i*3) {
+			t.Fatalf(
+				"block %d slot = %d, want %d",
+				i,
+				decoded.SlotNumber(),
+				20+i*3,
+			)
+		}
+		blockType, err := ledger.DetermineBlockType(decoded.Header().Cbor())
+		if err != nil {
+			t.Fatalf("block %d determine type: %s", i, err)
+		}
+		if blockType != wantType {
+			t.Fatalf("block %d type = %d, want %d", i, blockType, wantType)
+		}
+		if protocolMajor(decoded) != wantProtocolMajor {
+			t.Fatalf(
+				"block %d protocol major = %d, want %d",
+				i,
+				protocolMajor(decoded),
+				wantProtocolMajor,
+			)
+		}
+		if i == 0 {
+			if decoded.PrevHash() != origin {
+				t.Fatalf("first block does not honor origin")
+			}
+		} else if decoded.PrevHash() != blocks[i-1].Hash() {
+			t.Fatalf("block %d does not link to block %d", i, i-1)
+		}
+	}
+	empty, err := generate(1, origin, 0, 1, 0)
+	if err != nil {
+		t.Fatalf("generate empty chain: %s", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Fatalf("expected non-nil empty chain, got %#v", empty)
+	}
+}
+
+func protocolMajor(block ledger.Block) uint64 {
+	switch block := block.(type) {
+	case *babbage.BabbageBlock:
+		return block.BlockHeader.Body.ProtoVersion.Major
+	case *shelley.ShelleyBlock:
+		return block.BlockHeader.Body.ProtoMajorVersion
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
Adds valid Shelley and Babbage chain fixtures with configurable Babbage protocol versions. Corrects generated Conway body-size metadata.

Refs #199

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds valid Shelley and Babbage chain fixture generators and corrects Conway block body-size metadata so generated fixture blocks round-trip through `gouroboros` with accurate sizes.

- `GenerateShelleyChain`, `GenerateBabbageChain`, and `GenerateBabbageChainWithProtocolVersion` return connected empty blocks whose CBOR round-trips through `gouroboros`; the protocol-version variant supports unknown versions for fail-closed header classification tests.
- Conway generated blocks now report the real serialized body size instead of `0`, matching Shelley and Babbage behavior.
- Tests cover round-trip decoding, adjacent-era cross-decoding (Shelley as Mary, Babbage as Conway), chain linking, and unknown protocol-version rejection.

Refs #199

<sup>Written for commit 747fa1350c0d59f98f4eb039ba2ab30ac2213325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/ouroboros-mock/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools for generating connected Shelley, Babbage, and Conway blockchain fixtures.
  * Added configurable protocol-version support for Babbage chain generation.
  * Generated blocks now include accurate body sizes and linked hashes.
  * Added validation for encoding, decoding, cross-era compatibility, block sequencing, and unsupported protocol versions.

* **Documentation**
  * Documented the available generated chain fixtures and their round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->